### PR TITLE
Design updates for audit submissions page

### DIFF
--- a/backend/audit/templates/audit/my_submissions.html
+++ b/backend/audit/templates/audit/my_submissions.html
@@ -3,7 +3,7 @@
 
 {% block content%}
 <div class="grid-container">
-    <h1>My audit submissions</h1>
+    <h1>Create or modify an audit</h1>
     {% if data.len == 0 %}
     <p>
         No submissions found
@@ -11,29 +11,26 @@
     {% else %}
     <div class="grid-row" tabindex="0">
         <table class="usa-table margin-top-0">
-            <caption>My unpublished sybmissions list</caption>
+            <caption>The following audit submissions are only for 2022. You can find older audit submissions on the <a class="usa-link" href="https://facweb.census.gov/uploadpdf.aspx">U.S. Census Bureau’s FAC website.</a></caption>
             <thead>
                 <tr>
-                    <th data-sortable scope="col" role="columnheader">Report ID</th>
                     <th data-sortable scope="col" role="columnheader">Status</th>
+                    <th data-sortable scope="col" role="columnheader">Entity name</th>
+                    <th data-sortable scope="col" role="columnheader">Report ID</th>
                     <th data-sortable scope="col" role="columnheader">Auditee
-                        <button
-                            class="usa-button--unstyled margin-top-0"
-                            aria-controls="modal-uei-info"
-                            data-open-modal
-                        >UEI</button>
+                        <button class="usa-button--unstyled margin-top-0" aria-controls="modal-uei-info"
+                            data-open-modal>UEI</button>
                     </th>
-                    <th data-sortable scope="col" role="columnheader">Auditee Name</th>
-                    <th data-sortable scope="col" role="columnheader">Fiscal year end date</th>
+                    <th data-sortable scope="col" role="columnheader">Fiscal period end date</th>
                 </tr>
             </thead>
             <tbody> {% for item in data %}
                 <tr>
-                    <td><a href="/sac/edit/{{item.report_id}}">{{item.report_id}}</a></td>
                     <td>{{ item.submission_status }}</td>
-                    <td>{{ item.auditee_uei }}</td>
                     <td>{{ item.auditee_name }}</td>
-                    <td>{{ item.fiscal_year_end_date }}</td>
+                    <td>{{item.report_id}}</td>
+                    <td>{{ item.auditee_uei }}</td>
+                    <td><a class="usa-link" href="/sac/edit/{{item.report_id}}">{{ item.fiscal_year_end_date }}</a></td>
                 </tr>
                 {% endfor %}
             </tbody>
@@ -41,20 +38,15 @@
         {% endif %}
     </div>
     <div class="grid-row">
-        <h2>Start a new submission</h2>
-        <p class="margin-top-0">Before you start a new submission, double check to make sure that you don't already have
-            one in progress.</p>
+        <h2>Create a new audit</h2>
+        <p class="margin-top-0">Before you create a new audit submission, double check to make sure that you don't already have one in progress.</p>
         <form id="start-new-submission" class="usa-form usa-form--large">
             <div class="usa-checkbox">
                 <input id="check-start-new-submission" class="usa-checkbox__input" type="checkbox" />
                 <label class="usa-checkbox__label" for="check-start-new-submission">
-                    I agree to the above
-                    <button
-                        id="terms-conditions-trigger"
-                        class="usa-button--unstyled margin-top-0"
-                        aria-controls="modal-terms-conditions"
-                        data-open-modal
-                    >terms and
+                    I agree to the 
+                    <button id="terms-conditions-trigger" class="usa-button--unstyled margin-top-0"
+                        aria-controls="modal-terms-conditions" data-open-modal>terms and
                         conditions</button>.
                     <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
                 </label>
@@ -62,20 +54,19 @@
             <div class="usa-button-group">
                 <input type="submit" id="start-submission" class="usa-button" value="Start a new submission" disabled />
             </div>
-        </form> 
+        </form>
     </div>
 
