### PR TITLE
auto deploy 

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - prod
-      - ly/test-deploy
     tags:
       - v1.*
   pull_request:
@@ -14,87 +13,68 @@ on:
       - prod
   workflow_dispatch: null
 jobs:
-  # linting:
-  #   runs-on: ubuntu-latest
-  #   env:
-  #     ENV: TESTING
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Set up Python 3.10
-  #       uses: actions/setup-python@v3
-  #       with:
-  #         python-version: "3.10"
-  #     - name: Install linters
-  #       working-directory: ./backend
-  #       run: |
-  #         python -m pip install --upgrade pip
-  #         pip install -r dev-requirements.txt
-  #     - name: Lint with flake8
-  #       working-directory: ./backend
-  #       run: flake8 . --count --max-complexity=10  --show-source --statistics
-  #     - name: Check formatting with black
-  #       working-directory: ./backend
-  #       run: black --check .
-  #     - name: Run bandit
-  #       working-directory: ./backend
-  #       run: bandit -c pyproject.toml -r .
-  #     - name: Run type checking
-  #       working-directory: ./backend
-  #       run: mypy .
-  # test:
-  #   runs-on: ubuntu-latest
-  #   env:
-  #     ENV: TESTING
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Start services
-  #       working-directory: ./backend
-  #       run: docker-compose up -d
-  #     - name: Run Django test suite
-  #       working-directory: ./backend
-  #       run: docker-compose run web bash -c 'coverage run --source="." manage.py test &&
-  #         coverage report -m --fail-under=99'
-  #     - name: Run Django migrations for pa11y tests
-  #       working-directory: ./backend
-  #       run: docker-compose run web python manage.py migrate
-  #     - name: Create superuser for admin access
-  #       working-directory: ./backend
-  #       run: echo "from django.contrib.auth import get_user_model; User =
-  #         get_user_model(); User.objects.create_superuser('a', 'a@a.com', 'a')"
-  #         | docker-compose run web python manage.py shell
-  #     - name: Install pa11y-ci
-  #       working-directory: ./pa11y_tests
-  #       run: npm install
-  #     - name: Run pa11y-ci against admin
-  #       working-directory: ./pa11y_tests
-  #       run: npm run test:admin
-
-  # deploy-dev:
-  #   name: Deploy to dev
-  #   if: github.event.ref == 'refs/heads/ly/test-deploy'
-  #   runs-on: ubuntu-latest
-  #   # needs:
-  #   #   - linting
-  #   #   - test
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Run docker container for build
-  #       working-directory: ./backend
-  #       run: docker-compose up --build -d
-  #     - name: Login to cf api & push
-  #       working-directory: ./backend
-  #       # run: |
-  #       #   docker exec backend_web_1 /bin/bash -c "cd static && ls -a"
-  #       run: |
-  #         docker exec backend_web_1 /bin/bash -c "cf login -a https://api.fr.cloud.gov -u ${{ secrets.cf_username_dev }} -p ${{ secrets.cf_password_dev }} -o gsa-tts-oros-fac -s dev && cd manifests && cf push -f manifest-dev.yml --strategy rolling"
+  linting:
+    runs-on: ubuntu-latest
+    env:
+      ENV: TESTING
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
+      - name: Install linters
+        working-directory: ./backend
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r dev-requirements.txt
+      - name: Lint with flake8
+        working-directory: ./backend
+        run: flake8 . --count --max-complexity=10  --show-source --statistics
+      - name: Check formatting with black
+        working-directory: ./backend
+        run: black --check .
+      - name: Run bandit
+        working-directory: ./backend
+        run: bandit -c pyproject.toml -r .
+      - name: Run type checking
+        working-directory: ./backend
+        run: mypy .
+  test:
+    runs-on: ubuntu-latest
+    env:
+      ENV: TESTING
+    steps:
+      - uses: actions/checkout@v2
+      - name: Start services
+        working-directory: ./backend
+        run: docker-compose up -d
+      - name: Run Django test suite
+        working-directory: ./backend
+        run: docker-compose run web bash -c 'coverage run --source="." manage.py test &&
+          coverage report -m --fail-under=99'
+      - name: Run Django migrations for pa11y tests
+        working-directory: ./backend
+        run: docker-compose run web python manage.py migrate
+      - name: Create superuser for admin access
+        working-directory: ./backend
+        run: echo "from django.contrib.auth import get_user_model; User =
+          get_user_model(); User.objects.create_superuser('a', 'a@a.com', 'a')"
+          | docker-compose run web python manage.py shell
+      - name: Install pa11y-ci
+        working-directory: ./pa11y_tests
+        run: npm install
+      - name: Run pa11y-ci against admin
+        working-directory: ./pa11y_tests
+        run: npm run test:admin
 
   deploy-dev:
     name: Deploy to dev
