### PR TITLE
Deploy tweaking: change health check type to “process”.

### DIFF
--- a/backend/manifests/manifest-dev.yml
+++ b/backend/manifests/manifest-dev.yml
@@ -5,6 +5,7 @@ applications:
       - python_buildpack
     memory: 512M
     path: ../
+    health-check-type: process
     timeout: 180
     env:
       ENV: DEVELOPMENT


### PR DESCRIPTION
But what kind of health?
We should try “process” instead.
And see if that works.

-----

We'll probably want to change this back after figuring out the right way to handle `collectstatic`, but first let's see if this fixes anything.