-    <div
-        class="usa-modal flex-justify-start"
-        id="modal-uei-info"
-        aria-labelledby="modal-uei-info-heading"
-        aria-describedby="modal-uei-info-description"
-    >
+    <div class="usa-modal flex-justify-start" id="modal-uei-info" aria-labelledby="modal-uei-info-heading"
+        aria-describedby="modal-uei-info-description">
         <div class="usa-modal__content">
             <div class="usa-modal__main">
-                <h2 class="usa-modal__heading" id="modal-uei-info-heading">What is a Unique Entity Identifier (UEI)?</h2>
+                <h2 class="usa-modal__heading" id="modal-uei-info-heading">What is a Unique Entity Identifier (UEI)?
+                </h2>
                 <div class="usa-prose" id="modal-uei-info-description">
-                    <p>The Unique Entity Identifier (UEI) for an awardee or recipient is an alphanumeric code created in the System for Award Management (SAM.gov) that is used to uniquely identify specific commercial, nonprofit, or business entities registered to do business with the federal government.</p>
+                    <p>The Unique Entity Identifier (UEI) for an awardee or recipient is an alphanumeric code created in
+                        the System for Award Management (SAM.gov) that is used to uniquely identify specific commercial,
+                        nonprofit, or business entities registered to do business with the federal government.</p>
                 </div>
             </div>
             <button class="usa-button usa-modal__close" aria-label="Close this window" data-close-modal>
@@ -86,38 +77,38 @@
         </div>
     </div>
 
-    <div
-        class="usa-modal usa-modal--lg flex-justify-start"
-        id="modal-terms-conditions"
-        aria-labelledby="modal-terms-conditions-heading"
-        aria-describedby="modal-terms-conditions-description"
-    >
+    <div class="usa-modal usa-modal--lg flex-justify-start" id="modal-terms-conditions"
+        aria-labelledby="modal-terms-conditions-heading" aria-describedby="modal-terms-conditions-description">
         <div class="usa-modal__content">
             <div class="usa-modal__main">
-                <h2 class="usa-modal__heading" id="modal-terms-conditions-heading">Federal Audit Clearinghouse terms and conditions</h2>
+                <h2 class="usa-modal__heading" id="modal-terms-conditions-heading">Federal Audit Clearinghouse terms and
+                    conditions</h2>
                 <div class="usa-prose" id="modal-terms-conditions-description">
-                    <p>FAC.gov is a U.S. General Services Administration federal government service. This site collects required documentation from organizations that spend $750,000 or more in federal grant funds in a given year.</p>
-                    <p>All use of FAC.gov will be monitored, recorded, and subject to audit by GSA staff and other federal government authorities. By using this system, you consent to your use being monitored and recorded.</p>
-                    <p>Unauthorized use is prohibited, and individuals found performing unauthorized activities are subject to disciplinary action including criminal prosecution.</p>
-                    <p>If you have questions about these conditions, please email <a class="usa-link" href="mailto:fac-support@gsa.gov">fac-support@gsa.gov</a>.</p>
+                    <p>FAC.gov is a U.S. General Services Administration federal government service. This site collects
+                        required documentation from organizations that spend $750,000 or more in federal grant funds in
+                        a given year.</p>
+                    <p>All use of FAC.gov will be monitored, recorded, and subject to audit by GSA staff and other
+                        federal government authorities. By using this system, you consent to your use being monitored
+                        and recorded.</p>
+                    <p>Unauthorized use is prohibited, and individuals found performing unauthorized activities are
+                        subject to disciplinary action including criminal prosecution.</p>
+                    <p>If you have questions about these conditions, please email <a class="usa-link"
+                            href="mailto:fac-support@gsa.gov">fac-support@gsa.gov</a>.</p>
                 </div>
 
                 <div class="usa-modal__footer">
                     <ul class="usa-button-group">
