### PR TITLE
Expand detail of tests for SAM.gov API queries

### DIFF
--- a/backend/api/test_uei.py
+++ b/backend/api/test_uei.py
@@ -2,6 +2,9 @@ import json
 
 from unittest.mock import patch
 from django.test import TestCase
+import requests
+
+# from requests.exceptions import Timeout, TooManyRedirects
 
 from api.uei import get_uei_info_from_sam_gov
 
@@ -97,6 +100,53 @@ invalid_uei_results_dict = {
 invalid_uei_results = json.dumps(invalid_uei_results_dict)
 
 missing_uei_results = json.dumps({"totalRecords": 0, "entityData": []})
+lying_uei_results = json.dumps({"totalRecords": 1, "entityData": []})
+misshapen_uei_results = json.dumps({"totalRecords": 1, "entityData": [""]})
+
+inactive_uei_results_dict = {
+    "totalRecords": 1,
+    "entityData": [
+        {
+            "entityRegistration": {
+                "samRegistered": "Yes",
+                "ueiSAM": "ZQGGHJH74DW7",
+                "entityEFTIndicator": None,
+                "cageCode": "855J5",
+                "dodaac": None,
+                "legalBusinessName": "INTERNATIONAL BUSINESS MACHINES CORPORATION",
+                "dbaName": None,
+                "purposeOfRegistrationCode": "Z2",
+                "purposeOfRegistrationDesc": "All Awards",
+                "registrationStatus": "Inactive",
+                "evsSource": "D&B",
+                "registrationDate": "2018-07-24",
+                "lastUpdateDate": "2022-03-29",
+                "registrationExpirationDate": "2022-02-06",
+                "activationDate": "2020-08-13",
+                "ueiStatus": "Inactive",
+                "ueiExpirationDate": None,
+                "ueiCreationDate": "2020-05-01",
+                "publicDisplayFlag": "Y",
+                "exclusionStatusFlag": "N",
+                "exclusionURL": None,
+                "dnbOpenData": None,
+            }
+        }
+    ],
+    "links": {
+        "selfLink": "".join(
+            [
+                "https://api.sam.gov/entity-information/v3/entities?",
+                "api_key=REPLACE_WITH_API_KEY&",
+                "ueiSAM=ZQGGHJH74DW7&",
+                "includeSections=entityRegistration&",
+                "page=0&",
+                "size=10",
+            ]
+        )
+    },
+}
+inactive_uei_results = json.dumps(inactive_uei_results_dict)
 
 
 class UtilsTesting(TestCase):
@@ -112,23 +162,86 @@ class UtilsTesting(TestCase):
             mock_get.return_value.json.return_value = json.loads(
                 valid_uei_results
             )  # Mock the json
+            results = get_uei_info_from_sam_gov(uei=test_uei)
 
-            self.assertTrue(get_uei_info_from_sam_gov(uei=test_uei)["valid"])
-            self.assertRaises(
-                KeyError,
-                lambda: get_uei_info_from_sam_gov(uei=test_uei)["errors"],
-            )
+            self.assertTrue(results["valid"])
+            self.assertRaises(KeyError, lambda: results["errors"])
             self.assertEqual(
-                get_uei_info_from_sam_gov(uei=test_uei)["response"],
+                results["response"],
                 json.loads(valid_uei_results)["entityData"][0],
             )
 
         # Invalid Status Code
         with patch("api.uei.requests.get") as mock_get:
             mock_get.return_value.status_code = 400  # Mock the status code
+            results = get_uei_info_from_sam_gov(uei=test_uei)
 
-            self.assertFalse(get_uei_info_from_sam_gov(uei=test_uei)["valid"])
-            self.assertTrue(get_uei_info_from_sam_gov(uei=test_uei)["errors"])
+            self.assertFalse(results["valid"])
+            self.assertTrue(results["errors"])
+            self.assertEquals(
+                results["errors"],
+                ["SAM.gov API response status code invalid, status code: 400"],
+            )
+
+        # Timeout
+        with patch("api.uei.requests.get") as mock_get:
+
+            def bad_timeout(*args, **kwds):
+                raise requests.exceptions.Timeout
+
+            mock_get.side_effect = bad_timeout
+            results = get_uei_info_from_sam_gov(uei=test_uei)
+
+            self.assertFalse(results["valid"])
+            self.assertTrue(results["errors"])
+            self.assertEquals(results["errors"], ["SAM.gov API timeout"])
+
+        # TooManyRedirects
+        with patch("api.uei.requests.get") as mock_get:
+
+            def bad_redirects(*args, **kwds):
+                raise requests.exceptions.TooManyRedirects
+
+            mock_get.side_effect = bad_redirects
+            results = get_uei_info_from_sam_gov(uei=test_uei)
+
+            self.assertFalse(results["valid"])
+            self.assertTrue(results["errors"])
+            self.assertEquals(
+                results["errors"], ["SAM.gov API error - too many redirects"]
+            )
+
+        # RequestException
+        with patch("api.uei.requests.get") as mock_get:
+
+            def bad_reqexception(*args, **kwds):
+                raise requests.exceptions.RequestException
+
+            mock_get.side_effect = bad_reqexception
+            results = get_uei_info_from_sam_gov(uei=test_uei)
+
+            self.assertFalse(results["valid"])
+            self.assertTrue(results["errors"])
+            self.assertEquals(
+                results["errors"],
+                ["Unable to make SAM.gov API request, error: "],
+            )
+
+        # Exception
+        with patch("api.uei.requests.get") as mock_get:
+
+            def bad_exception(*args, **kwds):
+                raise Exception
+
+            mock_get.side_effect = bad_exception
+            results = get_uei_info_from_sam_gov(uei=test_uei)
+
+            self.assertFalse(results["valid"])
+            self.assertTrue(results["errors"])
+            self.assertEquals(
+                results["errors"],
+                ["Uncaught SAM.gov API request exception: "],
+            )
 
         # UEI registrationStatus not active
         with patch("api.uei.requests.get") as mock_get:
@@ -136,9 +249,10 @@ class UtilsTesting(TestCase):
             mock_get.return_value.json.return_value = json.loads(
                 invalid_uei_results
             )  # Mock the json
+            results = get_uei_info_from_sam_gov(uei=test_uei)
 
-            self.assertFalse(get_uei_info_from_sam_gov(uei=test_uei)["valid"])
-            self.assertTrue(get_uei_info_from_sam_gov(uei=test_uei)["errors"])
+            self.assertFalse(results["valid"])
+            self.assertTrue(results["errors"])
 
         # No matching UEI's found
         with patch("api.uei.requests.get") as mock_get:
@@ -146,6 +260,59 @@ class UtilsTesting(TestCase):
             mock_get.return_value.json.return_value = json.loads(
                 missing_uei_results
             )  # Mock the json
+            results = get_uei_info_from_sam_gov(uei=test_uei)
 
-            self.assertFalse(get_uei_info_from_sam_gov(uei=test_uei)["valid"])
-            self.assertTrue(get_uei_info_from_sam_gov(uei=test_uei)["errors"])
+            self.assertFalse(results["valid"])
+            self.assertTrue(results["errors"])
+            self.assertEquals(
+                results["errors"],
+                ["UEI was not found in SAM.gov"],
+            )
+
+        # Invalid number of SAM.gov entries
+        with patch("api.uei.requests.get") as mock_get:
+            mock_get.return_value.status_code = 200  # Mock the status code
+            mock_get.return_value.json.return_value = json.loads(
+                lying_uei_results
+            )  # Mock the json
+
+            results = get_uei_info_from_sam_gov(uei=test_uei)
+
+            self.assertFalse(results["valid"])
+            self.assertTrue(results["errors"])
+            self.assertEquals(
+                results["errors"],
+                ["SAM.gov invalid number of entries"],
+            )
+
+        # Invalid number of SAM.gov entries
+        with patch("api.uei.requests.get") as mock_get:
+            mock_get.return_value.status_code = 200  # Mock the status code
+            mock_get.return_value.json.return_value = json.loads(
+                misshapen_uei_results
+            )  # Mock the json
+
+            results = get_uei_info_from_sam_gov(uei=test_uei)
+
+            self.assertFalse(results["valid"])
+            self.assertTrue(results["errors"])
+            self.assertEquals(
+                results["errors"],
+                ["SAM.gov unexpected JSON shape"],
+            )
+
+        # Inactive entry
+        with patch("api.uei.requests.get") as mock_get:
+            mock_get.return_value.status_code = 200  # Mock the status code
+            mock_get.return_value.json.return_value = json.loads(
+                inactive_uei_results
+            )  # Mock the json
+
+            results = get_uei_info_from_sam_gov(uei=test_uei)
+
+            self.assertFalse(results["valid"])
+            self.assertTrue(results["errors"])
+            self.assertEquals(
+                results["errors"],
+                ["UEI is not listed as active from SAM.gov response data"],
+            )

--- a/backend/api/uei.py
+++ b/backend/api/uei.py
@@ -11,18 +11,19 @@ def call_sam_api(params: dict) -> tuple[requests.Response, str]:
         return requests.get(SAM_API_URL, params=params, verify=False), None
 
     except requests.exceptions.Timeout:
-        return None, "SAM.gov API timeout"
+        error = "SAM.gov API timeout"
     except requests.exceptions.TooManyRedirects:
-        return None, "SAM.gov API error - too many redirects"
+        error = "SAM.gov API error - too many redirects"
     except requests.exceptions.RequestException as e:
-        return None, "Unable to make SAM.gov API request, error: " + str(e)
+        error = f"Unable to make SAM.gov API request, error: {str(e)}"
     except Exception as e:
-        return None, "Uncaught SAM.gov API request exception: " + str(e)
+        error = f"Uncaught SAM.gov API request exception: {str(e)}"
+    return None, error
 
 
 def get_uei_info_from_sam_gov(uei):
     """
-    This utility function will query sam.gov to determine the status and 
+    This utility function will query sam.gov to determine the status and
     return information about a provided UEI (or throws an Exception)
     """
 
@@ -31,16 +32,13 @@ def get_uei_info_from_sam_gov(uei):
         "api_key": SAM_API_KEY,
         "ueiSAM": uei,
         "samRegistered": "Yes",
-        "includeSections": "entityRegistration"
+        "includeSections": "entityRegistration",
     }
 
     # Call the SAM API
     r, error = call_sam_api(api_params)
     if not r:
