### PR TITLE
Create onboarding.md issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/onboarding.md
+++ b/.github/ISSUE_TEMPLATE/onboarding.md
@@ -1,0 +1,28 @@
+---
+name: Onboarding 
+about: An onboarding checklist for folks joining the team!
+title: 'Onboarding checklist for {Github Username}'
+labels: ''
+assignees: ''
+
+---
+
+**Background**
+
+Welcome to the team!
+
+Here's a few pointers to get you started as well as a checklist to make sure you've got access to :all-the-things:!
+
+
+**For you**
+- [ ] [Join](https://github.com/GSA/GitHub-Administration#joining-the-gsa-enterprise-organization) GSA’s Enterprise Github org
+- [ ] Review the [project README](https://docs.google.com/document/d/1g8nYqYS_ifFlZB-DBgfeSoJRMB__EqWsmLnacyk-bDI/) in drive
+- [ ] Join Slack channels in the project README
+
+
+**For your onboarding buddy**
+- [ ] Add to the FAC team folder in drive
+- [ ] Add to [FAC@GSA.gov](https://groups.google.com/a/gsa.gov/g/fac) google group
+- [ ] <Engineering> Added to `gsa-10x-prototyping` Organization in cloud.gov
+- [ ] Add to the [FAC team](https://github.com/orgs/GSA-TTS/teams/fac-team) in github
+- [ ] Add to standing meeting invites


### PR DESCRIPTION
Onboarding can be tough and we're already accumulating docs, permissions, roles, groups, tools, calendar invites etc.

Proposing a way to track those tasks within our github project board by using this template. 
We'll modify the template as needed and create a new issue for each friend that joins the team.