-    if: github.event.ref == 'refs/heads/ly/test-deploy'
+    if: github.event.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    # needs:
-    #   - linting
-    #   - test
+    needs:
+      - linting
+      - test
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.10
@@ -129,82 +109,84 @@ jobs:
           cf_space: dev
           push_arguments: -f backend/manifests/manifest-dev.yml --strategy rolling
 
-  # deploy-staging:
-  #   name: Deploy to staging
-  #   if: github.event.ref == 'refs/heads/prod'
-  #   runs-on: ubuntu-latest
-  #   needs:
-  #     - linting
-  #     - test
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Set up Python 3.10
-  #       uses: actions/setup-python@v3
-  #       with:
-  #         python-version: "3.10"
-  #     - name: Update service keys
-  #       uses: 18f/cg-deploy-action@main
-  #       env:
-  #         SAM_API_KEY: ${{ secrets.SAM_API_KEY }}
-  #         DJANGO_SECRET_LOGIN_KEY: $${{ secrets.DJANGO_SECRET_LOGIN_KEY }}
-  #       with:
-  #         cf_username: ${{ secrets.CF_USERNAME_STAGING }}
-  #         cf_password: ${{ secrets.CF_PASSWORD_STAGING }}
-  #         cf_org: gsa-tts-oros-fac
-  #         cf_space: staging
-  #         full_command: cf update-user-provided-service fac-key-service -p
-  #           "{\"SAM_API_KEY\":\"$SAM_API_KEY\",
-  #           \"DJANGO_SECRET_LOGIN_KEY\":\"$DJANGO_SECRET_LOGIN_KEY\"}"
-  #     - name: Deploy to cloud.gov
-  #       uses: 18f/cg-deploy-action@main
-  #       with:
-  #         cf_username: ${{ secrets.CF_USERNAME_STAGING }}
-  #         cf_password: ${{ secrets.CF_PASSWORD_STAGING }}
-  #         cf_org: gsa-tts-oros-fac
-  #         cf_space: staging
-  #         push_arguments: -f backend/manifests/manifest-staging.yml --strategy rolling
+  deploy-staging:
+    name: Deploy to staging
+    if: github.event.ref == 'refs/heads/prod'
+    runs-on: ubuntu-latest
+    needs:
+      - linting
+      - test
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
+      - name: Install npm dependencies
+        working-directory: ./backend
+        run: npm install
+      - name: Compile JS/CSS assets
+        working-directory: ./backend
+        run: npm run build
+      - name: Update service keys
+        uses: 18f/cg-deploy-action@main
+        env:
+          SAM_API_KEY: ${{ secrets.SAM_API_KEY }}
+          DJANGO_SECRET_LOGIN_KEY: $${{ secrets.DJANGO_SECRET_LOGIN_KEY }}
+        with:
+          cf_username: ${{ secrets.CF_USERNAME_STAGING }}
+          cf_password: ${{ secrets.CF_PASSWORD_STAGING }}
+          cf_org: gsa-tts-oros-fac
+          cf_space: staging
+          full_command: cf update-user-provided-service fac-key-service -p
+            "{\"SAM_API_KEY\":\"$SAM_API_KEY\",
+            \"DJANGO_SECRET_LOGIN_KEY\":\"$DJANGO_SECRET_LOGIN_KEY\"}"
+      - name: Deploy to cloud.gov
+        uses: 18f/cg-deploy-action@main
+        with:
+          cf_username: ${{ secrets.CF_USERNAME_STAGING }}
+          cf_password: ${{ secrets.CF_PASSWORD_STAGING }}
+          cf_org: gsa-tts-oros-fac
+          cf_space: staging
+          push_arguments: -f backend/manifests/manifest-staging.yml --strategy rolling
 
