### PR TITLE
Added local UEI validators

### DIFF
--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -14,6 +14,12 @@ class EligibilitySerializer(serializers.ModelSerializer):
         return data
 
 
+class UEISerializer(serializers.ModelSerializer):
+    class Meta:
+        model = SingleAuditChecklist
+        fields = ['uei']
+
+
 class SingleAuditChecklistSerializer(serializers.ModelSerializer):
     class Meta:
         model = SingleAuditChecklist

--- a/backend/api/test_serializers.py
+++ b/backend/api/test_serializers.py
@@ -1,5 +1,5 @@
 from django.test import SimpleTestCase
-from .serializers import EligibilitySerializer
+from .serializers import EligibilitySerializer, UEISerializer
 
 
 class EligibilityStepTests(SimpleTestCase):
@@ -18,3 +18,16 @@ class EligibilityStepTests(SimpleTestCase):
         self.assertFalse(EligibilitySerializer(data=empty).is_valid())
         self.assertFalse(EligibilitySerializer(data=wrong_choice).is_valid())
         self.assertTrue(EligibilitySerializer(data=valid).is_valid())
+
+
+class UEIValidatorStepTests(SimpleTestCase):
+
+    def test_serializer_validation(self):
+        """
+            UEI should meet UEI Technical Specifications defined in the UEI validator
+        """
+        valid = {'uei': 'ABC123DEF456'}
+        invalid = {'uei': '0000000000OI*'}
+
+        self.assertFalse(UEISerializer(data=invalid).is_valid())
+        self.assertTrue(UEISerializer(data=valid).is_valid())

--- a/backend/api/test_views.py
+++ b/backend/api/test_views.py
@@ -35,3 +35,33 @@ class EligibilityViewTests(TestCase):
         data = response.json()
         self.assertEqual(response.status_code, 200)
         self.assertEqual(data['eligible'], False)
+
+
+class UEIValidationViewTests(TestCase):
+    PATH = reverse('uei-validation')
+    SUCCESS = {'uei': 'ABC123DEF456'}
+    INELIGIBLE = {'uei': '000000000OI*'}
+
+    def test_auth_required(self):
+        """Unauthenticated requests return unauthorized response"""
+        client = APIClient()
+        response = client.post(self.PATH, self.SUCCESS, format='json')
+        self.assertEqual(response.status_code, 401)
+
+    def test_success_and_failure(self):
+        """
+        An authenticated request receives an eligible response and an ineligible response
+        """
+        client = APIClient()
+        user = baker.make(User)
+        client.force_authenticate(user=user)
+
+        response = client.post(self.PATH, self.SUCCESS, format='json')
+        data = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data['valid'], True)
+
+        response = client.post(self.PATH, self.INELIGIBLE, format='json')
+        data = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data['valid'], False)

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -4,7 +4,7 @@ from rest_framework import viewsets
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from .serializers import EligibilitySerializer, SingleAuditChecklistSerializer
+from .serializers import EligibilitySerializer, SingleAuditChecklistSerializer, UEISerializer
 
 
 class SACViewSet(viewsets.ModelViewSet):
@@ -31,6 +31,17 @@ class EligibilityFormView(APIView):
             request.session['sac'] = request.data
             return Response({'eligible': True, 'next': next_step})
         return Response({'eligible': False, 'errors': serializer.errors})
+
+
+class UEIValidationFormView(APIView):
+    """
+    Accepts UEI to validate and returns either a message describing the validation errors, or valid.
+    """
+    def post(self, request):
+        serializer = UEISerializer(data=request.data)
+        if serializer.is_valid():
+            return Response({'valid': True})
+        return Response({'valid': False, 'errors': serializer.errors})
 
 
 class GeneralInfoView(APIView):

--- a/backend/audit/models.py
+++ b/backend/audit/models.py
@@ -3,6 +3,8 @@ from django.contrib.auth import get_user_model
 
 from django.utils.translation import gettext_lazy as _
 
+from backend.audit.validators import validate_uei_leading_char, validate_uei_nine_digit_sequences, validate_uei_valid_chars
+
 User = get_user_model()
 
 
@@ -37,7 +39,7 @@ class SingleAuditChecklist(models.Model):
     is_usa_based = models.BooleanField(verbose_name=_('Is USA Based'))
 
     # 2 Auditee Information
-    uei = models.CharField(max_length=12, verbose_name=_('UEI'), help_text=_('Unique Entity Identifier'))
+    uei = models.CharField(max_length=12, verbose_name=_('UEI'), help_text=_('Unique Entity Identifier'), validators=[validate_uei_valid_chars, validate_uei_leading_char, validate_uei_nine_digit_sequences])
 
     auditee_name = models.CharField(max_length=500)
     auditee_fiscal_period_start = models.DateField()

