### PR TITLE
Tell Docker to migrate before running server

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -13,7 +13,9 @@ services:
     build:
       context: .
       dockerfile: ./Dockerfile
-    command: python manage.py runserver 0.0.0.0:8000
+    command: >
+      bash -c "python manage.py migrate 
+      && python manage.py runserver 0.0.0.0:8000"
     depends_on:
       - db
     environment:


### PR DESCRIPTION
This adds a line to `docker-compose.yml` so that when creating a new image or `docker-compose up`ing an existing container, that it tries to run all migrations before running the server. Without this, Django complains that the database is out of date and can possibly throw errors later on.