### PR TITLE
Public API for accessing SF-SAC data

### DIFF
--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -38,7 +38,7 @@ class SACViewSet(viewsets.ModelViewSet):
     serializer_class = SingleAuditChecklistSerializer
 
     def get_view_name(self):
-        return "SAC"
+        return "SF-SAC"
 
 
 class EligibilityFormView(APIView):

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -1,10 +1,13 @@
 import json
+from typing import List
 
 from audit.models import Access, SingleAuditChecklist
 from audit.permissions import SingleAuditChecklistPermission
 from django.http import Http404
 from django.urls import reverse
 from rest_framework import viewsets
+from rest_framework.authentication import BaseAuthentication
+from rest_framework.permissions import BasePermission
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from django.http import JsonResponse
@@ -26,8 +29,8 @@ class SACViewSet(viewsets.ModelViewSet):
     """
 
     # this is a public endpoint - no authentication or permission required
-    authentication_classes = []
-    permission_classes = []
+    authentication_classes: List[BaseAuthentication] = []
+    permission_classes: List[BasePermission] = []
 
     allowed_methods = ["GET"]
 

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -25,12 +25,20 @@ class SACViewSet(viewsets.ModelViewSet):
     API endpoint that allows SACs to be viewed.
     """
 
+    # this is a public endpoint - no authentication or permission required
+    authentication_classes = []
+    permission_classes = []
+
     allowed_methods = ["GET"]
-    queryset = SingleAuditChecklist.objects.all()
+
+    # lookup SACs with report_id rather than the default pk
+    lookup_field = "report_id"
+
+    queryset = SingleAuditChecklist.objects.filter(submission_status="submitted")
     serializer_class = SingleAuditChecklistSerializer
 
     def get_view_name(self):
-        return "SF-SAC"
+        return "SAC"
 
 
 class EligibilityFormView(APIView):

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -181,8 +181,6 @@ REST_FRAMEWORK = {
         "users.auth.ExpiringTokenAuthentication",
     ],
     "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticated",),
-    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
-    "PAGE_SIZE": 10,
     "TEST_REQUEST_RENDERER_CLASSES": [
         "rest_framework.renderers.MultiPartRenderer",
         "rest_framework.renderers.JSONRenderer",

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -1,16 +1,11 @@
 from api import views
 from django.conf import settings
 from django.contrib import admin
-from django.urls import include, path
-from rest_framework import routers
+from django.urls import path
 from rest_framework.renderers import JSONOpenAPIRenderer
 from rest_framework.schemas import get_schema_view
 
 from users.views import AuthToken
-
-#  DRF API views
-api_router = routers.DefaultRouter()
-api_router.register(r"sf-sac", views.SACViewSet)
 
 schema_view = get_schema_view(
     title="Federal Audit Clearinghouse API",
@@ -22,7 +17,12 @@ schema_view = get_schema_view(
 urlpatterns = [
     path("api/auth/token", AuthToken.as_view(), name="token"),
     path("api/schema.json", schema_view),
-    path("api/", include(api_router.urls)),
+    path("public/api/sac", views.SACViewSet.as_view({"get": "list"}), name="sac-list"),
+    path(
+        "public/api/sac/<str:report_id>",
+        views.SACViewSet.as_view({"get": "retrieve"}),
+        name="sac-detail",
+    ),
     path(
         "sac/eligibility",
         views.EligibilityFormView.as_view(),


### PR DESCRIPTION
Addresses #355 

Adds the following public API endpoints for accessing submitted SF-SAC data:
```
GET /public/api/sac
GET /public/api/sac/<report_id>
```