### PR TITLE
Add endpoint to return all accessible audits for a user

### DIFF
--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -148,4 +148,11 @@ class AccessListSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Access
-        fields = ["auditee_uei", "auditee_fiscal_period_end", "auditee_name", "role", "report_id", "submission_status"]
+        fields = [
+            "auditee_uei",
+            "auditee_fiscal_period_end",
+            "auditee_name",
+            "role",
+            "report_id",
+            "submission_status",
+        ]

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -122,3 +122,30 @@ class SingleAuditChecklistSerializer(serializers.ModelSerializer):
     class Meta:
         model = SingleAuditChecklist
         fields = "__all__"
+
+
+class AccessListSerializer(serializers.ModelSerializer):
+    auditee_uei = serializers.SerializerMethodField()
+    auditee_fiscal_period_end = serializers.SerializerMethodField()
+    auditee_name = serializers.SerializerMethodField()
+    report_id = serializers.SerializerMethodField()
+    submission_status = serializers.SerializerMethodField()
+
+    def get_auditee_uei(self, access):
+        return access.sac.auditee_uei
+
+    def get_auditee_fiscal_period_end(self, access):
+        return access.sac.auditee_fiscal_period_end
+
+    def get_auditee_name(self, access):
+        return access.sac.auditee_name
+
+    def get_report_id(self, access):
+        return access.sac.report_id
+
+    def get_submission_status(self, access):
+        return access.sac.submission_status
+
+    class Meta:
+        model = Access
+        fields = ["auditee_uei", "auditee_fiscal_period_end", "auditee_name", "role", "report_id", "submission_status"]

--- a/backend/api/test_serializers.py
+++ b/backend/api/test_serializers.py
@@ -14,7 +14,7 @@ from api.serializers import (
     AccessListSerializer,
     AccessAndSubmissionSerializer,
 )
-from audit.models import User, Access, SingleAuditChecklist
+from audit.models import User, Access
 
 
 class EligibilityStepTests(SimpleTestCase):
@@ -324,8 +324,13 @@ class AccessListSerializerTests(TestCase):
         serializer = AccessListSerializer(access)
 
         self.assertEquals(serializer.data["auditee_uei"], access.sac.auditee_uei)
-        self.assertEquals(serializer.data["auditee_fiscal_period_end"], access.sac.auditee_fiscal_period_end)
+        self.assertEquals(
+            serializer.data["auditee_fiscal_period_end"],
+            access.sac.auditee_fiscal_period_end,
+        )
         self.assertEquals(serializer.data["auditee_name"], access.sac.auditee_name)
         self.assertEquals(serializer.data["report_id"], access.sac.report_id)
-        self.assertEquals(serializer.data["submission_status"], access.sac.submission_status)
+        self.assertEquals(
+            serializer.data["submission_status"], access.sac.submission_status
+        )
         self.assertEquals(serializer.data["role"], access.role)

--- a/backend/api/test_views.py
+++ b/backend/api/test_views.py
@@ -1,7 +1,5 @@
 import json
-from tokenize import Single
 from unittest.mock import patch
-from venv import create
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase
@@ -482,7 +480,7 @@ class AccessListViewTests(TestCase):
         response = client.get(ACCESS_LIST_PATH, format="json")
 
         self.assertEqual(response.status_code, 401)
-    
+
     def test_no_access_returns_empty_list(self):
         """
         If a user does not have access to any audits, an empty list is returned
@@ -540,7 +538,9 @@ class AccessListViewTests(TestCase):
 
         self.assertEqual(len(data), 2)
 
-        auditee_cert_accesses = list(filter(lambda a: a["role"] == "auditee_cert", data))
+        auditee_cert_accesses = list(
+            filter(lambda a: a["role"] == "auditee_cert", data)
+        )
         self.assertEqual(len(auditee_cert_accesses), 1)
         self.assertEqual(auditee_cert_accesses[0]["report_id"], sac.report_id)
 

--- a/backend/api/test_views.py
+++ b/backend/api/test_views.py
@@ -548,6 +548,31 @@ class AccessListViewTests(TestCase):
         self.assertEqual(len(creator_accesses), 1)
         self.assertEqual(creator_accesses[0]["report_id"], sac.report_id)
 
+    def test_deleted_sac_not_returned(self):
+        """
+        If a user has their SACs deleted, it is no longer returned in their access list
+        """
+        sac = baker.make(SingleAuditChecklist)
+        access_1 = baker.make(Access, user=self.user)
+        baker.make(Access, user=self.user, sac=sac)
+
+        response_1 = self.client.get(ACCESS_LIST_PATH, format="json")
+        data_1 = response_1.json()
+
+        # initially we see both in our access list
+        self.assertEqual(len(data_1), 2)
+
+        # now delete one access_2
+        sac.delete()
+
+        response_2 = self.client.get(ACCESS_LIST_PATH, format="json")
+        data_2 = response_2.json()
+
+        # only the one remaining access should come back
+        self.assertEqual(len(data_2), 1)
+        self.assertEqual(data_2[0]["report_id"], access_1.sac.report_id)
+
+
     def test_deleted_access_not_returned(self):
         """
         If a user has their Access deleted, the associated SAC is no longer returned in their access list

