### PR TITLE
Adding the new app to installed apps

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -69,6 +69,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "report_submission",
 ]
 
 # Third-party apps


### PR DESCRIPTION
Since we want to leverage this like a web app, I think we will need to add the app to settings. 

The API is not an app in the settings, but my guess is that we aren't leveraging the web app Django utilities so I don't' think it matters. As always, correct me if I'm wrong.