### PR TITLE
Minor documentation tweaks

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ Misc:
 
 ## Onboarding
 
-As a new engineer assigned to the FAC, it's a great idea to familiarize yourself with Python, Django, and Cloud.gov - all tools used in this project.
+As a new engineer assigned to the FAC, it's a great idea to familiarize yourself with Python, Django, and Cloud.gov—all tools used in this project.
 
  - [ ] If you need to catch up on the latest in Python development, check out the [Python developer's guide](https://devguide.python.org/).
  - [ ] Work through the [Django Tutorial](https://docs.djangoproject.com/en/4.0/intro/tutorial01/) and writing your first Django app.
@@ -22,4 +22,4 @@ As a new engineer assigned to the FAC, it's a great idea to familiarize yourself
  - [ ] Practice deploying a [python application](https://github.com/cloud-gov/cf-hello-worlds/tree/main/python-flask) to Cloud.gov using the Cloud.gov command line interface (CLI): https://cloud.gov/docs/getting-started/your-first-deploy/.
  - [ ] Survey existing TTS projects which use Django+Cloud.gov like: [Tock](https://github.com/18F/tock) and the [DOJ CRT Portal](https://github.com/usdoj-crt/crt-portal).
 
-Once you're up to speed, check out [Local Development](./local-development.md) to get setup with a local development environment and start contributing!
+Once you're up to speed, check out [Local Development](./development.md#local-development) to get setup with a local development environment and start contributing!

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,6 +1,7 @@
 # Development
 
-We use either Docker with `docker-compose` or local development when working on issues and shipping pull requests.
+We use either [Docker with `docker-compose`](#docker) or [local development](#local-development) when working on issues and shipping pull requests.
+
 ## Contents
 
 * [Tools](#tools)
@@ -126,7 +127,7 @@ As a convenience, you can create an alias in your shell following this or a simi
 ```shell
 fac ()
 {
-  docker-compose run web python manage.py $1 $2 $3 $4 $5
+  docker-compose run web python manage.py ${@}
 }
 ```
 
@@ -140,7 +141,7 @@ Let's use this workflow to create a `superuser` in our development environment s
 docker-compose up
 
 # Django management command to create a new superuser
-docker-compose up run web python manage.py createsuperuser
+docker-compose run web python manage.py createsuperuser
 
 # Follow the prompts to enter username, password, etc.
 


### PR DESCRIPTION
Sometimes little things
Improve documentation.
So here are some tweaks.

-----

One of the local development links was broken, and there was a stray `up` in one of the `docker-compose` commands.

I like `${@}` for all the shell function arguments rather than enumerating them, unless I'm missing some subtlety.

I made some things into links.