### PR TITLE
Fix for flaky General Information schema test

### DIFF
--- a/backend/schemas/sections/GeneralInformation.schema.json
+++ b/backend/schemas/sections/GeneralInformation.schema.json
@@ -131,7 +131,6 @@
     },
     "UEI": {
       "type": "string",
-      "format": "regex",
       "pattern": "^[a-hj-np-zA-HJ-NP-Z1-9][a-hj-np-zA-HJ-NP-Z0-9]{11}$"
     },
     "UserProvidedOrganizationType": {


### PR DESCRIPTION
Intermittent failures in our schema tests revealed that we were mistakenly using the `regex` format specifier for `UEI` fields in `GeneralInformation.schema.json`. This meant that the `auditee_uei` field validation required the input to be a valid regex pattern.