### PR TITLE
Add Token delete endpoint

### DIFF
--- a/backend/users/test_views.py
+++ b/backend/users/test_views.py
@@ -23,7 +23,7 @@ class AuthTokenViewTests(TestCase):
         """
         view = AuthToken()
 
-        # AuthToken views should allow JWTUpsertAuthentication 
+        # AuthToken views should allow JWTUpsertAuthentication
         self.assertIn(JWTUpsertAuthentication, view.authentication_classes)
         # AuthToken views should allow ExpiringTokenAuthentication
         self.assertIn(ExpiringTokenAuthentication, view.authentication_classes)
@@ -82,6 +82,6 @@ class AuthTokenViewTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
 
-        # there should no longer be a token associated with this user        
+        # there should no longer be a token associated with this user
         tokens = Token.objects.filter(user=user)
         self.assertEqual(tokens.count(), 0)

--- a/backend/users/test_views.py
+++ b/backend/users/test_views.py
@@ -68,6 +68,9 @@ class AuthTokenViewTests(TestCase):
         self.assertIn("token", data)
         self.assertNotEqual(token.key, data["token"])
 
+        tokens = Token.objects.filter(user=user)
+        self.assertEqual(tokens.count(), 1)
+
     def test_delete_token(self):
         """
         if the delete endpoint is hit, the token associated with the authenticated user should be deleted

--- a/backend/users/test_views.py
+++ b/backend/users/test_views.py
@@ -6,7 +6,7 @@ from rest_framework.authtoken.models import Token
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.test import APIClient
 
-from .auth import JWTUpsertAuthentication
+from .auth import ExpiringTokenAuthentication, JWTUpsertAuthentication
 from .views import AuthToken
 
 from model_bakery import baker
@@ -17,19 +17,27 @@ TOKEN_PATH = reverse("token")
 
 
 class AuthTokenViewTests(TestCase):
-    def test_jwt_upsert_auth_required(self):
+    def test_authentication_classes(self):
+        """
+        AuthToken views should allow JWTUpsertAuthentication and ExpiringTokenAuthentication
+        """
         view = AuthToken()
 
-        # AuthToken views should require JWTUpsertAuthentication
+        # AuthToken views should allow JWTUpsertAuthentication 
         self.assertIn(JWTUpsertAuthentication, view.authentication_classes)
-        self.assertEqual(len(view.authentication_classes), 1)
+        # AuthToken views should allow ExpiringTokenAuthentication
+        self.assertIn(ExpiringTokenAuthentication, view.authentication_classes)
+        # AuthToken should *only* allow the above authentication classes
+        self.assertEqual(len(view.authentication_classes), 2)
 
         # AuthToken views should require that the user is authenticated
         self.assertIn(IsAuthenticated, view.permission_classes)
         self.assertEqual(len(view.permission_classes), 1)
 
     def test_no_existing_token(self):
-        # if a user has no existing tokens, one should be created
+        """
+        if a user has no existing tokens, one should be created
+        """
         user = baker.make(User)
 
         client = APIClient()
@@ -43,7 +51,9 @@ class AuthTokenViewTests(TestCase):
         self.assertIn("token", data)
 
     def test_existing_token(self):
-        # if a user has an existing token, a new one should be created in its place
+        """
+        if a user has an existing token, a new one should be created in its place
+        """
         user = baker.make(User)
         token = baker.make(Token, user=user)
 
@@ -57,3 +67,21 @@ class AuthTokenViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn("token", data)
         self.assertNotEqual(token.key, data["token"])
+
+    def test_delete_token(self):
+        """
+        if the delete endpoint is hit, the token associated with the authenticated user should be deleted
+        """
+        user = baker.make(User)
+        baker.make(Token, user=user)
+
+        client = APIClient()
+        client.force_authenticate(user=user)
+
+        response = client.delete(TOKEN_PATH)
+
+        self.assertEqual(response.status_code, 200)
+
+        # there should no longer be a token associated with this user        
+        tokens = Token.objects.filter(user=user)
+        self.assertEqual(tokens.count(), 0)

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -3,11 +3,11 @@ from rest_framework.authtoken.models import Token
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
-from .auth import JWTUpsertAuthentication
+from .auth import ExpiringTokenAuthentication, JWTUpsertAuthentication
 
 
 class AuthToken(ObtainAuthToken):
-    authentication_classes = [JWTUpsertAuthentication]
+    authentication_classes = [JWTUpsertAuthentication, ExpiringTokenAuthentication]
     permission_classes = [IsAuthenticated]
 
     def post(self, request):
@@ -22,3 +22,9 @@ class AuthToken(ObtainAuthToken):
 
         token = Token.objects.create(user=request.user)
         return Response({"token": token.key})
+
+    def delete(self, request):
+        token = Token.objects.get(user=request.user)
+        token.delete()
+
+        return Response()


### PR DESCRIPTION
Addresses #379 

Adds a `DELETE` endpoint at `/api/auth/token`, which deletes the `Token` associated with the authenticated user, effectively logging them out of the backend. Before making additional API calls, a JWT from Login.gov would need to be exchanged for a new API token.