### PR TITLE
Adding a postgrest instance and swagger instance to the environments

### DIFF
--- a/backend/manifests/manifest-dev.yml
+++ b/backend/manifests/manifest-dev.yml
@@ -23,3 +23,31 @@ applications:
       - fac-public-s3
       - fac-key-service
       - dev-deployer
+
+  - name: postgrest
+    instances: 1
+    disk_quota: 256M
+    memory: 128M
+    timeout: 180
+    docker:
+      image: postgrest/postgrest:v10.1.2
+    routes:
+      - route: fac-dev-postgrest.app.cloud.gov
+    env:
+      PGRST_DB_URI: ((DB_URI))
+      PGRST_DB_ANON_ROLE: anon
+
+  - name: swagger
+    instances: 1
+    disk_quota: 256M
+    memory: 256M
+    timeout: 20
+    health-check-type: process
+    docker:
+      image: swaggerapi/swagger-ui
+    routes:
+      - route: fac-dev-swagger.app.cloud.gov
+    env:
+      API_URL: https://fac-dev-postgrest.app.cloud.gov
+      SWAGGER_JSON_URL: https://fac-dev-postgrest.app.cloud.gov/
+    port: 8080

--- a/backend/manifests/manifest-production.yml
+++ b/backend/manifests/manifest-production.yml
@@ -19,3 +19,31 @@ applications:
       - fac-public-s3
       - fac-key-service
       - production-deployer
+
+  - name: postgrest
+    instances: 2
+    disk_quota: 256M
+    memory: 128M
+    timeout: 180
+    docker:
+      image: postgrest/postgrest:v10.1.2
+    routes:
+      - route: fac-prod-postgrest.app.cloud.gov
+    env:
+      PGRST_DB_URI: ((DB_URI))
+      PGRST_DB_ANON_ROLE: anon
+
+  - name: swagger
+    instances: 2
+    disk_quota: 256M
+    memory: 256M
+    timeout: 20
+    health-check-type: process
+    docker:
+      image: swaggerapi/swagger-ui
+    routes:
+      - route: fac-prod-swagger.app.cloud.gov
+    env:
+      API_URL: https://fac-prod-postgrest.app.cloud.gov
+      SWAGGER_JSON_URL: https://fac-prod-postgrest.app.cloud.gov/
+    port: 8080

--- a/backend/manifests/manifest-staging.yml
+++ b/backend/manifests/manifest-staging.yml
@@ -20,3 +20,30 @@ applications:
       - fac-key-service
       - staging-deployer
 
+  - name: postgrest
+    instances: 1
+    disk_quota: 256M
+    memory: 128M
+    timeout: 180
+    docker:
+      image: postgrest/postgrest:v10.1.2
+    routes:
+      - route: fac-staging-postgrest.app.cloud.gov
+    env:
+      PGRST_DB_URI: ((DB_URI))
+      PGRST_DB_ANON_ROLE: anon
+
+  - name: swagger
+    instances: 1
+    disk_quota: 256M
+    memory: 256M
+    timeout: 20
+    health-check-type: process
+    docker:
+      image: swaggerapi/swagger-ui
+    routes:
+      - route: fac-staging-swagger.app.cloud.gov
+    env:
+      API_URL: https://fac-staging-postgrest.app.cloud.gov
+      SWAGGER_JSON_URL: https://fac-staging-postgrest.app.cloud.gov/
+    port: 8080


### PR DESCRIPTION
closes #860
closes #861 

This deploys the Postgrest API and a simple Swagger image to each environment.

For these to work, there needs to be updates to URI variable in each environment
In GitHub. You can see the value by looking at  the app env in the respective  environment.
- [x] add DB_URI to dev
- [x] add DB_URI to staging
- [x] add DB_URI to production