### PR TITLE
Fix typo in development.md

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -68,7 +68,7 @@ To test UEI validation using the SAM.gov API with a personal API key, follow the
 #### SECRET_KEY
 Generate a random secret key for local development. Django uses this to provide cryptographic signing.
 
-#### DJANGO_LOGIN_SECRET_KEY
+#### DJANGO_SECRET_LOGIN_KEY
 The `DJANGO_SECRET_LOGIN_KEY` environment variable is used to interact with Login.gov. For local development, you have three options:
 *  (Recommended) If you wish to use the shared Login.gov sandbox client application and credentials, you can obtain a valid  `DJANGO_SECRET_LOGIN_KEY` from our shared [dev secrets document](https://docs.google.com/spreadsheets/d/1byrBp16jufbiEY_GP5MyR0Uqf6WvB_5tubSXN_mYyJY/edit#gid=0)
 *  If you wish to use the shared Login.gov sandbox client application, but create your own client credentials, you must first be granted access to the GSA-FAC Login.gov sandbox team. Once you can access the GSA-FAC client application, follow [Login.gov's documentation for creating a public certificate](https://developers.login.gov/testing/#creating-a-public-certificate). Once created, you can add the newly-generated public key to the GSA-FAC app, and set `DJANGO_SECRET_LOGIN_KEY` to the base64-encoded value of the corresponding private key.


### PR DESCRIPTION
Changing `DJANGO_LOGIN_SECRET_KEY` to `DJANGO_SECRET_LOGIN_KEY` in a header. We fixed the body text, but not the header.

No other changes.