### PR TITLE
Authorized GET endpoint for SingleAuditChecklist

### DIFF
--- a/backend/api/test_views.py
+++ b/backend/api/test_views.py
@@ -442,7 +442,7 @@ class SingleAuditChecklistViewTests(TestCase):
         sac = baker.make(SingleAuditChecklist)
 
         response = self.client.get(self.path(sac.report_id))
-        assert response.status_code == 403
+        self.assertEqual(response.status_code, 403)
 
         # create a SAC
 
@@ -453,7 +453,7 @@ class SingleAuditChecklistViewTests(TestCase):
         access = baker.make(Access, user=self.user)
         response = self.client.get(self.path(access.sac.report_id))
 
-        assert response.status_code == 200
+        self.assertEqual(response.status_code, 200)
 
         # create an Access with our user
 
@@ -463,7 +463,7 @@ class SingleAuditChecklistViewTests(TestCase):
     def test_bad_report_id(self):
         response = self.client.get(self.path("nonsensical_id"))
 
-        assert response.status_code == 404
+        self.assertEqual(response.status_code, 404)
 
         # hit with auth'd client, random report_id
         # expect 404

--- a/backend/api/test_views.py
+++ b/backend/api/test_views.py
@@ -461,7 +461,10 @@ class SingleAuditChecklistViewTests(TestCase):
         # expect 200
 
     def test_bad_report_id(self):
-        pass
+        access = baker.make(Access, user=self.user)
+        response = self.client.get(self.path("nonsensical_id"))
+
+        assert response.status_code == 404
 
         # hit with auth'd client, random report_id
         # expect 404

--- a/backend/api/test_views.py
+++ b/backend/api/test_views.py
@@ -417,6 +417,30 @@ class SACCreationTests(TestCase):
         self.assertEqual(sac.submission_status, "in_progress")
 
 
+class SingleAuditChecklistViewTests(TestCase):
+    def setUp(self):
+        self.user = baker.make(User)
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+
+    def path(self, report_id):
+        return reverse("singleauditchecklist", kwargs={ "report_id": report_id })        
+
+    def test_authentication_required(self):
+        """
+        If a request is not authenticated, it should be rejected with a 401
+        """
+
+        # use a different client that doesn't authenticate
+        client = APIClient()
+
+        response = client.get(self.path("test-report-id"), format="json")
+
+        self.assertEqual(response.status_code, 401)
+
+
+
+
 class SubmissionsViewTests(TestCase):
     def setUp(self):
         self.user = baker.make(User)

--- a/backend/api/test_views.py
+++ b/backend/api/test_views.py
@@ -461,7 +461,6 @@ class SingleAuditChecklistViewTests(TestCase):
         # expect 200
 
     def test_bad_report_id(self):
-        access = baker.make(Access, user=self.user)
         response = self.client.get(self.path("nonsensical_id"))
 
         assert response.status_code == 404

--- a/backend/api/test_views.py
+++ b/backend/api/test_views.py
@@ -424,7 +424,7 @@ class SingleAuditChecklistViewTests(TestCase):
         self.client.force_authenticate(user=self.user)
 
     def path(self, report_id):
