### PR TITLE
Add .local/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,7 @@ staticfiles/
 # pa11y_tests/screenshots/*.png
 
 excel/
+
+# Things that folks might want to have in their local directories
+# that don't need to be checked in
+.local/


### PR DESCRIPTION
We track many things,
But we don’t need everything.
So, add `.local`.

-----

Add `.local/` to `.gitignore` so that we have a place to put files that we want to keep locally but don’t want to check in and don’t want to track one-by-one in `.gitignore`.