### PR TITLE
Compile and build static assets  in Procfile

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -81,9 +81,6 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: "3.10"
-      - name: Compile with dev docker-compose
-        working-directory: ./backend
-        run: docker-compose up -d
       - name: Update service keys
         uses: 18f/cg-deploy-action@main
         env:

--- a/backend/Procfile
+++ b/backend/Procfile
@@ -1,4 +1,6 @@
 # used by cloud.gov
 web: echo 'Starting procfile....' &&
     python manage.py migrate &&
+    npm run build &&
+    python manage.py collectstatic --noinput &&
     gunicorn config.wsgi -t 60

--- a/backend/manifests/manifest-dev.yml
+++ b/backend/manifests/manifest-dev.yml
@@ -9,6 +9,7 @@ applications:
   env:
     ENV: DEVELOPMENT
     DJANGO_BASE_URL: https://fac-dev.app.cloud.gov
+    DISABLE_COLLECTSTATIC: true
   routes:
   - route: fac-dev.app.cloud.gov
   instances: 1


### PR DESCRIPTION
1. Tell the build pack not to run collectstatic.
2. Change Procfile to add npm build and then collectstatic.
3. Remove extra build from dev deploy step

If this works and we want to use this approach we will add these changes to staging and dev next.