-        return reverse("singleauditchecklist", kwargs={ "report_id": report_id })        
+        return reverse("singleauditchecklist", kwargs={"report_id": report_id})
 
     def test_authentication_required(self):
         """
@@ -439,7 +439,10 @@ class SingleAuditChecklistViewTests(TestCase):
         self.assertEqual(response.status_code, 401)
 
     def test_no_audit_access(self):
-        pass
+        sac = baker.make(SingleAuditChecklist)
+
+        response = self.client.get(self.path(sac.report_id))
+        assert response.status_code == 403
 
         # create a SAC
 
@@ -447,7 +450,10 @@ class SingleAuditChecklistViewTests(TestCase):
         # expect 403
 
     def test_audit_access(self):
-        pass
+        access = baker.make(Access, user=self.user)
+        response = self.client.get(self.path(access.sac.report_id))
+
+        assert response.status_code == 200
 
         # create an Access with our user
 
@@ -458,7 +464,8 @@ class SingleAuditChecklistViewTests(TestCase):
         pass
 
         # hit with auth'd client, random report_id
-        #expect 404
+        # expect 404
+
 
 class SubmissionsViewTests(TestCase):
     def setUp(self):

--- a/backend/api/test_views.py
+++ b/backend/api/test_views.py
@@ -438,8 +438,27 @@ class SingleAuditChecklistViewTests(TestCase):
 
         self.assertEqual(response.status_code, 401)
 
+    def test_no_audit_access(self):
+        pass
 
+        # create a SAC
 
+        # hit endpoint with auth'd client
+        # expect 403
+
+    def test_audit_access(self):
+        pass
+
+        # create an Access with our user
+
+        # hit with auth'd client
+        # expect 200
+
+    def test_bad_report_id(self):
+        pass
+
+        # hit with auth'd client, random report_id
+        #expect 404
 
 class SubmissionsViewTests(TestCase):
     def setUp(self):

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -1,6 +1,8 @@
 import json
 
 from audit.models import Access, SingleAuditChecklist
+from audit.permissions import SingleAuditChecklistPermission
+from django.http import Http404
 from django.urls import reverse
 from rest_framework import viewsets
 from rest_framework.response import Response
@@ -181,6 +183,16 @@ class AccessAndSubmissionView(APIView):
             return Response({"sac_id": sac.id, "next": "TBD"})
 
         return Response({"errors": serializer.errors})
+
+
+class SingleAuditChecklistView(APIView):
+    """
+    Accepts and returns data for a SingleAuditChecklist
+    """
+    permission_classes = [SingleAuditChecklistPermission]
+
+    def get(self, request, report_id):
+        return "asiodfj"
 
 
 class SubmissionsView(APIView):

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -194,7 +194,10 @@ class SingleAuditChecklistView(APIView):
 
     def get(self, request, report_id):
         """ """
-        sac = SingleAuditChecklist.objects.get(report_id=report_id)
+        try:
+            sac = SingleAuditChecklist.objects.get(report_id=report_id)
+        except SingleAuditChecklist.DoesNotExist:
+            raise Http404()
         self.check_object_permissions(request, sac)
         serialized = SingleAuditChecklistSerializer(sac)
         return JsonResponse(serialized.data)

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -189,10 +189,15 @@ class SingleAuditChecklistView(APIView):
     """
     Accepts and returns data for a SingleAuditChecklist
     """
+
     permission_classes = [SingleAuditChecklistPermission]
 
     def get(self, request, report_id):
-        return "asiodfj"
+        """ """
+        sac = SingleAuditChecklist.objects.get(report_id=report_id)
+        self.check_object_permissions(request, sac)
+        serialized = SingleAuditChecklistSerializer(sac)
+        return JsonResponse(serialized.data)
 
 
 class SubmissionsView(APIView):

--- a/backend/audit/permissions.py
+++ b/backend/audit/permissions.py
@@ -1,0 +1,6 @@
+from rest_framework.permissions import BasePermission
+
+class SingleAuditChecklistPermission(BasePermission):
+    def has_object_permission(self, request, view, obj):
+        print('im here!')
+        return False

--- a/backend/audit/permissions.py
+++ b/backend/audit/permissions.py
@@ -1,6 +1,19 @@
 from rest_framework.permissions import BasePermission
+from .models import Access
+
 
 class SingleAuditChecklistPermission(BasePermission):
     def has_object_permission(self, request, view, obj):
-        print('im here!')
+        """
+        In future, multiple Access objects here would mean that the user has
+        multiple roles, and we will at some point probably have to enforce
+        different permissions for different roles, so it's not clear how we'd
+        handle that yet.
+        For the moment, we just assume that if there are more than zero results
+        for this query, we know the user has access to the SAC and return True.
+        """
+        accesses = Access.objects.filter(sac=obj, user=request.user)
+        if accesses:
+            return True
+
         return False

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -42,7 +42,7 @@ urlpatterns = [
     path(
         "sac/edit/<str:report_id>",
         views.SingleAuditChecklistView.as_view(),
-        name="singleauditchecklist",  
+        name="singleauditchecklist",
     ),
     path(
         "submissions",

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -40,6 +40,11 @@ urlpatterns = [
         name="accessandsubmission",
     ),
     path(
+        "sac/edit/<str:report_id>",
+        views.SingleAuditChecklistView.as_view(),
+        name="singleauditchecklist",  
+    ),
+    path(
         "submissions",
         views.SubmissionsView.as_view(),
         name="submissions",


### PR DESCRIPTION
Partially addresses #398 

Adds a `GET` endpoint at `/sac/edit/<report_id>` which returns the `SingleAuditChecklist` for the given `report_id` iff the user has `Access` to it. If the user does not have `Access` to the `SingleAuditChecklist`, a `403` error response is returned. If there is no `SingleAuditChecklist` with the given `report_id`, a `404` error response is returned. 