--- a/backend/audit/models.py
+++ b/backend/audit/models.py
@@ -3,7 +3,7 @@ from django.contrib.auth import get_user_model
 
 from django.utils.translation import gettext_lazy as _
 
-from backend.audit.validators import validate_uei_leading_char, validate_uei_nine_digit_sequences, validate_uei_valid_chars
+from .validators import validate_uei_leading_char, validate_uei_nine_digit_sequences, validate_uei_valid_chars
 
 User = get_user_model()
 

--- a/backend/audit/models.py
+++ b/backend/audit/models.py
@@ -3,7 +3,7 @@ from django.contrib.auth import get_user_model
 
 from django.utils.translation import gettext_lazy as _
 
-from .validators import validate_uei_leading_char, validate_uei_nine_digit_sequences, validate_uei_valid_chars
+from .validators import validate_uei
 
 User = get_user_model()
 
@@ -39,7 +39,7 @@ class SingleAuditChecklist(models.Model):
     is_usa_based = models.BooleanField(verbose_name=_('Is USA Based'))
 
     # 2 Auditee Information
-    uei = models.CharField(max_length=12, verbose_name=_('UEI'), help_text=_('Unique Entity Identifier'), validators=[validate_uei_valid_chars, validate_uei_leading_char, validate_uei_nine_digit_sequences])
+    uei = models.CharField(max_length=12, verbose_name=_('UEI'), help_text=_('Unique Entity Identifier'), validators=[validate_uei])
 
     auditee_name = models.CharField(max_length=500)
     auditee_fiscal_period_start = models.DateField()

--- a/backend/audit/models.py
+++ b/backend/audit/models.py
@@ -1,9 +1,10 @@
 from django.db import models
 from django.contrib.auth import get_user_model
+from django.core.validators import MinLengthValidator
 
 from django.utils.translation import gettext_lazy as _
 
-from .validators import validate_uei
+from .validators import validate_uei_alphanumeric, validate_uei_leading_char, validate_uei_nine_digit_sequences, validate_uei_valid_chars
 
 User = get_user_model()
 
@@ -39,7 +40,7 @@ class SingleAuditChecklist(models.Model):
     is_usa_based = models.BooleanField(verbose_name=_('Is USA Based'))
 
     # 2 Auditee Information
-    uei = models.CharField(max_length=12, verbose_name=_('UEI'), help_text=_('Unique Entity Identifier'), validators=[validate_uei])
+    uei = models.CharField(max_length=12, verbose_name=_('UEI'), help_text=_('Unique Entity Identifier'), validators=[MinLengthValidator(12), validate_uei_alphanumeric, validate_uei_valid_chars, validate_uei_leading_char, validate_uei_nine_digit_sequences])
 
     auditee_name = models.CharField(max_length=500)
     auditee_fiscal_period_start = models.DateField()

--- a/backend/audit/test_validators.py
+++ b/backend/audit/test_validators.py
@@ -1,10 +1,17 @@
 from django.test import SimpleTestCase
 from django.core.exceptions import ValidationError
 
-from .validators import validate_uei_valid_chars, validate_uei_leading_char, validate_uei_nine_digit_sequences
+from .validators import validate_uei, validate_uei_valid_chars, validate_uei_leading_char, validate_uei_nine_digit_sequences
 
 # Create your tests here.
 class UEIValidatorTests(SimpleTestCase):
+
+    def test_uei(self):
+        """UEI is valid using all tests"""
+        # Invalid UEI
+        validate_uei("000000000000")
+        # Valid UEI
+        validate_uei("ABC123DEF456")
 
     def test_uei_does_not_contain_o_or_i(self):
         """UEI does not contain O or I"""

--- a/backend/audit/test_validators.py
+++ b/backend/audit/test_validators.py
@@ -9,7 +9,7 @@ class UEIValidatorTests(SimpleTestCase):
     def test_uei(self):
         """UEI is valid using all tests"""
         # Invalid UEI
-        validate_uei("000000000000")
+        self.assertRaises(ValidationError, validate_uei, "000000000000")
         # Valid UEI
         validate_uei("ABC123DEF456")
 

