### PR TITLE
Try removing docker layer caching

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,8 +94,6 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 16
-      - name: Enable Docker Layer Caching
-        uses: jpribyl/action-docker-layer-caching@v0.1.1
       - name: Pull Docker Hub images
         working-directory: ./backend
         run: touch .env && docker-compose pull


### PR DESCRIPTION
So caching sounds good
But cache invalidation
Is a hard problem

-----

Remove the that uses Docker layer caching to see if that solves the `collectstatic` issues that are causing test failures in `main`.
