### PR TITLE
Pre-SAC serialization bugfix

### DIFF
--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -48,7 +48,7 @@ def eligibility_check(user, data):
         next_step = reverse("api-auditee-info")
 
         # Store step 0 data in profile, overwriting any pre-existing.
-        user.profile.entry_form_data = data
+        user.profile.entry_form_data = serializer.data
         user.profile.save()
         return {"eligible": True, "next": next_step}
 

--- a/backend/report_submission/forms.py
+++ b/backend/report_submission/forms.py
@@ -22,7 +22,6 @@ class GeneralInformationForm(forms.Form):
     auditee_contact_title = forms.CharField()
     auditee_phone = forms.CharField()
     auditee_email = forms.CharField()
-    user_provided_organization_type = forms.CharField()
     auditor_firm_name = forms.CharField()
     auditor_ein = forms.CharField()
     auditor_ein_not_an_ssn_attestation = forms.BooleanField(required=False)

--- a/backend/report_submission/test_views.py
+++ b/backend/report_submission/test_views.py
@@ -127,8 +127,8 @@ class TestPreliminaryViews(TestCase):
         user.refresh_from_db()
         saved = user.profile.entry_form_data
         self.assertEqual(saved["user_provided_organization_type"], "state")
-        self.assertEqual(saved["met_spending_threshold"], "True")
-        self.assertEqual(saved["is_usa_based"], "True")
+        self.assertEqual(saved["met_spending_threshold"], True)
+        self.assertEqual(saved["is_usa_based"], True)
 
     def test_step_one_eligibility_submission_fail(self):
         """
@@ -445,7 +445,6 @@ class GeneralInformationFormViewTests(TestCase):
             "auditee_contact_title": "Lord of Windows",
             "auditee_phone": "5558675310",
             "auditee_email": "auditee.mcaudited.again@leftfield.com",
-            "user_provided_organization_type": "state",
             "auditor_firm_name": "Penny Audit Store",
             "auditor_ein": "123456780",
             "auditor_ein_not_an_ssn_attestation": True,


### PR DESCRIPTION
Relates to #563 

#829 implemented the General Information form, but in so doing introduced a serialization issue for two of the pre-SAC boolean fields (`met_spending_threshold` and `is_usa_based`). These were being stored in the `UserProfile` as strings, which caused a downstream failure when the general information JSON document is checked against the JSON schema, which expects them to be boolean types.