--- a/backend/api/test_views.py
+++ b/backend/api/test_views.py
@@ -572,7 +572,6 @@ class AccessListViewTests(TestCase):
         self.assertEqual(len(data_2), 1)
         self.assertEqual(data_2[0]["report_id"], access_1.sac.report_id)
 
-
     def test_deleted_access_not_returned(self):
         """
         If a user has their Access deleted, the associated SAC is no longer returned in their access list

--- a/backend/api/test_views.py
+++ b/backend/api/test_views.py
@@ -547,3 +547,26 @@ class AccessListViewTests(TestCase):
         creator_accesses = list(filter(lambda a: a["role"] == "creator", data))
         self.assertEqual(len(creator_accesses), 1)
         self.assertEqual(creator_accesses[0]["report_id"], sac.report_id)
+
+    def test_deleted_access_not_returned(self):
+        """
+        If a user has their Access deleted, the associated SAC is no longer returned in their access list
+        """
+        access_1 = baker.make(Access, user=self.user)
+        access_2 = baker.make(Access, user=self.user)
+
+        response_1 = self.client.get(ACCESS_LIST_PATH, format="json")
+        data_1 = response_1.json()
+
+        # initially we see both in our access list
+        self.assertEqual(len(data_1), 2)
+
+        # now delete one access_2
+        access_2.delete()
+
+        response_2 = self.client.get(ACCESS_LIST_PATH, format="json")
+        data_2 = response_2.json()
+
+        # only the one remaining access should come back
+        self.assertEqual(len(data_2), 1)
+        self.assertEqual(data_2[0]["report_id"], access_1.sac.report_id)

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -1,5 +1,4 @@
 import json
-from os import access
 
 from audit.models import Access, SingleAuditChecklist
 from django.urls import reverse
@@ -211,8 +210,8 @@ class AccessListView(APIView):
     """
 
     def get(self, request):
-        accesses = Access.objects.select_related('sac').filter(user=request.user)
-        
+        accesses = Access.objects.select_related("sac").filter(user=request.user)
+
         serializer = AccessListSerializer(accesses, many=True)
 
         return Response(serializer.data)

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -1,4 +1,5 @@
 import json
+from os import access
 
 from audit.models import Access, SingleAuditChecklist
 from django.urls import reverse
@@ -9,6 +10,7 @@ from django.http import JsonResponse
 
 from .serializers import (
     AccessAndSubmissionSerializer,
+    AccessListSerializer,
     AuditeeInfoSerializer,
     EligibilitySerializer,
     SingleAuditChecklistSerializer,
@@ -201,3 +203,16 @@ class SubmissionsView(APIView):
         )
 
         return JsonResponse(list(all_submissions), safe=False)
+
+
+class AccessListView(APIView):
+    """
+    Returns a summary list of SingleAuditChecklists that the user has Access to
+    """
+
+    def get(self, request):
+        accesses = Access.objects.select_related('sac').filter(user=request.user)
+        
+        serializer = AccessListSerializer(accesses, many=True)
+
+        return Response(serializer.data)

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -44,5 +44,10 @@ urlpatterns = [
         views.SubmissionsView.as_view(),
         name="submissions",
     ),
+    path(
+        "access-list",
+        views.AccessListView.as_view(),
+        name="access-list",
+    ),
     path(settings.ADMIN_URL, admin.site.urls),
 ]


### PR DESCRIPTION
Resolves #410

Adds `/access-list` endpoint, which returns all of the `SingleAuditChecklists` for which the authenticated `User` has `Access` (see return format below). If a `User` holds multiple roles for a `SingleAuditChecklist`, that `SingleAuditChecklist` will appear in the list once for each role the user holds. 

```
[
    {
        "auditee_uei": "ABC123DEF456",
        "auditee_fiscal_period_end": "2022-08-01",
        "auditee_name": "a new one",
        "role": "auditee_contact",
        "report_id": "2021XC70001000003",
        "submission_status": "in_progress"
    },
    {
        "auditee_uei": "ABC123DEF456",
        "auditee_fiscal_period_end": "2022-08-01",
        "auditee_name": "a new one",
        "role": "auditee_cert",
        "report_id": "2021XC70001000003",
        "submission_status": "in_progress"
    },
    {
        "auditee_uei": "ABC123DEF456",
        "auditee_fiscal_period_end": "2022-08-01",
        "auditee_name": "somethingelse",
        "role": "creator",
        "report_id": "2021E060001000002",
        "submission_status": "in_progress"
    }
]
```