### PR TITLE
Use tasklists in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -1,22 +1,14 @@
 ---
 name: Basic task tracking issue
-about: Starting point for new issues tracking project tasks
+about: Starting point for new issues tracking general tasks
 title: ''
 labels: ''
 assignees: ''
 
 ---
-
-Breakout issue of <story>
-
-### Background
-
-### Acceptance Criteria (We'll know we're done when...)
-
-- [ ] 
-- [ ] 
-
 ### Tasks
 
-- [ ] 
-- [ ]
+```[tasklist]
+- [ ] A thing
+- [ ] Antoher thing
+```


### PR DESCRIPTION
We want to encourage the use of task lists from the time that story issues are created so that it's easy to break ACs and tasks out into sub-issues as needed without losing hierarchy.

(Note the preview of these changes won't properly render the tasklist in the PR context, but I verified the markup in an existing issue to ensure it's correct.)