### PR TITLE
Set REQUESTS_CA_BUNDLE in cg manifests

### DIFF
--- a/backend/.profile
+++ b/backend/.profile
@@ -1,3 +1,5 @@
+export REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+
 # We only want to run migrate and collecstatic for the first app instance, not
 # for additional app instances, so we gate all of this behind CF_INSTANCE_INDEX
 # being 0.

--- a/backend/manifests/manifest-dev.yml
+++ b/backend/manifests/manifest-dev.yml
@@ -12,6 +12,7 @@ applications:
       DJANGO_BASE_URL: https://fac-dev.app.cloud.gov
       ALLOWED_HOSTS: fac-dev.app.cloud.gov
       AV_SCAN_URL: https://fac-av-dev.apps.internal:61443/scan
+      REQUESTS_CA_BUNDLE: /etc/ssl/certs/ca-certificates.crt
       # The following is commented out because collectstatic in the buildpack phase does not seem to be working, so we're running it in .profile.
       # If we find out what's broken, or it's fixed up stream, then we can decide whether or not we want to disable it.
       # DISABLE_COLLECTSTATIC: true

--- a/backend/manifests/manifest-dev.yml
+++ b/backend/manifests/manifest-dev.yml
@@ -12,7 +12,6 @@ applications:
       DJANGO_BASE_URL: https://fac-dev.app.cloud.gov
       ALLOWED_HOSTS: fac-dev.app.cloud.gov
       AV_SCAN_URL: https://fac-av-dev.apps.internal:61443/scan
-      REQUESTS_CA_BUNDLE: /etc/ssl/certs/ca-certificates.crt
       # The following is commented out because collectstatic in the buildpack phase does not seem to be working, so we're running it in .profile.
       # If we find out what's broken, or it's fixed up stream, then we can decide whether or not we want to disable it.
       # DISABLE_COLLECTSTATIC: true

--- a/backend/manifests/manifest-production.yml
+++ b/backend/manifests/manifest-production.yml
@@ -11,7 +11,6 @@ applications:
       DJANGO_BASE_URL: https://fac-prod.app.cloud.gov
       ALLOWED_HOSTS: fac-prod.app.cloud.gov
       AV_SCAN_URL: https://fac-av-production.apps.internal:61443/scan
-      REQUESTS_CA_BUNDLE: /etc/ssl/certs/ca-certificates.crt
     routes:
       - route: fac-prod.app.cloud.gov
     instances: 2

--- a/backend/manifests/manifest-production.yml
+++ b/backend/manifests/manifest-production.yml
@@ -1,21 +1,22 @@
 ---
 applications:
-- name: gsa-fac
-  buildpacks:
-    - python_buildpack
-  memory: 512M
-  path: ../
-  timeout: 180
-  env:
-    ENV: PRODUCTION
-    DJANGO_BASE_URL: https://fac-prod.app.cloud.gov
-    ALLOWED_HOSTS: fac-prod.app.cloud.gov
-    AV_SCAN_URL: https://fac-av-production.apps.internal:61443/scan
-  routes:
-  - route: fac-prod.app.cloud.gov
-  instances: 2
-  services:
-  - fac-db
-  - fac-public-s3
-  - fac-key-service
-  - production-deployer
+  - name: gsa-fac
+    buildpacks:
+      - python_buildpack
+    memory: 512M
+    path: ../
+    timeout: 180
+    env:
+      ENV: PRODUCTION
+      DJANGO_BASE_URL: https://fac-prod.app.cloud.gov
+      ALLOWED_HOSTS: fac-prod.app.cloud.gov
+      AV_SCAN_URL: https://fac-av-production.apps.internal:61443/scan
+      REQUESTS_CA_BUNDLE: /etc/ssl/certs/ca-certificates.crt
+    routes:
+      - route: fac-prod.app.cloud.gov
+    instances: 2
+    services:
+      - fac-db
+      - fac-public-s3
+      - fac-key-service
+      - production-deployer

--- a/backend/manifests/manifest-staging.yaml
+++ b/backend/manifests/manifest-staging.yaml
@@ -1,22 +1,23 @@
 ---
 applications:
-- name: gsa-fac
-  buildpacks:
-    - python_buildpack
-  memory: 512M
-  path: ../
-  timeout: 180
-  env:
-    ENV: STAGING
-    DJANGO_BASE_URL: https://fac-staging.app.cloud.gov
-    ALLOWED_HOSTS: fac-staging.app.cloud.gov
-    AV_SCAN_URL: https://fac-av-staging.apps.internal:61443/scan
-  routes:
-  - route: fac-staging.app.cloud.gov
-  instances: 1
-  services:
-  - fac-db
-  - fac-public-s3
-  - fac-key-service
-  - staging-deployer
+  - name: gsa-fac
+    buildpacks:
+      - python_buildpack
+    memory: 512M
+    path: ../
+    timeout: 180
+    env:
+      ENV: STAGING
+      DJANGO_BASE_URL: https://fac-staging.app.cloud.gov
+      ALLOWED_HOSTS: fac-staging.app.cloud.gov
+      AV_SCAN_URL: https://fac-av-staging.apps.internal:61443/scan
+      REQUESTS_CA_BUNDLE: /etc/ssl/certs/ca-certificates.crt
+    routes:
+      - route: fac-staging.app.cloud.gov
+    instances: 1
+    services:
+      - fac-db
+      - fac-public-s3
+      - fac-key-service
+      - staging-deployer
 

--- a/backend/manifests/manifest-staging.yaml
+++ b/backend/manifests/manifest-staging.yaml
@@ -11,7 +11,6 @@ applications:
       DJANGO_BASE_URL: https://fac-staging.app.cloud.gov
       ALLOWED_HOSTS: fac-staging.app.cloud.gov
       AV_SCAN_URL: https://fac-av-staging.apps.internal:61443/scan
-      REQUESTS_CA_BUNDLE: /etc/ssl/certs/ca-certificates.crt
     routes:
       - route: fac-staging.app.cloud.gov
     instances: 1


### PR DESCRIPTION
Relates to #780 

[Sets `REQUESTS_CA_BUNDLE` to allow validation of cloud.gov-provided certs](https://cloud.gov/docs/management/container-to-container/#addressing-certificate-validation-errors)