### PR TITLE
Sign-out button tweaks

### DIFF
--- a/backend/static/scss/_header.scss
+++ b/backend/static/scss/_header.scss
@@ -21,7 +21,7 @@
 .sign-in,
 .sign-out {
   background-color: color('primary-darker');
-  padding: 0.5em 2.5em 0.5em 1em;
+  padding: 0.5em 1.5em 1.5em 1em;
 }
 
 .usa-menu-btn {

--- a/backend/static/scss/_header.scss
+++ b/backend/static/scss/_header.scss
@@ -75,6 +75,7 @@
     svg {
       font-size: size('body', 9);
       height: 2em;
+      margin-right: 0.4em;
     }
   }
 }

--- a/backend/templates/base.html
+++ b/backend/templates/base.html
@@ -6,9 +6,9 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <link rel="stylesheet"
-            href="{% static 'compiled/scss/main-post.css' %}"
-            media="all"
-            type="text/css"/>
+              href="{% static 'compiled/scss/main-post.css' %}"
+              media="all"
+              type="text/css"/>
         {% block metatags %}
             <title>{{ post.title }}</title>
             <meta name="description" content="{{ post.meta_description }}" />
@@ -23,10 +23,10 @@
         <main id="main-content">
             {% block content %}{% endblock %}
             <div class="usa-modal usa-modal--lg"
-                id="legacy-fac-modal"
-                aria-labelledby="legacy-fac-modal-heading"
-                aria-describedby="legacy-fac-modal-description"
-                data-force-action>
+                 id="legacy-fac-modal"
+                 aria-labelledby="legacy-fac-modal-heading"
+                 aria-describedby="legacy-fac-modal-description"
+                 data-force-action>
                 <div class="usa-modal__content">
                     <div class="usa-modal__main">
                         <h2 class="usa-modal__heading" id="legacy-fac-modal-heading">You are leaving the fac.gov website</h2>
@@ -41,16 +41,16 @@
                             <ul class="usa-button-group">
                                 <li class="usa-button-group__item">
                                     <a type="button"
-                                        class="usa-button"
-                                        data-close-modal
-                                        href="https://facides.census.gov/Account/Login.aspx">
+                                       class="usa-button"
+                                       data-close-modal
+                                       href="https://facides.census.gov/Account/Login.aspx">
                                         Continue to the U.S. Census Bureau FAC site
                                     </a>
                                 </li>
                                 <li class="usa-button-group__item">
                                     <button type="button"
-                                        class="usa-button usa-button--unstyled padding-105 text-center"
-                                        data-close-modal>Cancel</button>
+                                            class="usa-button usa-button--unstyled padding-105 text-center"
+                                            data-close-modal>Cancel</button>
                                 </li>
                             </ul>
                         </div>

--- a/backend/templates/includes/header.html
+++ b/backend/templates/includes/header.html
@@ -6,16 +6,16 @@
             <div class="usa-banner__inner">
                 <div class="grid-col-auto">
                     <img class="usa-banner__header-flag"
-                        src="{% static 'img/us_flag_small.png' %}"
-                        alt="U.S. flag"/>
+                         src="{% static 'img/us_flag_small.png' %}"
+                         alt="U.S. flag"/>
                 </div>
                 <div class="grid-col-fill tablet:grid-col-auto">
                     <p class="usa-banner__header-text">An official website of the United States government</p>
                     <p class="usa-banner__header-action" aria-hidden="true">Here’s how you know</p>
                 </div>
                 <button class="usa-accordion__button usa-banner__button"
-                    aria-expanded="false"
-                    aria-controls="gov-banner">
+                        aria-expanded="false"
+                        aria-controls="gov-banner">
                     <span class="usa-banner__button-text">Here’s how you know</span>
                 </button>
             </div>
@@ -24,10 +24,10 @@
             <div class="grid-row grid-gap-lg">
                 <div class="usa-banner__guidance tablet:grid-col-6">
                     <img class="usa-banner__icon usa-media-block__img"
-                        src="{% static 'img/icon-dot-gov.svg' %}"
-                        role="img"
-                        alt=""
-                        aria-hidden="true"/>
+                         src="{% static 'img/icon-dot-gov.svg' %}"
+                         role="img"
+                         alt=""
+                         aria-hidden="true"/>
                     <div class="usa-media-block__body">
                         <p>
                             <strong>Official websites use .gov</strong>
