### PR TITLE
Switch strong to headers for headers in issue templates.

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -9,12 +9,14 @@ assignees: ''
 
 Breakout issue of <story>
 
-**Background**
+### Background
 
-**Acceptance Criteria (We'll know we're done when...)**
+### Acceptance Criteria (We'll know we're done when...)
+
 - [ ] 
 - [ ] 
 
-**Tasks**
+### Tasks
+
 - [ ] 
 - [ ]

--- a/.github/ISSUE_TEMPLATE/story-issue-template-.md
+++ b/.github/ISSUE_TEMPLATE/story-issue-template-.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-**Background**
+### Background
 
 <<background>>
 
@@ -15,14 +15,16 @@ It covers the following stories:
 
 1. As an ...
 
-**Acceptance criteria (We'll know we're done when...)**
+### Acceptance criteria (We'll know we're done when...)
+
 - [ ] When a user can ...
   
-**Tasks**
+### Tasks
+
 - [ ] Design designs all the things
 - [ ] Engineering engineers all the things
 
-**Definition of Done**
+### Definition of Done
 
 - [ ] Meets acceptance criteria
 - [ ] Screen reader - Listen to the experience with a screen reader extension, ensure the information presented in order


### PR DESCRIPTION
Semantic markup
Is something I like a lot
So I used headers.

-----

Tweak issue templates to use headers instead of strong, because I found myself making that edit every time I went to create an issue.