### PR TITLE
Run collect static twice

### DIFF
--- a/backend/Procfile
+++ b/backend/Procfile
@@ -1,7 +1,5 @@
 # used by cloud.gov
 web: echo 'Starting procfile....' &&
-    npm install &&
-    npm run build &&
-    python manage.py migrate &&
     python manage.py collectstatic --noinput &&
+    python manage.py migrate &&
     gunicorn config.wsgi -t 60

--- a/backend/manifests/manifest-dev.yml
+++ b/backend/manifests/manifest-dev.yml
@@ -9,7 +9,6 @@ applications:
   env:
     ENV: DEVELOPMENT
     DJANGO_BASE_URL: https://fac-dev.app.cloud.gov
-    DISABLE_COLLECTSTATIC: true
   routes:
   - route: fac-dev.app.cloud.gov
   instances: 1


### PR DESCRIPTION
It is run by the buildpack and run in the Procfile.

Collectstatic needs to be run by the Procfile to get assets to s3. This adds images etc to the bucket, but not NPM built assets. Collectstatic needs to be run by the buildpack so that the Procfile doesn't timeout.