--- a/backend/audit/test_validators.py
+++ b/backend/audit/test_validators.py
@@ -1,0 +1,30 @@
+from django.test import SimpleTestCase
+from django.core.exceptions import ValidationError
+
+from .validators import validate_uei_valid_chars, validate_uei_leading_char, validate_uei_nine_digit_sequences
+
+# Create your tests here.
+class UEIValidatorTests(SimpleTestCase):
+
+    def test_uei_does_not_contain_o_or_i(self):
+        """UEI does not contain O or I"""
+        # UEI with O
+        self.assertRaises(ValidationError, validate_uei_valid_chars, "123456789O11")
+        # UEI with I
+        self.assertRaises(ValidationError, validate_uei_valid_chars, "I23456789011")
+        # This should not raise a validation error because it does not have an O or I
+        validate_uei_valid_chars("123456789011")
+        
+    def test_uei_does_not_start_with_0(self):
+        """UEI does not start with 0"""
+        # UEI starts with O
+        self.assertRaises(ValidationError, validate_uei_leading_char, "012345678901")
+        # UEI does not start with 0
+        validate_uei_leading_char("123456789011")
+
+    def test_uei_does_not_contain_9_digit_sequence(self):
+        """UEI does not contain 9 digit sequence"""
+        # UEI contains 9 digit sequence
+        self.assertRaises(ValidationError, validate_uei_nine_digit_sequences, "12345678901")
+        # UEI does not contain 9 digit sequence
+        validate_uei_nine_digit_sequences("ABC123DEF456")

--- a/backend/audit/test_validators.py
+++ b/backend/audit/test_validators.py
@@ -1,37 +1,66 @@
+from operator import contains
 from django.test import SimpleTestCase
 from django.core.exceptions import ValidationError
+from pkg_resources import invalid_marker
 
-from .validators import validate_uei, validate_uei_valid_chars, validate_uei_leading_char, validate_uei_nine_digit_sequences
+from .validators import validate_uei, validate_uei_alphanumeric, validate_uei_valid_chars, validate_uei_leading_char, validate_uei_nine_digit_sequences
 
 # Create your tests here.
 class UEIValidatorTests(SimpleTestCase):
 
+    # Valid UEI
+    valid = "ABC123DEF456"
+
     def test_uei(self):
         """UEI is valid using all tests"""
+        invalid = "000000000000"
+
         # Invalid UEI
-        self.assertRaises(ValidationError, validate_uei, "000000000000")
+        self.assertRaises(ValidationError, validate_uei, invalid)
         # Valid UEI
-        validate_uei("ABC123DEF456")
+        validate_uei(self.valid)
+
+    def test_uei_is_alphanumeric_only(self):
+        """UEI is alphanumeric only"""
+        invalid = "!@#123ABC456"
+
+        # Invalid UEI
+        self.assertRaises(ValidationError, validate_uei_alphanumeric, invalid)
+        # Valid UEI
+        validate_uei(self.valid)
 
     def test_uei_does_not_contain_o_or_i(self):
         """UEI does not contain O or I"""
+        contains_o = "ABCo123"
+        contains_O = "ABCO123"
+        contains_i = "ABC0i23"
+        contains_I = "ABC0I23"
+
+        # UEI with o
+        self.assertRaises(ValidationError, validate_uei_valid_chars, contains_o)
         # UEI with O
-        self.assertRaises(ValidationError, validate_uei_valid_chars, "123456789O11")
+        self.assertRaises(ValidationError, validate_uei_valid_chars, contains_O)
+        # UEI with i
+        self.assertRaises(ValidationError, validate_uei_valid_chars, contains_i)
         # UEI with I
-        self.assertRaises(ValidationError, validate_uei_valid_chars, "I23456789011")
-        # This should not raise a validation error because it does not have an O or I
-        validate_uei_valid_chars("123456789011")
+        self.assertRaises(ValidationError, validate_uei_valid_chars, contains_I)
+        # Valid UEI
+        validate_uei_valid_chars(self.valid)
         
     def test_uei_does_not_start_with_0(self):
         """UEI does not start with 0"""
+        invalid = "012345678901"
+
         # UEI starts with O
-        self.assertRaises(ValidationError, validate_uei_leading_char, "012345678901")
-        # UEI does not start with 0
-        validate_uei_leading_char("123456789011")
+        self.assertRaises(ValidationError, validate_uei_leading_char, invalid)
+        # Valid UEI
+        validate_uei_leading_char(self.valid)
 
     def test_uei_does_not_contain_9_digit_sequence(self):
         """UEI does not contain 9 digit sequence"""
+        invalid = "12345678901"
+
         # UEI contains 9 digit sequence
-        self.assertRaises(ValidationError, validate_uei_nine_digit_sequences, "12345678901")
-        # UEI does not contain 9 digit sequence
-        validate_uei_nine_digit_sequences("ABC123DEF456")
+        self.assertRaises(ValidationError, validate_uei_nine_digit_sequences, invalid)
+        # Valid UEI
+        validate_uei_nine_digit_sequences(self.valid)

--- a/backend/audit/validators.py
+++ b/backend/audit/validators.py
@@ -1,6 +1,12 @@
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
 