-  # deploy-production:
-  #   name: Deploy to production
-  #   if: github.event.ref == 'refs/tag/v1.*'
-  #   runs-on: ubuntu-latest
-  #   needs:
-  #     - linting
-  #     - test
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Set up Python 3.10
-  #       uses: actions/setup-python@v3
-  #       with:
-  #         python-version: "3.10"
-  #     - name: Update service keys
-  #       uses: 18f/cg-deploy-action@main
-  #       env:
-  #         SAM_API_KEY: ${{ secrets.SAM_API_KEY }}
-  #         DJANGO_SECRET_LOGIN_KEY: $${{ secrets.DJANGO_SECRET_LOGIN_KEY }}
-  #       with:
-  #         cf_username: ${{ secrets.CF_USERNAME_PROD }}
-  #         cf_password: ${{ secrets.CF_PASSWORD_PROD }}
-  #         cf_org: gsa-tts-oros-fac
-  #         cf_space: production
-  #         full_command: cf update-user-provided-service fac-key-service -p
-  #           "{\"SAM_API_KEY\":\"$SAM_API_KEY\",
-  #           \"DJANGO_SECRET_LOGIN_KEY\":\"$DJANGO_SECRET_LOGIN_KEY\"}"
-  #     - name: Deploy to cloud.gov
-  #       uses: 18f/cg-deploy-action@main
-  #       with:
-  #         cf_username: ${{ secrets.CF_USERNAME_PROD }}
-  #         cf_password: ${{ secrets.CF_PASSWORD_PROD }}
-  #         cf_org: gsa-tts-oros-fac
-  #         cf_space: production
-  #         push_arguments: -f backend/manifests/manifest-production.yml --strategy rolling
-
-# RET_LOGIN_KEY\":\"$DJANGO_SECRET_LOGIN_KEY\"}"
-#       - name: Deploy to cloud.gov
-#         uses: 18f/cg-deploy-action@main
-#         with:
-#           cf_username: ${{ secrets.CF_USERNAME_PROD }}
-#           cf_password: ${{ secrets.CF_PASSWORD_PROD }}
-#           cf_org: gsa-tts-oros-fac
-#           cf_space: production
-#           push_arguments: -f backend/manifests/manifest-production.yml --strategy rolling
+  deploy-production:
+    name: Deploy to production
+    if: github.event.ref == 'refs/tag/v1.*'
+    runs-on: ubuntu-latest
+    needs:
+      - linting
+      - test
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
+      - name: Install npm dependencies
+        working-directory: ./backend
+        run: npm install
+      - name: Compile JS/CSS assets
+        working-directory: ./backend
+        run: npm run build
+      - name: Update service keys
+        uses: 18f/cg-deploy-action@main
+        env:
+          SAM_API_KEY: ${{ secrets.SAM_API_KEY }}
+          DJANGO_SECRET_LOGIN_KEY: $${{ secrets.DJANGO_SECRET_LOGIN_KEY }}
+        with:
+          cf_username: ${{ secrets.CF_USERNAME_PROD }}
+          cf_password: ${{ secrets.CF_PASSWORD_PROD }}
+          cf_org: gsa-tts-oros-fac
+          cf_space: production
+          full_command: cf update-user-provided-service fac-key-service -p
+            "{\"SAM_API_KEY\":\"$SAM_API_KEY\",
+            \"DJANGO_SECRET_LOGIN_KEY\":\"$DJANGO_SECRET_LOGIN_KEY\"}"
+      - name: Deploy to cloud.gov
+        uses: 18f/cg-deploy-action@main
+        with:
+          cf_username: ${{ secrets.CF_USERNAME_PROD }}
+          cf_password: ${{ secrets.CF_PASSWORD_PROD }}
+          cf_org: gsa-tts-oros-fac
+          cf_space: production
+          push_arguments: -f backend/manifests/manifest-production.yml --strategy rolling

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - prod
+      - ly/test-deploy
     tags:
       - v1.*
   pull_request:
@@ -13,74 +14,99 @@ on:
       - prod
   workflow_dispatch: null
 jobs:
