### PR TITLE
Change test coverage fail threshold from 99% to 90%

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
         working-directory: ./backend
         run:
           docker-compose run web bash -c 'coverage run --source="." manage.py test &&
-          coverage report -m --fail-under=99'
+          coverage report -m --fail-under=90'
       - name: Run Django migrations for pa11y tests
         working-directory: ./backend
         run: docker-compose run web python manage.py migrate

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -39,7 +39,7 @@ lint:
 
 # Run Django tests:
 test:
-	@python -m coverage run --source="." manage.py test && coverage report -m --fail-under=99
+	@python -m coverage run --source="." manage.py test && coverage report -m --fail-under=90
 
 # Run Django tests with no coverage and with scoping
 # e.g. just the audit/test_models.py tests:


### PR DESCRIPTION
99 is high.
Change the Seal of Quality
To require 90.

-----

Change Python test coverage requirement from 99% to 90%, matching the QASP.

This is in order to ease development; unless there are compelling reasons why it can’t be done, all Python files considered “finished” should still have complete test coverage.