### PR TITLE
Add JP to tf config

### DIFF
--- a/terraform/management/config.tf
+++ b/terraform/management/config.tf
@@ -15,6 +15,7 @@ locals {
     "bret.mogilefsky@gsa.gov",
     "lindsayn.young@gsa.gov",
     "jason.nakai@gsa.gov",
+    "james.person@gsa.gov",
     "jeanmarie.mariadassou@gsa.gov",
     "matt.henry@gsa.gov",
     "sarah.withee@gsa.gov",


### PR DESCRIPTION
Add james.person@gsa.gov to the list of developers in the terraform management config, as specified in #844 [Onboarding checklist for @jperson1]. 