### PR TITLE
Better deploy process

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -108,7 +108,7 @@ jobs:
           cf_password: ${{ secrets.CF_PASSWORD_DEV }}
           cf_org: gsa-tts-oros-fac
           cf_space: dev
-          push_arguments: -f backend/manifests/manifest-dev.yml --strategy rolling
+          push_arguments: -f backend/manifests/manifest-dev.yml
 
   deploy-staging:
     name: Deploy to staging
@@ -149,7 +149,7 @@ jobs:
           cf_password: ${{ secrets.CF_PASSWORD_STAGING }}
           cf_org: gsa-tts-oros-fac
           cf_space: staging
-          push_arguments: -f backend/manifests/manifest-staging.yml --strategy rolling
+          push_arguments: -f backend/manifests/manifest-staging.yml
 
   deploy-production:
     name: Deploy to production
@@ -190,4 +190,4 @@ jobs:
           cf_password: ${{ secrets.CF_PASSWORD_PROD }}
           cf_org: gsa-tts-oros-fac
           cf_space: production
-          push_arguments: -f backend/manifests/manifest-production.yml --strategy rolling
+          push_arguments: -f backend/manifests/manifest-production.yml

--- a/backend/.cfignore
+++ b/backend/.cfignore
@@ -1,0 +1,1 @@
+static/img/material-icons

--- a/backend/.profile
+++ b/backend/.profile
@@ -1,0 +1,9 @@
+# We only want to run migrate and collecstatic for the first app instance, not
+# for additional app instances, so we gate all of this behind CF_INSTANCE_INDEX
+# being 0.
+[ "$CF_INSTANCE_INDEX" = 0 ] && echo 'Starting .profile' &&
+python manage.py migrate &&
+echo 'Finished migrate' &&
+echo 'Starting collectstatic' &&
+python manage.py collectstatic --noinput &&
+echo 'Finished collectstatic, finished .profile'

--- a/backend/Procfile
+++ b/backend/Procfile
@@ -1,5 +1,2 @@
 # used by cloud.gov
-web: echo 'Starting procfile....' &&
-    python manage.py migrate &&
-    python manage.py collectstatic --noinput &&
-    gunicorn config.wsgi -t 60
+web: gunicorn config.wsgi -t 60

--- a/backend/manifests/manifest-dev.yml
+++ b/backend/manifests/manifest-dev.yml
@@ -9,7 +9,9 @@ applications:
     env:
       ENV: DEVELOPMENT
       DJANGO_BASE_URL: https://fac-dev.app.cloud.gov
-      DISABLE_COLLECTSTATIC: true
+      # The following is commented out because collectstatic in the buildpack phase does not seem to be working, so we're running it in .profile.
+      # If we find out what's broken, or it's fixed up stream, then we can decide whether or not we want to disable it.
+      # DISABLE_COLLECTSTATIC: true
     routes:
       - route: fac-dev.app.cloud.gov
     instances: 1


### PR DESCRIPTION
Put things in their place.
Don't do things multiple times.
All as it should be.

-----

Add `.cfignore` to not put over 2,000 material icon SVG images so that Django’s `collectstatic` step doesn’t time out.

Move steps from `Procfile` to `.profile` and make those steps only run when the initial app instance is deployed.

Remove `--strategy rolling` from push arguments because the action already adds it to the command.
