### PR TITLE
Enable build pipeline caching

### DIFF
--- a/.github/workflows/deploy-apps.yml
+++ b/.github/workflows/deploy-apps.yml
@@ -17,10 +17,31 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Restore npm cache
+        uses: actions/cache@v3
+        id: cache-npm
+        with:
+          path: ~/.npm
+          key: fac-build-npm-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            fac-build-npm-
+            fac-build-
       - name: Set up Python 3.10
         uses: actions/setup-python@v3
         with:
           python-version: "3.10"
+      - name: Restore pip cache
+        uses: actions/cache@v3
+        id: cache-pip
+        with:
+          path: |
+            ~/.cache/pip
+            /opt/hostedtoolcache/Python/
+          key: fac-build-pip-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('**/dev-requirements.txt') }}
+          restore-keys: |
+            fac-build-pip-${{ hashFiles('**/requirements.txt') }}-
+            fac-build-pip-
+            fac-build-
       - name: Install npm dependencies
         working-directory: ./backend
         run: npm install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,10 +20,6 @@ jobs:
           restore-keys: |
             fac-build-npm-
             fac-build-
-      - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
-        name: List the state of node modules
-        continue-on-error: true
-        run: npm list
       - name: Set up Python 3.10
         uses: actions/setup-python@v3
         with:
@@ -74,10 +70,6 @@ jobs:
           restore-keys: |
             fac-build-npm-
             fac-build-
-      - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
-        name: List the state of node modules
-        continue-on-error: true
-        run: npm list
       - uses: actions/setup-node@v3
         with:
           node-version: 18

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,35 @@ jobs:
       SECRET_KEY: secrets.SECRET_KEY
     steps:
       - uses: actions/checkout@v3
+      - name: Restore npm cache
+        uses: actions/cache@v3
+        id: cache-npm
+        with:
+          path: ~/.npm
+          key: fac-build-npm-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            fac-build-npm-
+            fac-build-
+      - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
+        name: List the state of node modules
+        continue-on-error: true
+        run: npm list
       - name: Set up Python 3.10
         uses: actions/setup-python@v3
         with:
           python-version: '3.10'
+      - name: Restore pip cache
+        uses: actions/cache@v3
+        id: cache-pip
+        with:
+          path: |
+            ~/.cache/pip
+            /opt/hostedtoolcache/Python/
+          key: fac-build-pip-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('**/dev-requirements.txt') }}
+          restore-keys: |
+            fac-build-pip-${{ hashFiles('**/requirements.txt') }}-
+            fac-build-pip-
+            fac-build-
       - name: Install linters
         working-directory: ./backend
         run: |
@@ -39,14 +64,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
+      - name: Restore npm cache
+        uses: actions/cache@v3
+        id: cache-npm
+        with:
+          path: ~/.npm
+          key: fac-build-npm-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            fac-build-npm-
+            fac-build-
+      - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
+        name: List the state of node modules
+        continue-on-error: true
+        run: npm list
       - uses: actions/setup-node@v3
         with:
           node-version: 18
+      - name: Install npm packages
+        working-directory: ./backend
+        run: npm ci
       - name: Lint JS & SCSS
         working-directory: ./backend
-        run: |
-          npm ci
-          npm run check-all
+        run: npm run check-all
   test:
     runs-on: ubuntu-latest
     env:
@@ -62,12 +102,25 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 16
+#      - name: Set up Docker buildx
+#        uses: docker/setup-buildx-action@v2
+      - name: Enable Docker Layer Caching
+        uses: jpribyl/action-docker-layer-caching@v0.1.1
+      - name: Pull Docker Hub images
+        working-directory: ./backend
+        run: touch .env && docker-compose pull
       - name: Start services
         working-directory: ./backend
-        run: touch .env && docker-compose up -d
+        run: docker-compose up -d
+      - name: Create LocalStack emulated S3 bucket
+        working-directory: ./backend
+        run:
+          docker-compose run web bash -c 'AWS_SECRET_ACCESS_ID="test" AWS_ACCESS_KEY_ID="test" awslocal s3 mb s3://gsa-fac-private-s3'
       - name: Run Django test suite
         working-directory: ./backend
-        run: make docker-test
+        run:
+          docker-compose run web bash -c 'coverage run --source="." manage.py test &&
+          coverage report -m --fail-under=90'
       - name: run Lighthouse CI
         run: |
           npm install -g @lhci/cli@0.8.x


### PR DESCRIPTION
_Note: I won't be around to merge this... when it's good and everyone's happy, merge it in!_

This adds caching of different steps in the build process to try to save time off of the build, test, and verification processes.

* Add npm caching, which speeds up installs for frontend and lint actions
* Add pip caching, which does the same
* Add Docker layer caching, which speeds up builds of the main app container
* Moves the pull of localstack, postgres, and clamav to separate the step out a bit better so those aren't cached (they'd pull faster from Docker Hub)
* Replace `make docker-test` back with its instructions to not repeat steps, but also to force steps that need caching to be cached*
* Add npm and pip caching to the deploy process, using the same caches as the PRs were built on

This seems to have shaved ~5 minutes off of the test process, and frontend-testing and linting both run in under a minute.

(The same kind of Docker optimizations can be done to the `end-to-end-test.yml` file to speed up its Docker build, since it uses the same images/layers that testing does. Adding that in should shave minutes off of it as well, whenever it's turned back on.)

* It might be possible to put the command back, but this would need to be tested more and I ran out of time to really do it since this was added after I started try # 1 of this PR. 