### PR TITLE
Update ClamAV module

### DIFF
--- a/terraform/shared/modules/base/base.tf
+++ b/terraform/shared/modules/base/base.tf
@@ -1,5 +1,5 @@
 module "clamav" {
-  source = "github.com/18f/terraform-cloudgov//clamav?ref=v0.2.1"
+  source = "github.com/18f/terraform-cloudgov//clamav?ref=v0.3.0"
 
   # This generates eg "fac-av-staging.apps.internal", avoiding collisions with routes for other projects and spaces
   name           = "fac-av-${var.cf_space_name}"
@@ -7,7 +7,7 @@ module "clamav" {
 
   cf_org_name   = var.cf_org_name
   cf_space_name = var.cf_space_name
-  clamav_image  = "ajilaag/clamav-rest:20230220"
+  clamav_image  = "ajilaag/clamav-rest:20230224"
   max_file_size = "30M"
 }
 


### PR DESCRIPTION
Previously, the ClamAV container hard-coded the ports that it uses and did its own TLS termination on a second port (with a self-signed cert where they key is public!). The updated version of the module and the upstream Docker container enable properly using platform-provided c2c TLS.

Refer to [the Slack discussion here](https://gsa-tts.slack.com/archives/C04LR4FBM2N/p1677179420208889) for details.