+def validate_uei(value):
+    """Validates the UEI using the UEI Spec"""
+    validate_uei_valid_chars(value)
+    validate_uei_leading_char(value)
+    validate_uei_nine_digit_sequences(value)
+
 def validate_uei_valid_chars(value):
     """The letters “O” and “I” are not used to avoid confusion with zero and one."""
     if "O" in value.upper() or "I" in value.upper():

--- a/backend/audit/validators.py
+++ b/backend/audit/validators.py
@@ -1,11 +1,22 @@
+from curses.ascii import isalnum
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
 
 def validate_uei(value):
     """Validates the UEI using the UEI Spec"""
+    validate_uei_alphanumeric(value)
     validate_uei_valid_chars(value)
     validate_uei_leading_char(value)
     validate_uei_nine_digit_sequences(value)
+    return value
+
+def validate_uei_alphanumeric(value):
+    """The UEI should be alphanumeric"""
+    if not value.isalnum():
+        raise ValidationError(
+            _('The UEI should be alphanumeric'),
+        )
+    return value
 
 def validate_uei_valid_chars(value):
     """The letters “O” and “I” are not used to avoid confusion with zero and one."""
@@ -13,6 +24,7 @@ def validate_uei_valid_chars(value):
         raise ValidationError(
             _('The letters “O” and “I” are not used to avoid confusion with zero and one.'),
         )
+    return value
 
 def validate_uei_leading_char(value):
     """The first character is not zero to avoid cutting off digits that can occur during data imports, 
@@ -21,6 +33,7 @@ def validate_uei_leading_char(value):
         raise ValidationError(
             _('The first character is not zero to avoid cutting off digits that can occur during data imports.'),
         )
+    return value
 
 def validate_uei_nine_digit_sequences(value):
     """Nine-digit sequences are not used in the identifier to avoid collision with the nine-digit 
@@ -36,3 +49,4 @@ def validate_uei_nine_digit_sequences(value):
             raise ValidationError(
             _('Nine-digit sequences are not used in the identifier to avoid collision with the nine-digit DUNS Number or Taxpayer Identification Number (TIN).'),
         )
+    return value

--- a/backend/audit/validators.py
+++ b/backend/audit/validators.py
@@ -1,0 +1,32 @@
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
+
+def validate_uei_valid_chars(value):
+    """The letters “O” and “I” are not used to avoid confusion with zero and one."""
+    if "O" in value.upper() or "I" in value.upper():
+        raise ValidationError(
+            _('The letters “O” and “I” are not used to avoid confusion with zero and one.'),
+        )
+
+def validate_uei_leading_char(value):
+    """The first character is not zero to avoid cutting off digits that can occur during data imports, 
+    for example, when importing data into spreadsheet programs."""
+    if value.startswith('0'):
+        raise ValidationError(
+            _('The first character is not zero to avoid cutting off digits that can occur during data imports.'),
+        )
+
+def validate_uei_nine_digit_sequences(value):
+    """Nine-digit sequences are not used in the identifier to avoid collision with the nine-digit 
+    DUNS Number or Taxpayer Identification Number (TIN)."""
+    count = 0
+    for ch in value:
+        if ch.isnumeric():
+            count += 1
+        else:
+            count = 0
+            
+        if count >= 9:
+            raise ValidationError(
+            _('Nine-digit sequences are not used in the identifier to avoid collision with the nine-digit DUNS Number or Taxpayer Identification Number (TIN).'),
+        )

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -22,5 +22,6 @@ urlpatterns = [
     path('api/', include(api_router.urls)),
     path('sac/eligibility', views.EligibilityFormView.as_view(), name='eligibility'),
     path('sac/generalinfo', views.GeneralInfoView.as_view(), name='general-info'),
+    path('sac/ueivalidation', views.UEIValidationFormView.as_view(), name='uei-validation'),
     path(settings.ADMIN_URL, admin.site.urls),
 ]


### PR DESCRIPTION
Added local validators to ensure adherence to UEI standards.

According to the [UEI specification](https://www.gsa.gov/about-us/organization/federal-acquisition-service/office-of-systems-management/integrated-award-environment-iae/iae-systems-information-kit/uei-technical-specifications-and-api-information), there are several checks to determine a valid UEI. 

This performs the initial checks to ensure a valid UEI, including: 

> * The letters “O” and “I” are not used to avoid confusion with zero and one.
> * The first character is not zero to avoid cutting off digits that can occur during data imports, for example, when importing data into spreadsheet programs.
> * Nine-digit sequences are not used in the identifier to avoid collision with the nine-digit DUNS Number or Taxpayer Identification Number (TIN).