-  linting:
-    runs-on: ubuntu-latest
-    env:
-      ENV: TESTING
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v3
-        with:
-          python-version: "3.10"
-      - name: Install linters
-        working-directory: ./backend
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r dev-requirements.txt
-      - name: Lint with flake8
-        working-directory: ./backend
-        run: flake8 . --count --max-complexity=10  --show-source --statistics
-      - name: Check formatting with black
-        working-directory: ./backend
-        run: black --check .
-      - name: Run bandit
-        working-directory: ./backend
-        run: bandit -c pyproject.toml -r .
-      - name: Run type checking
-        working-directory: ./backend
-        run: mypy .
-  test:
-    runs-on: ubuntu-latest
-    env:
-      ENV: TESTING
-    steps:
-      - uses: actions/checkout@v2
-      - name: Start services
-        working-directory: ./backend
-        run: docker-compose up -d
-      - name: Run Django test suite
-        working-directory: ./backend
-        run: docker-compose run web bash -c 'coverage run --source="." manage.py test &&
-          coverage report -m --fail-under=99'
-      - name: Run Django migrations for pa11y tests
-        working-directory: ./backend
-        run: docker-compose run web python manage.py migrate
-      - name: Create superuser for admin access
-        working-directory: ./backend
-        run: echo "from django.contrib.auth import get_user_model; User =
-          get_user_model(); User.objects.create_superuser('a', 'a@a.com', 'a')"
-          | docker-compose run web python manage.py shell
-      - name: Install pa11y-ci
-        working-directory: ./pa11y_tests
-        run: npm install
-      - name: Run pa11y-ci against admin
-        working-directory: ./pa11y_tests
-        run: npm run test:admin
+  # linting:
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     ENV: TESTING
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Set up Python 3.10
+  #       uses: actions/setup-python@v3
+  #       with:
+  #         python-version: "3.10"
+  #     - name: Install linters
+  #       working-directory: ./backend
+  #       run: |
+  #         python -m pip install --upgrade pip
+  #         pip install -r dev-requirements.txt
+  #     - name: Lint with flake8
+  #       working-directory: ./backend
+  #       run: flake8 . --count --max-complexity=10  --show-source --statistics
+  #     - name: Check formatting with black
+  #       working-directory: ./backend
+  #       run: black --check .
+  #     - name: Run bandit
+  #       working-directory: ./backend
+  #       run: bandit -c pyproject.toml -r .
+  #     - name: Run type checking
+  #       working-directory: ./backend
+  #       run: mypy .
+  # test:
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     ENV: TESTING
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Start services
+  #       working-directory: ./backend
+  #       run: docker-compose up -d
+  #     - name: Run Django test suite
+  #       working-directory: ./backend
+  #       run: docker-compose run web bash -c 'coverage run --source="." manage.py test &&
+  #         coverage report -m --fail-under=99'
+  #     - name: Run Django migrations for pa11y tests
+  #       working-directory: ./backend
+  #       run: docker-compose run web python manage.py migrate
+  #     - name: Create superuser for admin access
+  #       working-directory: ./backend
+  #       run: echo "from django.contrib.auth import get_user_model; User =
+  #         get_user_model(); User.objects.create_superuser('a', 'a@a.com', 'a')"
+  #         | docker-compose run web python manage.py shell
+  #     - name: Install pa11y-ci
+  #       working-directory: ./pa11y_tests
+  #       run: npm install
+  #     - name: Run pa11y-ci against admin
+  #       working-directory: ./pa11y_tests
+  #       run: npm run test:admin
+
+  # deploy-dev:
+  #   name: Deploy to dev
+  #   if: github.event.ref == 'refs/heads/ly/test-deploy'
+  #   runs-on: ubuntu-latest
+  #   # needs:
+  #   #   - linting
+  #   #   - test
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Run docker container for build
+  #       working-directory: ./backend
+  #       run: docker-compose up --build -d
+  #     - name: Login to cf api & push
+  #       working-directory: ./backend
+  #       # run: |
+  #       #   docker exec backend_web_1 /bin/bash -c "cd static && ls -a"
+  #       run: |
+  #         docker exec backend_web_1 /bin/bash -c "cf login -a https://api.fr.cloud.gov -u ${{ secrets.cf_username_dev }} -p ${{ secrets.cf_password_dev }} -o gsa-tts-oros-fac -s dev && cd manifests && cf push -f manifest-dev.yml --strategy rolling"
 
   deploy-dev:
     name: Deploy to dev
