### PR TITLE
Use a Docker volume for collectstatic output

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -32,6 +32,7 @@ services:
     volumes:
       - .:/src
       - /src/node_modules
+      - /src/staticfiles
 
 volumes:
   postgres-data:


### PR DESCRIPTION
So `collectstatic`
Output has to go somewhere
Why not a volume?

-----

We were seeing failures in unrelated tests because the output from `python manage.py collectstatic` wasn’t being stored somewhere consistent, and @LindsayYoung came up with this solution.

There may be some other `whitenoise` issues; those will be addressed in other PRs.