### PR TITLE
Add CORS headers

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -44,7 +44,7 @@ INSTALLED_APPS = [
 
 # Third-party apps
 
-INSTALLED_APPS += ['rest_framework']
+INSTALLED_APPS += ['rest_framework', 'corsheaders']
 
 # Our apps
 
@@ -52,8 +52,9 @@ INSTALLED_APPS += ['audit', 'api']
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
-    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    "corsheaders.middleware.CorsMiddleware",
+    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -151,3 +152,7 @@ REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
     'PAGE_SIZE': 10,
 }
+
+
+## CORS
+CORS_ALLOW_ALL_ORIGINS = True

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -21,11 +21,16 @@ django==4.0.4 \
     --hash=sha256:4e8177858524417563cc0430f29ea249946d831eacb0068a1455686587df40b5
     # via
     #   -r ./requirements/requirements.in
+    #   django-cors-headers
     #   djangorestframework
 django-cache-url==3.4.0 \
     --hash=sha256:4559398a946ff24c4ee96e32c55e3b760bd69f7c2ba48844cdf8fcb4f76d10bd \
     --hash=sha256:9061f8e7ffbb29eb92ba93fa9058003ec92393e85c537d1969570652ff8721fa
     # via environs
+django-cors-headers==3.11.0 \
+    --hash=sha256:a22be2befd4069c4fc174f11cf067351df5c061a3a5f94a01650b4e928b0372b \
+    --hash=sha256:eb98389bf7a2afc5d374806af4a9149697e3a6955b5a2dc2bf049f7d33647456
+    # via -r ./requirements/requirements.in
 djangorestframework==3.13.1 \
     --hash=sha256:0c33407ce23acc68eca2a6e46424b008c9c02eceb8cf18581921d0092bc1f2ee \
     --hash=sha256:24c4bf58ed7e85d1fe4ba250ab2da926d263cd57d64b03e8dcef0ac683f8b1aa

--- a/backend/requirements/requirements.in
+++ b/backend/requirements/requirements.in
@@ -6,3 +6,4 @@ djangorestframework
 pyyaml
 uritemplate
 whitenoise
+django-cors-headers


### PR DESCRIPTION
Making our API available across origins by including the header: `access-control-allow-origin: *`

Bringing in [django-cors-headers](https://pypi.org/project/django-cors-headers/)`to handle creation of configuration making the API available across origins. 

Allowing all origins now during dev/testing. We may want to restrict it later.
