### PR TITLE
Deploy tweak: only run collectstatic once in Procfile

### DIFF
--- a/backend/Procfile
+++ b/backend/Procfile
@@ -1,9 +1,7 @@
 # used by cloud.gov
 web: echo 'Starting procfile....' &&
-    python manage.py collectstatic --noinput &&
-    echo "collectstatic finished" &&
-    python manage.py migrate &&
     npm install &&
     npm run build &&
+    python manage.py migrate &&
     python manage.py collectstatic --noinput &&
     gunicorn config.wsgi -t 60


### PR DESCRIPTION
So… `collectstatic`
Is really quite expensive.
Only run it once.