### PR TITLE
Try adding explicit npm install

### DIFF
--- a/backend/Procfile
+++ b/backend/Procfile
@@ -1,6 +1,7 @@
 # used by cloud.gov
 web: echo 'Starting procfile....' &&
     python manage.py migrate &&
+    npm install &&
     npm run build &&
     python manage.py collectstatic --noinput &&
     gunicorn config.wsgi -t 60


### PR DESCRIPTION
`npm install`
Will solve everything. I'm sure.
No doubt in my mind.

-----

Let's see if we can get cloud.gov deployment to build the assets before running `collectstatic` if we also tell it to install the various JS dependencies required. 