### PR TITLE
Generate Terraform plans on PR to `main` or `prod`

### DIFF
--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -1,10 +1,11 @@
 ---
 name: Terraform plan
-
 on:
   pull_request:
-    paths:
-      - 'terraform/**'
+    # These two branches are deployment-sensitive
+    branches:
+      - main
+      - prod
 
 jobs:
   all-envs:

--- a/.github/workflows/triggers.yml
+++ b/.github/workflows/triggers.yml
@@ -81,14 +81,14 @@ jobs:
   # deploy to production
   scan-staging:
     name: Zap scan of the staging site
-    if: github.event.ref == 'refs/tags/v1.*'
+    if: startsWith(github.ref, 'refs/tags/v')
     uses: ./.github/workflows/zap-scan.yml
     with:
       url: "https://fac-staging.app.cloud.gov/"
 
   deploy-infrastructure-production:
     name: Deploy infrastructure (production)
-    if: github.event.ref == 'refs/tags/v1.*'
+    if: startsWith(github.ref, 'refs/tags/v')
     needs:
       - test-and-lint
       - scan-staging
@@ -99,7 +99,7 @@ jobs:
 
   deploy-production:
     name: Deploy production to cloud.gov
-    if: github.event.ref == 'refs/tags/v1.*'
+    if: startsWith(github.ref, 'refs/tags/v')
     needs:
       - deploy-infrastructure-production
     uses: ./.github/workflows/deploy-apps.yml
@@ -109,7 +109,7 @@ jobs:
 
   scan-production-post-deploy:
     name: Zap scan of the production site
-    if: github.event.ref == 'refs/tags/v1.*'
+    if: startsWith(github.ref, 'refs/tags/v')
     needs:
       - deploy-production
     uses: ./.github/workflows/zap-scan.yml


### PR DESCRIPTION
Terraform magic
Combined with GitHub actions—
Maybe deploy now?

-----

Change `terraform-plan.yml` to create terraform plans on any PRs.
This should create the plan we need to successfully deploy to production.