### PR TITLE
Re-enable Python invalid name lint check.

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -27,7 +27,6 @@ disable = [
     "duplicate-code",
     "format",
     "import-error",
-    "invalid-name",
     "missing-module-docstring",
     "no-value-for-parameter",
     "pointless-string-statement",


### PR DESCRIPTION
We use PascalCase
And conventions, so
Should enable this.