### PR TITLE
add api schema to postgrest

### DIFF
--- a/backend/data_distro/api_views/basic_views.sql
+++ b/backend/data_distro/api_views/basic_views.sql
@@ -151,3 +151,7 @@ left join gen on pass.id=gen.passthrough_id
 
 
 commit;
+
+notify pgrst,
+       'reload schema';
+

--- a/backend/data_distro/api_views/findings.sql
+++ b/backend/data_distro/api_views/findings.sql
@@ -50,3 +50,7 @@ left join gen on gen.findingtext_id=findings_text.id
 ;
 
 commit;
+
+notify pgrst,
+       'reload schema';
+

--- a/backend/data_distro/api_views/general.sql
+++ b/backend/data_distro/api_views/general.sql
@@ -72,3 +72,6 @@ left join passthrough on passthrough.general_id=gen.id
 
 commit;
 
+notify pgrst,
+       'reload schema';
+

--- a/backend/data_distro/api_views/sql_migrations/007_add_postgrest_notify.sql
+++ b/backend/data_distro/api_views/sql_migrations/007_add_postgrest_notify.sql
@@ -1,2 +1,3 @@
+-- This makes the views in the schema available to the postgrest API
 notify pgrst,
        'reload schema';

--- a/backend/data_distro/api_views/sql_migrations/007_add_postgrest_notify.sql
+++ b/backend/data_distro/api_views/sql_migrations/007_add_postgrest_notify.sql
@@ -1,0 +1,2 @@
+notify pgrst,
+       'reload schema';

--- a/backend/data_distro/management/commands/create_docs.py
+++ b/backend/data_distro/management/commands/create_docs.py
@@ -131,6 +131,7 @@ def create_sql_comments(distro_classes, definations):
                             str(define_txt["Data Source"]),
                         ]
                     )
+                # add def to table
                 conn = connection(conn_string)
                 conn.autocommit = True
                 with conn.cursor() as curs:
@@ -144,3 +145,17 @@ def create_sql_comments(distro_classes, definations):
                         ),
                         (full_defination,),
                     )
+                # add def to view
+                if model_name in api_views:
+                    view = api_views[model_name]
+                    conn = connection(conn_string)
+                    conn.autocommit = True
+                    with conn.cursor() as curs:
+                        curs.execute(
+                            # These should be safe strings, but I am going to treat them with caution anyway.
+                            sql.SQL("COMMENT ON COLUMN {}.{} is %s;").format(
+                                sql.SQL(view),
+                                sql.Identifier(define_txt["Field name"]),
+                            ),
+                            (full_defination,),
+                        )

--- a/backend/data_distro/migrations/0034_API_improvements.py
+++ b/backend/data_distro/migrations/0034_API_improvements.py
@@ -1,0 +1,31 @@
+from io import StringIO
+
+from django.db import migrations
+from django.core.management import call_command
+
+
+def update_view(apps, schema_editor):
+    """Runs our management command to add documentation to sql"""
+
+    # Making views available to Postgrest API
+    call_command(
+        "create_distro_api",
+        stdout="",
+        stderr=StringIO(),
+        **{"file": "sql_migrations/007_add_postgrest_notify.sql"},
+    )
+
+    # Adding column docs for the views
+    call_command(
+        "create_docs",
+        stdout="",
+        stderr=StringIO(),
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("data_distro", "0033_dbkey_to_auditee_API"),
+    ]
+
+    operations = [migrations.RunPython(update_view)]

--- a/backend/manifests/dev/manifest-postgrest-dev.yml
+++ b/backend/manifests/dev/manifest-postgrest-dev.yml
@@ -11,4 +11,5 @@ applications:
       - route: fac-dev-postgrest.app.cloud.gov
     env:
       PGRST_DB_URI: ((DB_URI))
+      PGRST_DB_SCHEMAS: api
       PGRST_DB_ANON_ROLE: anon

--- a/backend/manifests/production/manifest-postgrest-production.yml
+++ b/backend/manifests/production/manifest-postgrest-production.yml
@@ -11,4 +11,5 @@ applications:
       - route: fac-prod-postgrest.app.cloud.gov
     env:
       PGRST_DB_URI: ((DB_URI))
+      PGRST_DB_SCHEMAS: api
       PGRST_DB_ANON_ROLE: anon

--- a/backend/manifests/staging/manifest-postgrest-staging.yml
+++ b/backend/manifests/staging/manifest-postgrest-staging.yml
@@ -11,4 +11,5 @@ applications:
       - route: fac-staging-postgrest.app.cloud.gov
     env:
       PGRST_DB_URI: ((DB_URI))
+      PGRST_DB_SCHEMAS: api
       PGRST_DB_ANON_ROLE: anon


### PR DESCRIPTION
For views to show up on [postgrest API](https://fac-dev-swagger.app.cloud.gov/#/ )
- We need to add `notify pgrst, 'reload schema';` when we create or make changes to the schema
- We need to add the schema name as an environment variable
- Adding column documentation to the views, things that are pulled from other tables will not be documented, but this is a good 85% solution to start with.