### PR TITLE
Update eligibility checks to match current functionality

### DIFF
--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -1,6 +1,12 @@
 from rest_framework import serializers
+from django.utils.translation import gettext_lazy as _
 
 from audit.models import SingleAuditChecklist
+
+
+SPENDING_THRESHOLD = _("The FAC only accepts submissions from non-Federal entities that spend $750,000 or more in federal awards during its audit period (fiscal period begin dates on or after 12/26/2014) in accordance with Uniform Guidance")
+USA_BASED = _("The FAC only accepts submissions from U.S.-based entities")
+USER_PROVIDED_ORG_TYPE = _("The FAC only accepts submissions from States, Local governments, Indian tribes or Tribal organizations, Institutions of higher education (IHEs), and Non-profits")
 
 
 class EligibilitySerializer(serializers.ModelSerializer):
@@ -8,10 +14,20 @@ class EligibilitySerializer(serializers.ModelSerializer):
         model = SingleAuditChecklist
         fields = ['user_provided_organization_type', 'met_spending_threshold', 'is_usa_based']
 
-    def validate(self, data):
-        if not (data['met_spending_threshold'] and data['is_usa_based']):
-            raise serializers.ValidationError("Must be USA based and have met spending threshold")
-        return data
+    def validate_is_usa_based(self, value):
+        if not value:
+            raise serializers.ValidationError(USA_BASED)
+        return value
+
+    def validate_met_spending_threshold(self, value):
+        if not value:
+            raise serializers.ValidationError(SPENDING_THRESHOLD)
+        return value
+
+    def validate_user_provided_organization_type(self, value):
+        if value == 'none':
+            raise serializers.ValidationError(USER_PROVIDED_ORG_TYPE)
+        return value
 
 
 class SingleAuditChecklistSerializer(serializers.ModelSerializer):

--- a/backend/api/test_serializers.py
+++ b/backend/api/test_serializers.py
@@ -6,15 +6,17 @@ class EligibilityStepTests(SimpleTestCase):
 
     def test_serializer_validation(self):
         """
-            IS_USA_BASE and MET_SPENDING_THRESHOLD must bge True
+            IS_USA_BASE and MET_SPENDING_THRESHOLD must be True
             USER_PROVIDED_ORGANIZATION_TYPE must be one of: audit.SingleAuditChecklist.USER_PROVIDED_ORGANIZATION_TYPE
         """
         valid = {'is_usa_based': True, 'met_spending_threshold': True, 'user_provided_organization_type': 'state'}
         invalid = {'is_usa_based': False, 'met_spending_threshold': True, 'user_provided_organization_type': 'state'}
         empty = {}
         wrong_choice = {'is_usa_based': True, 'met_spending_threshold': True, 'user_provided_organization_type': 'not a valid type'}
+        did_not_meet_threshold = {'is_usa_based': True, 'met_spending_threshold': False, 'user_provided_organization_type': 'state'}
 
         self.assertFalse(EligibilitySerializer(data=invalid).is_valid())
         self.assertFalse(EligibilitySerializer(data=empty).is_valid())
         self.assertFalse(EligibilitySerializer(data=wrong_choice).is_valid())
+        self.assertFalse(EligibilitySerializer(data=did_not_meet_threshold).is_valid())
         self.assertTrue(EligibilitySerializer(data=valid).is_valid())

--- a/backend/audit/models.py
+++ b/backend/audit/models.py
@@ -11,6 +11,7 @@ class SingleAuditChecklist(models.Model):
         ('state', _('State')),
         ('local', _('Local Government')),
         ('tribal', _('Indian Tribe or Tribal Organization')),
+        ('higher-ed', _('Institution of higher education (IHE)')),
         ('non-profit', _('Non-profit')),
         ('unknown', _('Unknown')),
         ('none', _("None of these (for example, for-profit")),

--- a/docs/validations.md
+++ b/docs/validations.md
@@ -11,5 +11,6 @@ An essential function of this application is to validate inbound SF-SAC and Sing
 
 | Form Step | Validation | Fields | Implementation | Test coverage
 | --- | --- | --- | --- | --- |
-| Eligibility | Org type must be one of `audit.models.SingleAuditChecklist.USER_PROVIDED_ORGANIZATION_TYPES` | `USER_PROVIDED_ORGANIZATION_TYPE` | `api.serializers.EligibilitySerializer.validate` |  `api.test_serializers.EligibilityStepTests`
-| Eligibility | Must be USA based and have met spending threshold | `IS_USA_BASED`, `MET_SPENDING_THRESHOLD`| `api.serializers.EligibilitySerializer.validate` | `api.test_serializers.EligibilityStepTests`
+| Eligibility | Org type must be one of `audit.models.SingleAuditChecklist.USER_PROVIDED_ORGANIZATION_TYPES` | `USER_PROVIDED_ORGANIZATION_TYPE` | `api.serializers.EligibilitySerializer` |  `api.test_serializers.EligibilityStepTests`
+| Eligibility | Must be USA based | `IS_USA_BASED`| `api.serializers.EligibilitySerializer` | `api.test_serializers.EligibilityStepTests`
+| Eligibility | Must meet spending threshold| `MET_SPENDING_THRESHOLD`| `api.serializers.EligibilitySerializer` | `api.test_serializers.EligibilityStepTests`


### PR DESCRIPTION
For #122,

This implements the complete back-end logic to validate inbound eligibility requests. Error messages are pulled from the existing system.

API returns a json "errors" object with field named attributes whose values are the corresponding error message:


**Given input**
```json
{"user_provided_organization_type": "none", "is_usa_based": false, "met_spending_threshold": false}
```

**The API returns**
```json
{
    "eligible": false,
    "errors": {
        "user_provided_organization_type": [
            "The FAC only accepts submissions from States, Local governments, Indian tribes or Tribal organizations, Institutions of higher education (IHEs), and Non-profits"
        ],
        "met_spending_threshold": [
            "The FAC only accepts submissions from non-Federal entities that spend $750,000 or more in federal awards during its audit period (fiscal period begin dates on or after 12/26/2014) in accordance with Uniform Guidance"
        ],
        "is_usa_based": [
            "The FAC only accepts submissions from U.S.-based entities"
        ]
    }
}
```

**SUCCESS
Given input**
```json
{"user_provided_organization_type": "state", "is_usa_based": true, "met_spending_threshold": true}
```

**API Returns**
```json
{
    "eligible": true,
    "next": "/sac/auditee"
}
```