### PR TITLE
Tweak Makefile so that coverage is invoked by python executable

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -34,4 +34,4 @@ lint:
 
 # Run Django tests:
 test:
-	@coverage run --source="." manage.py test && coverage report -m --fail-under=99
+	@python -m coverage run --source="." manage.py test && coverage report -m --fail-under=99


### PR DESCRIPTION
Avoid confusion
By being more explicit.
This should help with that.

-----

I ran into a situation locally where the `coverage` executable was associated with a different version of Python, and this should fix that problem.