### PR TITLE
Tailor terraform plans based on target env

### DIFF
--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -8,13 +8,33 @@ on:
       - prod
 
 jobs:
-  all-envs:
-    strategy: 
-      matrix:
-        target: ["management", "dev", "staging", "production"]
+  management:
+    name: Generate plan for management space
+    if: github.event.ref == 'refs/heads/main'
     uses: ./.github/workflows/terraform-plan-env.yml
     with:
-      environment: ${{ matrix.target }}
+      environment: "management"
+    secrets: inherit
+  dev:
+    name: Generate plan for dev space
+    if: github.event.ref == 'refs/heads/main'
+    uses: ./.github/workflows/terraform-plan-env.yml
+    with:
+      environment: "dev"
+    secrets: inherit
+  staging:
+    name: Generate plan for staging space
+    if: github.event.ref == 'refs/heads/prod'
+    uses: ./.github/workflows/terraform-plan-env.yml
+    with:
+      environment: "staging"
+    secrets: inherit
+  production:
+    name: Generate plan for prod space
+    if: github.event.ref == 'refs/heads/prod'
+    uses: ./.github/workflows/terraform-plan-env.yml
+    with:
+      environment: "prod"
     secrets: inherit
 
 

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -1,10 +1,11 @@
 ---
 name: Terraform plan
-
 on:
   pull_request:
-    paths:
-      - 'terraform/**'
+    # These two branches are deployment-sensitive
+    branches:
+      - main
+      - prod
 
 jobs:
   all-envs:

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -1,7 +1,7 @@
 ---
 name: Terraform plan
 on:
-  pull_request:
+  pull_request_target:
     # These two branches are deployment-sensitive
     branches:
       - main


### PR DESCRIPTION
We now only generate a plan for the environments implicated by the target of the PR.

For example, in this case, the target is `main`, and that implies we should be generating plans for both `management` and `dev`, both of which could be impacted by merging this PR.