@@ -39,10 +39,10 @@
                 </div>
                 <div class="usa-banner__guidance tablet:grid-col-6">
                     <img class="usa-banner__icon usa-media-block__img"
-                        src="{% static 'img/icon-https.svg' %}"
-                        role="img"
-                        alt=""
-                        aria-hidden="true"/>
+                         src="{% static 'img/icon-https.svg' %}"
+                         role="img"
+                         alt=""
+                         aria-hidden="true"/>
                     <div class="usa-media-block__body">
                         <p>
                             <strong>Secure .gov websites use HTTPS</strong>
@@ -50,34 +50,34 @@
                             A <strong>lock</strong> (
                             <span class="icon-lock">
                                 <svg xmlns="http://www.w3.org/2000/svg"
-                                    width="52"
-                                    height="64"
-                                    viewBox="0 0 52 64"
-                                    class="usa-banner__lock-image"
-                                    role="img"
-                                    aria-labelledby="banner-lock-title banner-lock-description"
-                                    focusable="false">
+                                     width="52"
+                                     height="64"
+                                     viewBox="0 0 52 64"
+                                     class="usa-banner__lock-image"
+                                     role="img"
+                                     aria-labelledby="banner-lock-title banner-lock-description"
+                                     focusable="false">
                                     <title id="banner-lock-title">Lock</title>
                                     <desc id="banner-lock-description">A locked padlock</desc>
                                     <path
-                                        fill="#000000"
-                                        fill-rule="evenodd"
-                                        d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z"
+                                    fill="#000000"
+                                    fill-rule="evenodd"
+                                    d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z"
                                     />
-                                    </svg
-                                    >
-                                </span>
-                                ) or <strong>https://</strong> means you’ve safely connected to
-                                the .gov website. Share sensitive information only on official,
-                                secure websites.
-                            </p>
-                        </div>
+                                </svg
+                                >
+                            </span>
+                            ) or <strong>https://</strong> means you’ve safely connected to
+                            the .gov website. Share sensitive information only on official,
+                            secure websites.
+                        </p>
                     </div>
                 </div>
             </div>
         </div>
-    </section>
-    <div class="usa-overlay"></div>
-    <header class="usa-header usa-header--basic">
-        {% include "includes/nav_primary.html" %}
-    </header>
+    </div>
+</section>
+<div class="usa-overlay"></div>
+<header class="usa-header usa-header--basic">
+    {% include "includes/nav_primary.html" %}
+</header>

--- a/backend/templates/includes/nav_primary.html
+++ b/backend/templates/includes/nav_primary.html
@@ -44,14 +44,19 @@
             </li>
         </ul>
         {% if request.user.is_authenticated %}
-            <div class="usa-card__container">
-                <div>
-                    <a class="usa-button sign-in-button"
-                       aria-controls="login-modal"
-                       data-open-modal
-                       href="/openid/logout/">Sign off {{ request.user.username }} </a>
-                </div>
-            </div>
+            <form action="/openid/logout" class="sign-out">
+                <button class="usa-button usa-button--unstyled">
+                    <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
+                        <use xlink:href="/static/img/sprite.svg#logout"></use>
+                    </svg>
+                    <span>Sign out</span>
+                    {% if request.user.first_name == '' %}
+                        <span>{{ request.user.email }}</span>
+                    {% else %}
+                        <span>{{ request.user.first_name }} {{ request.user.last_name }}</span>
+                    {% endif %}
+                </button>
+            </form>
         {% else %}
             <div class="sign-in">
                 <a class="sign-in-logo"


### PR DESCRIPTION
PR for issue #733 - tweaks to the sign out button.

Sign out button style should match [the Figma designs](https://www.figma.com/file/1bNncVt1TcFFDhQslqFC2o/FAC-Playground?node-id=2443%3A11490).

Button will display "Sign out" followed by the users first and last name, if it is present. Otherwise, it displays their email.

Also includes djlint automatic changes on a few HTML files.

Examples:
<img width="230" alt="image" src="https://user-images.githubusercontent.com/91098850/227277533-d962096d-4d4a-496f-b8d0-9438aa585f0a.png">
<img width="168" alt="image" src="https://user-images.githubusercontent.com/91098850/227277714-7bb321fd-0acb-49c9-bab7-66fdbfc53662.png">

Edits: Further details and example images
