### PR TITLE
Explicitly adding the postgres user doesn't work in the cg environments

### DIFF
--- a/backend/data_distro/api_views/sql_migrations/001_initial_migration.sql
+++ b/backend/data_distro/api_views/sql_migrations/001_initial_migration.sql
@@ -26,14 +26,8 @@ $$
 begin
     if not exists (select schema_name from information_schema.schemata where schema_name = 'api') then
         create schema api;
-        -- Grant access to tables and views
-        alter default privileges
-            in schema api
-            grant select
-        -- this includes views
-        on tables
-        to postgres;
 
+        -- Grant access to tables and views
         alter default privileges
             in schema api
             grant select
@@ -42,13 +36,6 @@ begin
         to anon;
 
         -- Grant access to sequences, if we have them
-        grant select, usage on all sequences in schema api to anon;
-        alter default privileges
-            in schema api
-            grant select, usage
-        on sequences
-        to postgres;
-
         grant select, usage on all sequences in schema api to anon;
         alter default privileges
             in schema api


### PR DESCRIPTION
This prevents an error in the cloud envs where the postgres user doesn't exist. 