-        return {
-            "valid": False,
-            "errors": [error]
-        }
+        return {"valid": False, "errors": [error]}
 
     # Get the status code
     if r.status_code == 200:
@@ -48,40 +46,41 @@ def get_uei_info_from_sam_gov(uei):
         response = r.json()
 
         # Ensure the UEI exists in SAM.gov
-        if response.get('totalRecords') != 1:
-            return {
-                "valid": False,
-                "errors": ["UEI was not found in SAM.gov"]
-            }
+        if response.get("totalRecords") != 1:
+            return {"valid": False, "errors": ["UEI was not found in SAM.gov"]}
 
         entries = response.get("entityData", [])
         if len(entries) != 1:
             return {
                 "valid": False,
-                "errors": ["SAM.gov invalid number of entries"]
+                "errors": ["SAM.gov invalid number of entries"],
             }
         entry = entries[0]
         try:
-            status = entry.get('entityRegistration', {}).get('ueiStatus', "").upper()
+            status = (
+                entry.get("entityRegistration", {})
+                .get("ueiStatus", "")
+                .upper()
+            )
         except AttributeError:
             return {
                 "valid": False,
-                "errors": ["SAM.gov unexpected JSON shape."]
+                "errors": ["SAM.gov unexpected JSON shape"],
             }
 
         if status != "ACTIVE":
             return {
                 "valid": False,
-                "errors": ["UEI is not listed as active from SAM.gov response data"]
+                "errors": [
+                    "UEI is not listed as active from SAM.gov response data"
+                ],
             }
 
-        return {
-            "valid": True,
-            "response": response["entityData"][0]
-        }
+        return {"valid": True, "response": response["entityData"][0]}
 
-    else:
-        return {
-            "valid": False,
-            "errors": ["SAM.gov API response status code invalid, status code: " + str(r.status_code)]
-        }
+    return {
+        "valid": False,
+        "errors": [
+            f"SAM.gov API response status code invalid, status code: {r.status_code}"
+        ],
+    }


### PR DESCRIPTION
Many things can break.
Try to cover more of them
By adding these tests.

-----

Add a bunch of tests for specific edge cases we could encounter when fetching UEI info from SAM.gov.