### PR TITLE
Adding manifest storage for cache busting of assets

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -186,7 +186,7 @@ elif environment in ["TESTING", "UNDEFINED"]:
     STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
     MIDDLEWARE.append("whitenoise.middleware.WhiteNoiseMiddleware")
 else:
-    STATICFILES_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
+    STATICFILES_STORAGE = "storages.backends.s3boto3.S3ManifestStaticStorage"
     vcap = json.loads(env.str("VCAP_SERVICES"))
     for service in vcap["s3"]:
         if service["instance_name"] == "fac-public-s3":


### PR DESCRIPTION
This came up when debugging other issues and it is an easy upgrade to make