-    if: github.event.ref == 'refs/heads/main'
+    if: github.event.ref == 'refs/heads/ly/test-deploy'
     runs-on: ubuntu-latest
-    needs:
-      - linting
-      - test
+    # needs:
+    #   - linting
+    #   - test
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v2
       - name: Set up Python 3.10
         uses: actions/setup-python@v3
         with:
           python-version: "3.10"
+      - name: Install npm dependencies
+        working-directory: ./backend
+        run: npm install
+      - name: Compile JS/CSS assets
+        working-directory: ./backend
+        run: npm run build
       - name: Update service keys
         uses: 18f/cg-deploy-action@main
         env:
@@ -103,72 +129,82 @@ jobs:
           cf_space: dev
           push_arguments: -f backend/manifests/manifest-dev.yml --strategy rolling
 
-  deploy-staging:
-    name: Deploy to staging
-    if: github.event.ref == 'refs/heads/prod'
-    runs-on: ubuntu-latest
-    needs:
-      - linting
-      - test
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v3
-        with:
-          python-version: "3.10"
-      - name: Update service keys
-        uses: 18f/cg-deploy-action@main
-        env:
-          SAM_API_KEY: ${{ secrets.SAM_API_KEY }}
-          DJANGO_SECRET_LOGIN_KEY: $${{ secrets.DJANGO_SECRET_LOGIN_KEY }}
-        with:
-          cf_username: ${{ secrets.CF_USERNAME_STAGING }}
-          cf_password: ${{ secrets.CF_PASSWORD_STAGING }}
-          cf_org: gsa-tts-oros-fac
-          cf_space: staging
-          full_command: cf update-user-provided-service fac-key-service -p
-            "{\"SAM_API_KEY\":\"$SAM_API_KEY\",
-            \"DJANGO_SECRET_LOGIN_KEY\":\"$DJANGO_SECRET_LOGIN_KEY\"}"
-      - name: Deploy to cloud.gov
-        uses: 18f/cg-deploy-action@main
-        with:
-          cf_username: ${{ secrets.CF_USERNAME_STAGING }}
-          cf_password: ${{ secrets.CF_PASSWORD_STAGING }}
-          cf_org: gsa-tts-oros-fac
-          cf_space: staging
-          push_arguments: -f backend/manifests/manifest-staging.yml --strategy rolling
+  # deploy-staging:
+  #   name: Deploy to staging
+  #   if: github.event.ref == 'refs/heads/prod'
+  #   runs-on: ubuntu-latest
+  #   needs:
+  #     - linting
+  #     - test
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Set up Python 3.10
+  #       uses: actions/setup-python@v3
+  #       with:
+  #         python-version: "3.10"
+  #     - name: Update service keys
+  #       uses: 18f/cg-deploy-action@main
+  #       env:
+  #         SAM_API_KEY: ${{ secrets.SAM_API_KEY }}
+  #         DJANGO_SECRET_LOGIN_KEY: $${{ secrets.DJANGO_SECRET_LOGIN_KEY }}
+  #       with:
+  #         cf_username: ${{ secrets.CF_USERNAME_STAGING }}
+  #         cf_password: ${{ secrets.CF_PASSWORD_STAGING }}
+  #         cf_org: gsa-tts-oros-fac
+  #         cf_space: staging
+  #         full_command: cf update-user-provided-service fac-key-service -p
+  #           "{\"SAM_API_KEY\":\"$SAM_API_KEY\",
+  #           \"DJANGO_SECRET_LOGIN_KEY\":\"$DJANGO_SECRET_LOGIN_KEY\"}"
+  #     - name: Deploy to cloud.gov
+  #       uses: 18f/cg-deploy-action@main
+  #       with:
+  #         cf_username: ${{ secrets.CF_USERNAME_STAGING }}
+  #         cf_password: ${{ secrets.CF_PASSWORD_STAGING }}
+  #         cf_org: gsa-tts-oros-fac
+  #         cf_space: staging
+  #         push_arguments: -f backend/manifests/manifest-staging.yml --strategy rolling
 
