### PR TITLE
Procfile fix for cloud.gov build failure

### DIFF
--- a/backend/Procfile
+++ b/backend/Procfile
@@ -1,3 +1,3 @@
 # used by cloud.gov
-web: python manage.py migrate && python manage.py collectstatic --noinput && gunicorn config.wsgi -t 60
+web: python -m pip install -r requirements-nohashes.txt && python manage.py migrate && python manage.py collectstatic --noinput && gunicorn config.wsgi -t 60
 


### PR DESCRIPTION
Magic can be vague
We need to be explicit
With requirements.

-----

Cloud.gov installs everything in requirements.txt magically, but we need to install from an extra file also.