-                    <li class="usa-button-group__item">
-                        <button id="modal-terms-continue" type="button" class="usa-button" data-close-modal>
-                            Accept and start a new submission
-                        </button>
-                    </li>
-                    <li class="usa-button-group__item">
-                        <button
-                        type="button"
-                        class="usa-button usa-button--unstyled padding-105 text-center"
-                        data-close-modal
-                        >
-                        Go back
-                        </button>
-                    </li>
+                        <li class="usa-button-group__item">
+                            <button id="modal-terms-continue" type="button" class="usa-button" data-close-modal>
+                                Accept and start a new submission
+                            </button>
+                        </li>
+                        <li class="usa-button-group__item">
+                            <button type="button" class="usa-button usa-button--unstyled padding-105 text-center"
+                                data-close-modal>
+                                Go back
+                            </button>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/backend/audit/templates/audit/my_submissions.html
+++ b/backend/audit/templates/audit/my_submissions.html
@@ -11,7 +11,9 @@
     {% else %}
     <div class="grid-row" tabindex="0">
         <table class="usa-table margin-top-0">
-            <caption>The following audit submissions are only for 2022. You can find older audit submissions on the <a class="usa-link" href="https://facweb.census.gov/uploadpdf.aspx">U.S. Census Bureau’s FAC website.</a></caption>
+            <caption class="text-normal">The following audit submissions are only for 2022. You can find older audit
+                submissions on the <a class="usa-link" href="https://facweb.census.gov/uploadpdf.aspx">U.S. Census
+                    Bureau’s FAC website.</a></caption>
             <thead>
                 <tr>
                     <th data-sortable scope="col" role="columnheader">Status</th>
@@ -35,19 +37,21 @@
                 {% endfor %}
             </tbody>
         </table>
+        <div class="usa-sr-only usa-table__announcement-region" aria-live="polite"></div>
         {% endif %}
     </div>
     <div class="grid-row">
         <h2>Create a new audit</h2>
-        <p class="margin-top-0">Before you create a new audit submission, double check to make sure that you don't already have one in progress.</p>
+        <p class="margin-top-0">Before you create a new audit submission, double check to make sure that you don't
+            already have one in progress.</p>
         <form id="start-new-submission" class="usa-form usa-form--large">
             <div class="usa-checkbox">
                 <input id="check-start-new-submission" class="usa-checkbox__input" type="checkbox" />
                 <label class="usa-checkbox__label" for="check-start-new-submission">
-                    I agree to the 
+                    I agree to the
                     <button id="terms-conditions-trigger" class="usa-button--unstyled margin-top-0"
                         aria-controls="modal-terms-conditions" data-open-modal>terms and
-                        conditions</button>.
+                        conditions.</button>
                     <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
                 </label>
             </div>

--- a/backend/static/scss/_home.scss
+++ b/backend/static/scss/_home.scss
@@ -74,3 +74,7 @@
     }
   }
 }
+
+.usa-table caption.text-normal {
+  font-weight: normal;
+}


### PR DESCRIPTION
Related to #654 which is a breakout of #343 

This PR concerns the design updates for the "My audit submissions" page.

What this PR covers:
- Updates to:
  - header text (See Image 1)
  - table caption (See Image 1)
  - column order (See Image 1)
  - "Start a new submission" header to "Create a new audit" (See Image 2)
  - Create a new audit text (See Image 2)
- Added link to old FAC site to table caption. (See Image 1)

(Image 1)
![image](https://user-images.githubusercontent.com/106776019/215909331-e5d6e6cc-b760-4e12-8067-cbfb24abe89c.png)

(Image 2)
![image](https://user-images.githubusercontent.com/106776019/215909411-07b0b9dd-bf82-4488-9cae-078c793e8954.png)

Not covered in this PR:
- Links to edit submissions that are on the Fiscal period end dates points to a un-finalized URL.
  - These URLs need to be updated when the destination is created.
- Table data needs to be properly formatted.
  - Status (i.e. "in_progress" should be "In Progress")
  - Fiscal period end dates should be in MM/DD/YYYY format
- The Entity name data returns "None". This is not correct.