-  deploy-production:
-    name: Deploy to production
-    if: github.event.ref == 'refs/tag/v1.*'
-    runs-on: ubuntu-latest
-    needs:
-      - linting
-      - test
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v3
-        with:
-          python-version: "3.10"
-      - name: Update service keys
-        uses: 18f/cg-deploy-action@main
-        env:
-          SAM_API_KEY: ${{ secrets.SAM_API_KEY }}
-          DJANGO_SECRET_LOGIN_KEY: $${{ secrets.DJANGO_SECRET_LOGIN_KEY }}
-        with:
-          cf_username: ${{ secrets.CF_USERNAME_PROD }}
-          cf_password: ${{ secrets.CF_PASSWORD_PROD }}
-          cf_org: gsa-tts-oros-fac
-          cf_space: production
-          full_command: cf update-user-provided-service fac-key-service -p
-            "{\"SAM_API_KEY\":\"$SAM_API_KEY\",
-            \"DJANGO_SECRET_LOGIN_KEY\":\"$DJANGO_SECRET_LOGIN_KEY\"}"
-      - name: Deploy to cloud.gov
-        uses: 18f/cg-deploy-action@main
-        with:
-          cf_username: ${{ secrets.CF_USERNAME_PROD }}
-          cf_password: ${{ secrets.CF_PASSWORD_PROD }}
-          cf_org: gsa-tts-oros-fac
-          cf_space: production
-          push_arguments: -f backend/manifests/manifest-production.yml --strategy rolling
+  # deploy-production:
+  #   name: Deploy to production
+  #   if: github.event.ref == 'refs/tag/v1.*'
+  #   runs-on: ubuntu-latest
+  #   needs:
+  #     - linting
+  #     - test
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Set up Python 3.10
+  #       uses: actions/setup-python@v3
+  #       with:
+  #         python-version: "3.10"
+  #     - name: Update service keys
+  #       uses: 18f/cg-deploy-action@main
+  #       env:
+  #         SAM_API_KEY: ${{ secrets.SAM_API_KEY }}
+  #         DJANGO_SECRET_LOGIN_KEY: $${{ secrets.DJANGO_SECRET_LOGIN_KEY }}
+  #       with:
+  #         cf_username: ${{ secrets.CF_USERNAME_PROD }}
+  #         cf_password: ${{ secrets.CF_PASSWORD_PROD }}
+  #         cf_org: gsa-tts-oros-fac
+  #         cf_space: production
+  #         full_command: cf update-user-provided-service fac-key-service -p
+  #           "{\"SAM_API_KEY\":\"$SAM_API_KEY\",
+  #           \"DJANGO_SECRET_LOGIN_KEY\":\"$DJANGO_SECRET_LOGIN_KEY\"}"
+  #     - name: Deploy to cloud.gov
+  #       uses: 18f/cg-deploy-action@main
+  #       with:
+  #         cf_username: ${{ secrets.CF_USERNAME_PROD }}
+  #         cf_password: ${{ secrets.CF_PASSWORD_PROD }}
+  #         cf_org: gsa-tts-oros-fac
+  #         cf_space: production
+  #         push_arguments: -f backend/manifests/manifest-production.yml --strategy rolling
+
+# RET_LOGIN_KEY\":\"$DJANGO_SECRET_LOGIN_KEY\"}"
+#       - name: Deploy to cloud.gov
+#         uses: 18f/cg-deploy-action@main
+#         with:
+#           cf_username: ${{ secrets.CF_USERNAME_PROD }}
+#           cf_password: ${{ secrets.CF_PASSWORD_PROD }}
+#           cf_org: gsa-tts-oros-fac
+#           cf_space: production
+#           push_arguments: -f backend/manifests/manifest-production.yml --strategy rolling

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -15,7 +15,12 @@ WORKDIR ..
 
 RUN \
   apt-get update && \
-  apt-get install -yqq apt-transport-https wget gnupg2
+  apt-get install -yqq apt-transport-https wget gnupg2  && \
+  apt-get install wget && \
+  wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | apt-key add - && \
+  echo "deb https://packages.cloudfoundry.org/debian stable main" | tee /etc/apt/sources.list.d/cloudfoundry-cli.list && \
+  apt-get update && \
+  apt-get install cf7-cli
 
 RUN \
     apt-get update -yq && \
