### PR TITLE
Add federal awards placeholder endpoint + tests

### DIFF
--- a/backend/api/test_views.py
+++ b/backend/api/test_views.py
@@ -879,7 +879,29 @@ class SacFederalAwardsViewTests(TestCase):
         """Convenience method to get the path for a report_id)"""
         return reverse("sacfederalawards", kwargs={"report_id": self.sac_report_id})
 
-    def test_get_placeholder_data(self):
+    def test_get_authentication_required(self):
+        """
+        If a request is not authenticated, it should be rejected with a 401
+        """
+
+        # use a different client that doesn't authenticate
+        client = APIClient()
+        response = client.get(self.path(self.sac_report_id), format="json")
+        self.assertEqual(response.status_code, 401)
+
+    def test_get_no_audit_awards_access(self):
+        """
+        If a user doesn't have an Access object for the SAC, they should get a
+        403.
+        """
+        user = baker.make(User)
+        sac = baker.make(SingleAuditChecklist)
+        # sac.submitted_by = user
+
+        response = self.client.get(self.path(sac.report_id))
+        self.assertEqual(response.status_code, 403)
+
+    def test_get_valid_placeholder_data(self):
         """
         If the federal awards endpoint is hit, (for now) it should return an empty object
         """

--- a/backend/api/test_views.py
+++ b/backend/api/test_views.py
@@ -873,11 +873,11 @@ class SacFederalAwardsViewTests(TestCase):
 
         # Report details to be used for tests
         self.sac_data = response.json()
-        self.sac_report_id = self.sac_data["sac_id"]
+        self.sac_report_id = self.sac_data["report_id"]
 
     def path(self, report_id):
         """Convenience method to get the path for a report_id)"""
-        return reverse("sacfederalawards", kwargs={"report_id": self.sac_report_id})
+        return reverse("sacfederalawards", kwargs={"report_id": report_id})
 
     def test_get_authentication_required(self):
         """
@@ -894,9 +894,8 @@ class SacFederalAwardsViewTests(TestCase):
         If a user doesn't have an Access object for the SAC, they should get a
         403.
         """
-        user = baker.make(User)
+        
         sac = baker.make(SingleAuditChecklist)
-        # sac.submitted_by = user
 
         response = self.client.get(self.path(sac.report_id))
         self.assertEqual(response.status_code, 403)

--- a/backend/api/test_views.py
+++ b/backend/api/test_views.py
@@ -894,7 +894,7 @@ class SacFederalAwardsViewTests(TestCase):
         If a user doesn't have an Access object for the SAC, they should get a
         403.
         """
-        
+
         sac = baker.make(SingleAuditChecklist)
 
         response = self.client.get(self.path(sac.report_id))

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -321,7 +321,7 @@ class SacFederalAwardsView(APIView):
             sac = SingleAuditChecklist.objects.get(report_id=report_id)
         except SingleAuditChecklist.DoesNotExist as e:
             raise Http404() from e
-            
+
         self.check_object_permissions(request, sac)
 
         # To do: Get federal awards info here

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -317,11 +317,12 @@ class SacFederalAwardsView(APIView):
 
         # Note this is a placeholder, so we're not returning anything yet.
 
-        # try:
-        #     sac = SingleAuditChecklist.objects.get(report_id=report_id)
-        # except SingleAuditChecklist.DoesNotExist as e:
-        #     raise Http404() from e
-        # self.check_object_permissions(request, sac)
+        try:
+            sac = SingleAuditChecklist.objects.get(report_id=report_id)
+        except SingleAuditChecklist.DoesNotExist as e:
+            raise Http404() from e
+            
+        self.check_object_permissions(request, sac)
 
         # To do: Get federal awards info here
 

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -302,6 +302,32 @@ class SingleAuditChecklistView(APIView):
         return JsonResponse(full_data)
 
 
+class SacFederalAwardsView(APIView):
+    """
+    Accepts and returns data for a SAC's federal awards section
+    """
+
+    permission_classes = [SingleAuditChecklistPermission]
+
+    def get(self, request, report_id):
+        """
+        Get the SAC by report_id and return the federal award section in JSON format.
+        Return 404 if it doesn't exist.
+        """
+
+        # Note this is a placeholder, so we're not returning anything yet.
+
+        # try:
+        #     sac = SingleAuditChecklist.objects.get(report_id=report_id)
+        # except SingleAuditChecklist.DoesNotExist as e:
+        #     raise Http404() from e
+        # self.check_object_permissions(request, sac)
+
+        # To do: Get federal awards info here
+
+        return JsonResponse({})
+
+
 class SubmissionsView(APIView):
     """
     Returns the list of SingleAuditChecklists the current user has submitted

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -45,6 +45,11 @@ urlpatterns = [
         name="singleauditchecklist",
     ),
     path(
+        "sac/edit/<str:report_id>/federal_awards",
+        views.SacFederalAwardsView.as_view(),
+        name="sacfederalawards",
+    ),
+    path(
         "submissions",
         views.SubmissionsView.as_view(),
         name="submissions",


### PR DESCRIPTION
Resolves #478 

This adds in the placeholder that will become the federal awards endpoint. For now, it just returns a `{}`. 