### PR TITLE
Optionally disable OIDC authentication

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -319,3 +319,14 @@ OIDC_PROVIDERS = {
 LOGIN_URL = f"{env_base_url}/openid/login/"
 
 USER_PROMOTION_COMMANDS_ENABLED = environment in ["LOCAL", "TESTING", "UNDEFINED"]
+
+DISABLE_AUTH = env.bool("DISABLE_AUTH", default=False)
+if DISABLE_AUTH:
+    TEST_USERNAME = "test_user@test.test"
+    MIDDLEWARE.append(
+        "users.middleware.authenticate_test_user",
+    )
+
+    AUTHENTICATION_BACKENDS = [
+        "users.auth.FACTestAuthenticationBackend",
+    ]

--- a/backend/users/auth.py
+++ b/backend/users/auth.py
@@ -1,8 +1,11 @@
+from django.contrib.auth import backends, get_user_model
 from djangooidc.backends import OpenIdConnectBackend
 
 from audit.models import Access
 
 import logging
+
+UserModel = get_user_model()
 
 logger = logging.getLogger(__name__)
 
@@ -23,4 +26,15 @@ class FACAuthenticationBackend(OpenIdConnectBackend):
             all_emails = user_info.get("all_emails", [])
             claim_audit_access(user, all_emails)
 
+        return user
+
+
+class FACTestAuthenticationBackend(backends.BaseBackend):
+    """
+    Backend for testing purposes which automatically creates (if necessary) and
+    returns a user with the provided username
+    """
+
+    def authenticate(self, request, **kwargs):
+        user, _ = UserModel.objects.get_or_create(username=kwargs["username"])
         return user

--- a/backend/users/middleware.py
+++ b/backend/users/middleware.py
@@ -1,0 +1,21 @@
+from django.conf import settings
+from django.contrib.auth import authenticate, login
+
+
+def authenticate_test_user(get_response):
+    """
+    Middleware that invokes the authentication and login flow automatically incoming requests
+    using a test username. This middleware should ONLY be enabled in testing/CI scenarios
+    that need to bypass the OIDC login flow
+    """
+
+    def middleware(request):
+        user = authenticate(request, username=settings.TEST_USERNAME)
+
+        login(request, user)
+
+        response = get_response(request)
+
+        return response
+
+    return middleware


### PR DESCRIPTION
Resolves #765 

When the `DISABLE_AUTH` environment variable is set to true, the OIDC authentication flows are disabled, and incoming requests are automatically authenticated as a test user.