### PR TITLE
SAM.gov System Account Documentation

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -32,9 +32,16 @@ Target python version is defined in [../backend/runtime.txt](../backend/runtime.
 
 ## Environment Variables
 
-Currently, the only environment variable is `SAM_API_KEY` to validate UEI's.  
+We use the `SAM_API_KEY` environment variable to interact with the SAM.gov API. 
 
-To test UEI validation locally, apply for a SAM.gov [System Account](https://www.fsd.gov/sys_attachment.do?sys_id=5462e13d1b594d9006b09796bc4bcbd2) and then copy the API key into your local environment (should end up somewhere in `~/.bash_profile`, `~/.bashrc`, `~/.zshrc`, or whatever flavor of shell you're using.)
+To test UEI validation using the SAM.gov API with a personal API key, follow these steps on (https://SAM.gov):
+
+* Registered users can request for a public API on ‘Account Details’ page. This page can be accessed here: [Account Details page on SAM.gov](https://sam.gov/profile/details)
+* Users must enter their password on ‘Account Details’ page to view the API Key information. If an incorrect password is entered, an error will be returned.
+* After the API Key is generated on ‘Account Details’ page, the API Key can be viewed on the Account Details page immediately. The API Key is visible until users navigate to a different page.
+* If an error is encountered during the API Key generation/retrieval, then users will receive an error message and they can try again.
+
+After receiving a personal API key, copy the API key into your local environment (should end up in `~/.bash_profile`, `~/.bashrc`, `~/.zshrc`, or whatever flavor of shell you're using.)
 
 ## Docker
 
@@ -113,7 +120,7 @@ python -m pip install --upgrade pip
 pip install pip-tools
 ```
 
-### Set environment variables
+### Django environment variables
 
 We use environment variables to configure much of how Django operates, at a minimum you'll need to configure the uri of your local database.
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -36,7 +36,18 @@ The service account credentials are stored in the repository secrets under:
 
 To use the SAM.gov API, we will have a `system account` [system account](https://www.fsd.gov/gsafsd_sp?id=gsafsd_kb_articles&sys_id=f8426db91b594d9006b09796bc4bcb52) that holds a system account API key.  
 
-The system account API key will be stored in the repository secrets under:
+To generate a SAM.gov System Account API key, follow these steps:
+
+* Users registered with a non-government email address and associated with an entity OR users registered with a government email address may request a system account for public data access.
+* If a user satisfies the above registration criteria they will be able to access the System Accounts widget from their Workspace page after logging in.
+* The user can then select “Go to System Accounts” from the widget and fill out the required sections.
+* The requested system account will then need to be approved. After approval the user will be notified via email and they can also see the updated status in the System Account widget.
+* The user can select ‘Go to System Accounts’ again in the widget from their workspace and enter a new system account password.
+* After setting up the password the user will see a new section for retrieving a system account API Key.
+* The user must enter their password again to retrieve the key.
+* NOTE: To obtain access to the FOUO/Sensitive Entity API data with a system account the user must be registered with a government email address.
+
+The system account API key will be stored in the repository secrets (in Github) under:
 
 - `SAM_API_KEY`
 


### PR DESCRIPTION
Satisfies #164 - documents the process of requesting a personal SAM.gov API key for local development and how to request a SAM.gov system account API key for deployment and where to store it.