@@ -24,6 +29,7 @@ RUN \
     apt-get -y install nodejs && \
     apt-get install nodejs npm -yqq && \
     npm i -g npm@^8
+
 
 RUN \
     set -ex && \
@@ -37,6 +43,9 @@ COPY . /src/
 WORKDIR /src/
 
 RUN npm install
+RUN chown -R 1001:123 "/root/.npm"
+RUN npm run build && python manage.py shell --command="import environs; env = environs.Env(); print(env.str('ENV', 'UNDEFINED').upper())" && python manage.py collectstatic
+
 
 # ------------------------------------------------------------
 # Dev/testing layer

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -15,12 +15,7 @@ WORKDIR ..
 
 RUN \
   apt-get update && \
-  apt-get install -yqq apt-transport-https wget gnupg2  && \
-  apt-get install wget && \
-  wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | apt-key add - && \
-  echo "deb https://packages.cloudfoundry.org/debian stable main" | tee /etc/apt/sources.list.d/cloudfoundry-cli.list && \
-  apt-get update && \
-  apt-get install cf7-cli
+  apt-get install -yqq apt-transport-https wget gnupg2
 
 RUN \
     apt-get update -yq && \
@@ -29,7 +24,6 @@ RUN \
     apt-get -y install nodejs && \
     apt-get install nodejs npm -yqq && \
     npm i -g npm@^8
-
 
 RUN \
     set -ex && \
@@ -44,8 +38,7 @@ WORKDIR /src/
 
 RUN npm install
 RUN chown -R 1001:123 "/root/.npm"
-RUN npm run build && python manage.py shell --command="import environs; env = environs.Env(); print(env.str('ENV', 'UNDEFINED').upper())" && python manage.py collectstatic
-
+RUN npm run build && python manage.py collectstatic
 
 # ------------------------------------------------------------
 # Dev/testing layer

--- a/backend/Procfile
+++ b/backend/Procfile
@@ -1,5 +1,4 @@
 # used by cloud.gov
-# Test comment 2022-12-14 to kick off deploy to make sure it's still broken
 web: echo 'Starting procfile....' &&
     python manage.py collectstatic --noinput &&
     echo "collectstatic finished" &&

--- a/backend/Procfile
+++ b/backend/Procfile
@@ -1,5 +1,8 @@
 # used by cloud.gov
+# Test comment 2022-12-14 to kick off deploy to make sure it's still broken
 web: echo 'Starting procfile....' &&
+    python manage.py collectstatic --noinput &&
+    echo "collectstatic finished" &&
     python manage.py migrate &&
     npm install &&
     npm run build &&

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,7 +1,6 @@
 version: "3.7"
 
 services:
-
   db:
     image: "postgres:11"
     environment:
@@ -16,9 +15,7 @@ services:
       context: .
       dockerfile: ./Dockerfile
     command: >
-      bash -c "python manage.py migrate 
-      && python manage.py collectstatic --noinput
-      && npm run dev
+      bash -c "python manage.py migrate
       & python manage.py runserver 0.0.0.0:8000"
     depends_on:
       - db

--- a/backend/manifests/manifest-dev.yml
+++ b/backend/manifests/manifest-dev.yml
@@ -3,7 +3,6 @@ applications:
 - name: gsa-fac
   buildpacks:
     - python_buildpack
-    - https://github.com/cloudfoundry/nodejs-buildpack
   memory: 512M
   path: ../
   timeout: 180


### PR DESCRIPTION
Uses github actions to build assets and deploy.

Thank you to @tadhg-ohiggins @geekygirlsarah  & @timoballard for lugging this over the finish line!!

We moved npm run build to its own step in test_and_deploy.yml and put that ahead of the 18f/cg-deploy-action@main actions.
We switched back to using 18f/cg-deploy-action@main to push to cloud.gov and removed the debug step of trying to do that from a Docker container.
We put python manage.py collectstatic --noinput into the Procfile.
The result is that after having deleted all the assets in the bucket earlier, the last build (with the above changes) pushed the assets to the S3 bucket.
One of the key issues was that running collectstatic anywhere outside of the CF instance meant that Django couldn’t access the S3 credentials that are stored in VCAP_SERVICES, which is why we moved collectstatic back into the Procfile.
