### PR TITLE
Federal Awards Upload Page

### DIFF
--- a/backend/report_submission/templates/report_submission/federal-awards.html
+++ b/backend/report_submission/templates/report_submission/federal-awards.html
@@ -11,43 +11,7 @@
 {% block content %}
 <div class="grid-container margin-top-6">
   <div class="grid-row grid-gap">
-    <nav class="desktop:grid-col-3 sticky-nav" aria-label="Secondary navigation">
-      <ul class="usa-sidenav margin-bottom-6">
-        <li class="usa-sidenav__item">
-          <a href="#" class="">General information</a>
-        </li>
-        <li class="usa-sidenav__item">
-          <a href="#federal-awards" class="usa-current">Federal Awards</a>
-        </li>
-        <li class="usa-sidenav__item">
-          <a href="#" class="">Notes to SEFA</a>
-        </li>
-        <li class="usa-sidenav__item">
-          <a href="#" class="">Audit information</a>
-        </li>
-        <li class="usa-sidenav__item">
-          <a href="#" class="">Audit findings</a>
-        </li>
-        <li class="usa-sidenav__item">
-          <a href="#" class="">Findings text</a>
-        </li>
-        <li class="usa-sidenav__item">
-          <a href="#" class="">CAP text</a>
-        </li>
-        <li class="usa-sidenav__item">
-          <a href="#" class="">Additional EINs</a>
-        </li>
-        <li class="usa-sidenav__item">
-          <a href="#" class="">Additional UEIs</a>
-        </li>
-        <li class="usa-sidenav__item">
-          <a href="#" class="">Secondary auditors</a>
-        </li>
-        <li class="usa-sidenav__item">
-          <a href="#" class="">Finalize</a>
-        </li>
-      </ul>
-    </nav>
+    {% include "../sidenav.html" %}
     <form class="usa-form usa-form--large" id="federal-awards" method="post">
       {% csrf_token %}
       <fieldset class="usa-fieldset">

--- a/backend/report_submission/templates/report_submission/federal-awards.html
+++ b/backend/report_submission/templates/report_submission/federal-awards.html
@@ -1,76 +1,77 @@
 {% extends "base.html" %}
 {% load static %}
 {% block metatags %}
-<title>{{ post.title }}</title>
-<meta name="description" content="{{ post.meta_description }}" />
-<meta property="og:title" content="{{ post.title }}" />
-<meta property="og:site_name" content="Federal Audit Clearinghouse" />
-<meta property="og:description" content="{{ post.meta_description }}" />
-<meta property="og:type" content="website" />
+    <title>{{ post.title }}</title>
+    <meta name="description" content="{{ post.meta_description }}" />
+    <meta property="og:title" content="{{ post.title }}" />
+    <meta property="og:site_name" content="Federal Audit Clearinghouse" />
+    <meta property="og:description" content="{{ post.meta_description }}" />
+    <meta property="og:type" content="website" />
 {% endblock %}
 {% block content %}
-<div class="grid-container margin-top-6">
-  <div class="grid-row grid-gap">
-    {% include "../sidenav.html" %}
-    <form class="usa-form usa-form--large" id="federal-awards" method="post">
-      {% csrf_token %}
-      <fieldset class="usa-fieldset">
-        <legend class="usa-legend usa-legend--large" id="federal-awards">
-          Federal awards
-        </legend>
-        <p>Enter the federal awards you recieved in the last audit year using the provided worksheet.</p>
-        <h4 class="usa-process-list__heading">Upload completed worksheet</h4>
-        <p>Save your completed worksheet as an XLSX file and upload it below.</p>
-        <div class="usa-form-group">
-          <input id="file-input-federal-awards-xlsx" class="usa-file-input" type="file"
-            name="file-input-federal-awards-xlsx" aria-describedby="file-input-federal-awards-xlsx" accept=".xlsx" />
+    <div class="grid-container margin-top-6">
+        <div class="grid-row grid-gap">
+            {% include "../sidenav.html" %}
+            <form class="usa-form usa-form--large" id="federal-awards" method="post">
+                {% csrf_token %}
+                <fieldset class="usa-fieldset">
+                    <legend class="usa-legend usa-legend--large" id="federal-awards">
+                        Federal awards
+                    </legend>
+                    <p>Enter the federal awards you recieved in the last audit year using the provided worksheet.</p>
+                    <h4 class="usa-process-list__heading">Upload completed worksheet</h4>
+                    <p>Save your completed worksheet as an XLSX file and upload it below.</p>
+                    <div class="usa-form-group">
+                        <input id="file-input-federal-awards-xlsx"
+                               class="usa-file-input"
+                               type="file"
+                               name="file-input-federal-awards-xlsx"
+                               aria-describedby="file-input-federal-awards-xlsx"
+                               accept=".xlsx"/>
+                    </div>
+                    <button class="usa-button" id="continue" disabled="disabled">Save and continue to next section</button>
+                </fieldset>
+            </form>
         </div>
-        <button class="usa-button" id="continue" disabled="disabled">Save and continue to next section</button>
-      </fieldset>
-    </form>
-
-
-  </div>
-</div>
-
-<div class="audit-metadata">
-  <div class="grid-container">
-    <dl class="grid-row grid-gap">
-      <div class="tablet:grid-col-6">
-        <dt>
-          Entity name
-        </dt>
-        <dd>
-          {{ auditee_name | default_if_none:'' }}
-        </dd>
-      </div>
-      <div class="tablet:grid-col-6">
-        <dt>
-          Report ID
-        </dt>
-        <dd>
-          <!-- Adding the 'json_script' alias allows this variable to be accessed by its alias in javascript. -->
-          #{{ report_id | default_if_none:'' | json_script:'sac_id' }}
-        </dd>
-      </div>
-      <div class="tablet:grid-col-6">
-        <dt>
-          UEI
-        </dt>
-        <dd>
-          {{ auditee_uei | default_if_none:'' }}
-        </dd>
-      </div>
-      <div class="tablet:grid-col-6">
-        <dt>
-          Type of entity
-        </dt>
-        <dd>
-          {{ user_provided_organization_type | default_if_none:'' }}
-        </dd>
-      </div>
-    </dl>
-  </div>
-</div>
-<script src="{% static 'compiled/js/federal-awards.js' %}"></script>
+    </div>
+    <div class="audit-metadata">
+        <div class="grid-container">
+            <dl class="grid-row grid-gap">
+                <div class="tablet:grid-col-6">
+                    <dt>
+                        Entity name
+                    </dt>
+                    <dd>
+                        {{ auditee_name | default_if_none:'' }}
+                    </dd>
+                </div>
+                <div class="tablet:grid-col-6">
+                    <dt>
+                        Report ID
+                    </dt>
+                    <dd>
+                        <!-- Adding the 'json_script' alias allows this variable to be accessed by its alias in javascript. -->
+                        #{{ report_id | default_if_none:'' | json_script:'sac_id' }}
+                    </dd>
+                </div>
+                <div class="tablet:grid-col-6">
+                    <dt>
+                        UEI
+                    </dt>
+                    <dd>
+                        {{ auditee_uei | default_if_none:'' }}
+                    </dd>
+                </div>
+                <div class="tablet:grid-col-6">
+                    <dt>
+                        Type of entity
+                    </dt>
+                    <dd>
+                        {{ user_provided_organization_type | default_if_none:'' }}
+                    </dd>
+                </div>
+            </dl>
+        </div>
+    </div>
+    <script src="{% static 'compiled/js/federal-awards.js' %}"></script>
 {% endblock content %}

--- a/backend/report_submission/templates/report_submission/federal-awards.html
+++ b/backend/report_submission/templates/report_submission/federal-awards.html
@@ -1,125 +1,112 @@
 {% extends "base.html" %}
 {% load static %}
 {% block metatags %}
-    <title>{{ post.title }}</title>
-    <meta name="description" content="{{ post.meta_description }}" />
-    <meta property="og:title" content="{{ post.title }}" />
-    <meta property="og:site_name" content="Federal Audit Clearinghouse" />
-    <meta property="og:description" content="{{ post.meta_description }}" />
-    <meta property="og:type" content="website" />
+<title>{{ post.title }}</title>
+<meta name="description" content="{{ post.meta_description }}" />
+<meta property="og:title" content="{{ post.title }}" />
+<meta property="og:site_name" content="Federal Audit Clearinghouse" />
+<meta property="og:description" content="{{ post.meta_description }}" />
+<meta property="og:type" content="website" />
 {% endblock %}
 {% block content %}
-    <div class="grid-container margin-top-6">
-        <div class="grid-row grid-gap">
-            <nav class="desktop:grid-col-3 sticky-nav"
-                 aria-label="Secondary navigation">
-                <ul class="usa-sidenav">
-                    <li class="usa-sidenav__item">
-                        <a href="#" class="">General information</a>
-                    </li>
-                    <li class="usa-sidenav__item">
-                        <a href="#federal-awards" class="usa-current">Federal Awards</a>
-                    </li>
-                    <li class="usa-sidenav__item">
-                        <a href="#" class="">Notes to SEFA</a>
-                    </li>
-                    <li class="usa-sidenav__item">
-                        <a href="#" class="">Audit information</a>
-                    </li>
-                    <li class="usa-sidenav__item">
-                        <a href="#" class="">Audit findings</a>
-                    </li>
-                    <li class="usa-sidenav__item">
-                        <a href="#" class="">Findings text</a>
-                    </li>
-                    <li class="usa-sidenav__item">
-                        <a href="#" class="">CAP text</a>
-                    </li>
-                    <li class="usa-sidenav__item">
-                        <a href="#" class="">Additional EINs</a>
-                    </li>
-                    <li class="usa-sidenav__item">
-                        <a href="#" class="">Additional UEIs</a>
-                    </li>
-                    <li class="usa-sidenav__item">
-                        <a href="#" class="">Secondary auditors</a>
-                    </li>
-                    <li class="usa-sidenav__item">
-                        <a href="#" class="">Finalize</a>
-                    </li>
-                </ul>
-            </nav>
-            <form class="usa-form usa-form--large"
-                  id="federal-awards"
-                  method="post">
-                {% csrf_token %}
-                <fieldset class="usa-fieldset">
-                    <legend class="usa-legend usa-legend--large" id="federal-awards">
-                        Federal awards
-                    </legend>
-                    <p>Enter the federal awards you recieved in the last audit year using the provided worksheet.</p>
-                    <ol class="usa-process-list connector-color-black">
-                        <li class="usa-process-list__item">
-                            <h4 class="usa-process-list__heading">Download worksheet</h4>
-                            <p class="">
-                                This worksheet is a spreadsheet file (XLSX).
-                                <a href="javascript:void(0);" class="usa-button usa-button--outline">Download worksheet</a>
-                            </p>
-                        </li>
-                        <li class="usa-process-list__item">
-                            <h4 class="usa-process-list__heading">Upload completed worksheet</h4>
-                            <p>Save your completed worksheet as an XLSX file and upload it below.</p>
-                            <div class="usa-form-group">
-                                    <input id="file-input-federal-awards-xlsx"
-                                           class="usa-file-input"
-                                           type="file"
-                                           name="file-input-federal-awards-xlsx"
-                                           aria-describedby="file-input-federal-awards-xlsx"
-                                           accept=".xlsx"/>
-                            </div>
-                        </ol>
-                        <button class="usa-button" id="continue" disabled="disabled">Save and continue to next section</button>
-                    </fieldset>
-                </form>
-            </div>
+<div class="grid-container margin-top-6">
+  <div class="grid-row grid-gap">
+    <nav class="desktop:grid-col-3 sticky-nav" aria-label="Secondary navigation">
+      <ul class="usa-sidenav margin-bottom-6">
+        <li class="usa-sidenav__item">
+          <a href="#" class="">General information</a>
+        </li>
+        <li class="usa-sidenav__item">
+          <a href="#federal-awards" class="usa-current">Federal Awards</a>
+        </li>
+        <li class="usa-sidenav__item">
+          <a href="#" class="">Notes to SEFA</a>
+        </li>
+        <li class="usa-sidenav__item">
+          <a href="#" class="">Audit information</a>
+        </li>
+        <li class="usa-sidenav__item">
+          <a href="#" class="">Audit findings</a>
+        </li>
+        <li class="usa-sidenav__item">
+          <a href="#" class="">Findings text</a>
+        </li>
+        <li class="usa-sidenav__item">
+          <a href="#" class="">CAP text</a>
+        </li>
+        <li class="usa-sidenav__item">
+          <a href="#" class="">Additional EINs</a>
+        </li>
+        <li class="usa-sidenav__item">
+          <a href="#" class="">Additional UEIs</a>
+        </li>
+        <li class="usa-sidenav__item">
+          <a href="#" class="">Secondary auditors</a>
+        </li>
+        <li class="usa-sidenav__item">
+          <a href="#" class="">Finalize</a>
+        </li>
+      </ul>
+    </nav>
+    <form class="usa-form usa-form--large" id="federal-awards" method="post">
+      {% csrf_token %}
+      <fieldset class="usa-fieldset">
+        <legend class="usa-legend usa-legend--large" id="federal-awards">
+          Federal awards
+        </legend>
+        <p>Enter the federal awards you recieved in the last audit year using the provided worksheet.</p>
+        <h4 class="usa-process-list__heading">Upload completed worksheet</h4>
+        <p>Save your completed worksheet as an XLSX file and upload it below.</p>
+        <div class="usa-form-group">
+          <input id="file-input-federal-awards-xlsx" class="usa-file-input" type="file"
+            name="file-input-federal-awards-xlsx" aria-describedby="file-input-federal-awards-xlsx" accept=".xlsx" />
         </div>
-        <div class="audit-metadata">
-            <div class="grid-container">
-                <dl class="grid-row grid-gap">
-                    <div class="tablet:grid-col-6">
-                        <dt>
-                            Entity name
-                        </dt>
-                        <dd>
-                            {{ auditee_name | default_if_none:'' }}
-                        </dd>
-                    </div>
-                    <div class="tablet:grid-col-6">
-                        <dt>
-                            Report ID
-                        </dt>
-                        <dd>
-                            #{{ report_id | default_if_none:'' }}
-                        </dd>
-                    </div>
-                    <div class="tablet:grid-col-6">
-                        <dt>
-                            UEI
-                        </dt>
-                        <dd>
-                            {{ auditee_uei | default_if_none:'' }}
-                        </dd>
-                    </div>
-                    <div class="tablet:grid-col-6">
-                        <dt>
-                            Type of entity
-                        </dt>
-                        <dd>
-                            {{ user_provided_organization_type | default_if_none:'' }}
-                        </dd>
-                    </div>
-                </dl>
-            </div>
-        </div>
-        <script src="{% static 'compiled/js/federal-awards.js' %}"></script>
-    {% endblock content %}
+        <button class="usa-button" id="continue" disabled="disabled">Save and continue to next section</button>
+      </fieldset>
+    </form>
+
+
+  </div>
+</div>
+
+<div class="audit-metadata">
+  <div class="grid-container">
+    <dl class="grid-row grid-gap">
+      <div class="tablet:grid-col-6">
+        <dt>
+          Entity name
+        </dt>
+        <dd>
+          {{ auditee_name | default_if_none:'' }}
+        </dd>
+      </div>
+      <div class="tablet:grid-col-6">
+        <dt>
+          Report ID
+        </dt>
+        <dd>
+          <!-- Adding the 'json_script' alias allows this variable to be accessed by its alias in javascript. -->
+          #{{ report_id | default_if_none:'' | json_script:'sac_id' }}
+        </dd>
+      </div>
+      <div class="tablet:grid-col-6">
+        <dt>
+          UEI
+        </dt>
+        <dd>
+          {{ auditee_uei | default_if_none:'' }}
+        </dd>
+      </div>
+      <div class="tablet:grid-col-6">
+        <dt>
+          Type of entity
+        </dt>
+        <dd>
+          {{ user_provided_organization_type | default_if_none:'' }}
+        </dd>
+      </div>
+    </dl>
+  </div>
+</div>
+<script src="{% static 'compiled/js/federal-awards.js' %}"></script>
+{% endblock content %}

--- a/backend/report_submission/templates/report_submission/federal-awards.html
+++ b/backend/report_submission/templates/report_submission/federal-awards.html
@@ -1,0 +1,125 @@
+{% extends "base.html" %}
+{% load static %}
+{% block metatags %}
+    <title>{{ post.title }}</title>
+    <meta name="description" content="{{ post.meta_description }}" />
+    <meta property="og:title" content="{{ post.title }}" />
+    <meta property="og:site_name" content="Federal Audit Clearinghouse" />
+    <meta property="og:description" content="{{ post.meta_description }}" />
+    <meta property="og:type" content="website" />
+{% endblock %}
+{% block content %}
+    <div class="grid-container margin-top-6">
+        <div class="grid-row grid-gap">
+            <nav class="desktop:grid-col-3 sticky-nav"
+                 aria-label="Secondary navigation">
+                <ul class="usa-sidenav">
+                    <li class="usa-sidenav__item">
+                        <a href="#" class="">General information</a>
+                    </li>
+                    <li class="usa-sidenav__item">
+                        <a href="#federal-awards" class="usa-current">Federal Awards</a>
+                    </li>
+                    <li class="usa-sidenav__item">
+                        <a href="#" class="">Notes to SEFA</a>
+                    </li>
+                    <li class="usa-sidenav__item">
+                        <a href="#" class="">Audit information</a>
+                    </li>
+                    <li class="usa-sidenav__item">
+                        <a href="#" class="">Audit findings</a>
+                    </li>
+                    <li class="usa-sidenav__item">
+                        <a href="#" class="">Findings text</a>
+                    </li>
+                    <li class="usa-sidenav__item">
+                        <a href="#" class="">CAP text</a>
+                    </li>
+                    <li class="usa-sidenav__item">
+                        <a href="#" class="">Additional EINs</a>
+                    </li>
+                    <li class="usa-sidenav__item">
+                        <a href="#" class="">Additional UEIs</a>
+                    </li>
+                    <li class="usa-sidenav__item">
+                        <a href="#" class="">Secondary auditors</a>
+                    </li>
+                    <li class="usa-sidenav__item">
+                        <a href="#" class="">Finalize</a>
+                    </li>
+                </ul>
+            </nav>
+            <form class="usa-form usa-form--large"
+                  id="federal-awards"
+                  method="post">
+                {% csrf_token %}
+                <fieldset class="usa-fieldset">
+                    <legend class="usa-legend usa-legend--large" id="federal-awards">
+                        Federal awards
+                    </legend>
+                    <p>Enter the federal awards you recieved in the last audit year using the provided worksheet.</p>
+                    <ol class="usa-process-list connector-color-black">
+                        <li class="usa-process-list__item">
+                            <h4 class="usa-process-list__heading">Download worksheet</h4>
+                            <p class="">
+                                This worksheet is a spreadsheet file (XLSX).
+                                <a href="javascript:void(0);" class="usa-button usa-button--outline">Download worksheet</a>
+                            </p>
+                        </li>
+                        <li class="usa-process-list__item">
+                            <h4 class="usa-process-list__heading">Upload completed worksheet</h4>
+                            <p>Save your completed worksheet as an XLSX file and upload it below.</p>
+                            <div class="usa-form-group">
+                                    <input id="file-input-federal-awards-xlsx"
+                                           class="usa-file-input"
+                                           type="file"
+                                           name="file-input-federal-awards-xlsx"
+                                           aria-describedby="file-input-federal-awards-xlsx"
+                                           accept=".xlsx"/>
+                            </div>
+                        </ol>
+                        <button class="usa-button" id="continue" disabled="disabled">Save and continue to next section</button>
+                    </fieldset>
+                </form>
+            </div>
+        </div>
+        <div class="audit-metadata">
+            <div class="grid-container">
+                <dl class="grid-row grid-gap">
+                    <div class="tablet:grid-col-6">
+                        <dt>
+                            Entity name
+                        </dt>
+                        <dd>
+                            {{ auditee_name | default_if_none:'' }}
+                        </dd>
+                    </div>
+                    <div class="tablet:grid-col-6">
+                        <dt>
+                            Report ID
+                        </dt>
+                        <dd>
+                            #{{ report_id | default_if_none:'' }}
+                        </dd>
+                    </div>
+                    <div class="tablet:grid-col-6">
+                        <dt>
+                            UEI
+                        </dt>
+                        <dd>
+                            {{ auditee_uei | default_if_none:'' }}
+                        </dd>
+                    </div>
+                    <div class="tablet:grid-col-6">
+                        <dt>
+                            Type of entity
+                        </dt>
+                        <dd>
+                            {{ user_provided_organization_type | default_if_none:'' }}
+                        </dd>
+                    </div>
+                </dl>
+            </div>
+        </div>
+        <script src="{% static 'compiled/js/federal-awards.js' %}"></script>
+    {% endblock content %}

--- a/backend/report_submission/templates/report_submission/gen-form.html
+++ b/backend/report_submission/templates/report_submission/gen-form.html
@@ -10,10 +10,7 @@
 {% endblock %}
 
 {% block content%}
-<div class="grid-container">
-  <h1>Submission Form</h1>
-</div>
-<div class="grid-container">
+<div class="grid-container margin-top-6">
   <div class="grid-row grid-gap">
     <nav class="desktop:grid-col-3 sticky-nav" aria-label="Secondary navigation">
       <ul class="usa-sidenav">
@@ -607,7 +604,7 @@
       </div>
       <div class="tablet:grid-col-6">
         <dt>Report ID</dt>
-        <dd>{{ report_id | default_if_none:'' }}</dd>
+        <dd>#{{ report_id | default_if_none:'' }}</dd>
       </div>
       <div class="tablet:grid-col-6">
         <dt>UEI</dt>

--- a/backend/report_submission/templates/report_submission/gen-form.html
+++ b/backend/report_submission/templates/report_submission/gen-form.html
@@ -1,621 +1,812 @@
 {% extends "base.html" %}
 {% load static %}
 {% block metatags %}
-<title>{{ post.title }}</title>
-<meta name="description" content="{{ post.meta_description }}" />
-<meta property="og:title" content="{{ post.title }}" />
-<meta property="og:site_name" content="Federal Audit Clearinghouse" />
-<meta property="og:description" content="{{ post.meta_description }}" />
-<meta property="og:type" content="website" />
+    <title>{{ post.title }}</title>
+    <meta name="description" content="{{ post.meta_description }}" />
+    <meta property="og:title" content="{{ post.title }}" />
+    <meta property="og:site_name" content="Federal Audit Clearinghouse" />
+    <meta property="og:description" content="{{ post.meta_description }}" />
+    <meta property="og:type" content="website" />
 {% endblock %}
-
-{% block content%}
-<div class="grid-container margin-top-6">
-  <div class="grid-row grid-gap">
-    <nav class="desktop:grid-col-3 sticky-nav" aria-label="Secondary navigation">
-      <ul class="usa-sidenav">
-        <li class="usa-sidenav__item">
-          <a href="#general-information" class="usa-current">
-            General information</a>
-          <ul class="usa-sidenav__sublist">
-            <li class="usa-sidenav__item"><a href="#audit-type">Type of audit</a></li>
-            <li class="usa-sidenav__item"><a href="#audit-period">Audit period</a></li>
-            <li class="usa-sidenav__item"><a href="#fiscal-period-dates">Fiscal period</a></li>
-            <li class="usa-sidenav__item"><a href="#auditee-information">Auditee information</a></li>
-            <li class="usa-sidenav__item"><a href="#primary-auditor-information">Primary Auditor Information</a>
-            </li>
-          </ul>
-        </li>
-      </ul>
-    </nav>
-    <form class="desktop:grid-col-9 usa-form usa-form--large sf-sac" id="general-info" method="post">
-      {% csrf_token %}
-      <fieldset class="usa-fieldset">
-        <legend class="usa-legend usa-legend--large" id="general-information">General information</legend>
-        <p>
-          <abbr title="required" class="usa-hint usa-hint--required">*</abbr>Indicates a required field.
-        </p>
-
-        <fieldset class="usa-fieldset question" id="audit-type">
-          <legend class="usa-legend">
-            Type of audit
-          </legend>
-          <p id="type_of_audit_instruction">Which type of Uniform Guidance audit are you filing for? <abbr
-              title="required" class="usa-hint usa-hint--required">*</abbr></p>
-          <ul class="usa-error-message" id="audit_type-error-message" role="alert">
-            <li id="audit_type-not-null" hidden>
-              This field is required
-            </li>
-          </ul>
-          <div class="usa-radio">
-            <input class="usa-radio__input" type="radio" id="single-audit" name="audit_type" value="single-audit"
-              required data-validate-not-null="" />
-            <label class="usa-radio__label" for="single-audit">
-              Single Audit
-            </label>
-          </div>
-
-          <div class="usa-radio">
-            <input class="usa-radio__input" id="program-specific-audit" name="audit_type" value="program-specific-audit"
-              type="radio" data-validate-not-null="" />
-            <label class="usa-radio__label" for="program-specific-audit">
-              Program-Specific Audit
-            </label>
-          </div>
-
-          <div class="usa-radio">
-            <input class="usa-radio__input" id="alt-compliance-examination" name="audit_type"
-              value="alt-compliance-examination" type="radio" data-validate-not-null="" />
-            <label class="usa-radio__label" for="alt-compliance-examination">
-              Alternative Compliance Examination
-            </label>
-          </div>
-        </fieldset>
-
-        <fieldset class="usa-fieldset question" id="audit-period">
-          <legend class="usa-legend">Audit period</legend>
-          <p id="audit_period_instruction">How long of an audit period is covered in this report? <abbr title="required"
-              class="usa-hint usa-hint--required">*</abbr></p>
-          <ul class="usa-error-message" id="audit_period_covered-error-message" role="alert">
-            <li id="audit_period_covered-not-null" hidden>
-              This field is required
-            </li>
-          </ul>
-          <div class="usa-radio">
-            <input class="usa-radio__input" type="radio" id="audit-period-annual" name="audit_period_covered"
-              value="annual" required data-validate-not-null="" />
-            <label class="usa-radio__label" for="audit-period-annual">
-              Annual
-            </label>
-          </div>
-
-          <div class="usa-radio">
-            <input class="usa-radio__input" id="audit-period-biennial" name="audit_period_covered" value="biennial"
-              type="radio" data-validate-not-null="" />
-            <label class="usa-radio__label" for="audit-period-biennial">
-              Biennial
-            </label>
-          </div>
-
-          <div class="usa-radio">
-            <input class="usa-radio__input" id="audit-period-other" name="audit_period_covered" value="other"
-              type="radio" data-validate-not-null="" />
-            <label class="usa-radio__label" for="audit-period-other">
-              Other
-            </label>
-            <input class="usa-input usa-input--small" type="text" id="audit_period_covered-other_months"
-              disabled />
-            <label class="usa-label usa-input--small__label" for="audit_period_covered-other_months">months</label>
-          </div>
-        </fieldset>
-
-        <fieldset class="usa-fieldset question" id="fiscal-period-dates">
-          <legend class="usa-legend">
-            Fiscal Period</legend>
-          <div class="usa-form-group" id="TEST">
-            <label class="usa-label" for="auditee_fiscal_period_start">
-              What is your fiscal period start date?
-              <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
-            </label>
-            <p class="usa-hint margin-0" id="auditee_fiscal_period_start-hint">mm/dd/yyyy</p>
-            <ul class="usa-error-message" id="auditee_fiscal_period_start-error-message" role="alert">
-              <li id="auditee_fiscal_period_start-not-null" hidden>
-                This field is required
-              </li>
-            </ul>
-            <input class="usa-input" id="auditee_fiscal_period_start" name="auditee_fiscal_period_start"
-              aria-required="true" required data-validate-not-null=""
-              value="{{ auditee_fiscal_period_start | default_if_none:'' }}" />
-          </div>
-
-          <div class="usa-form-group">
-            <label class="usa-label" for="auditee_fiscal_period_end">
-              What is your fiscal period end date?
-              <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
-            </label>
-            <p class="usa-hint margin-0" id="auditee_fiscal_period_end-hint">mm/dd/yyyy</p>
-            <ul class="usa-error-message" id="auditee_fiscal_period_end-error-message" role="alert">
-              <li id="auditee_fiscal_period_end-not-null" hidden>
-                This field is required
-              </li>
-            </ul>
-            <input class="usa-input" id="auditee_fiscal_period_end" name="auditee_fiscal_period_end"
-              aria-required="true" required data-validate-not-null=""
-              value="{{ auditee_fiscal_period_end | default_if_none:'' }}" />
-          </div>
-        </fieldset>
-
-        <fieldset class="usa-fieldset" id="auditee-information">
-          <legend class="usa-legend text-bold">
-            Auditee information
-          </legend>
-          <p class="usa-hint margin-0">Some auditee information is pulled from <a>SAM.gov</a> and is not editable here.
-          </p>
-          <fieldset class="usa-fieldset">
-            <legend class="usa-legend">
-              Auditee details
-            </legend>
-            <div class="usa-form-group">
-              <label class="usa-label" for="auditee_name">
-                Auditee name
-                <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
-              </label>
-              <ul class="usa-error-message" id="auditee_name-error-message" role="alert">
-                <li id="auditee_name-not-null" hidden>
-                  This field is required
-                </li>
-              </ul>
-              <input class="usa-input" id="auditee_name" name="auditee_name" aria-required="true" required
-                data-validate-not-null="" value="{{ auditee_name | default_if_none:'' }}" />
-            </div>
-            <div class="usa-form-group">
-              <label class="usa-label" for="auditee_address_line_1">
-                Street
-                <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
-              </label>
-              <ul class="usa-error-message" id="auditee_address_line_1-error-message" role="alert">
-                <li id="auditee_address_line_1-not-null" hidden>
-                  This field is required
-                </li>
-              </ul>
-              <input class="usa-input" id="auditee_address_line_1" name="auditee_address_line_1" aria-required="true"
-                required data-validate-not-null="" value="{{ auditee_address_line_1 | default_if_none:'' }}" />
-            </div>
-
-            <div class="usa-form-group">
-              <label class="usa-label" for="auditee_city">
-                City
-                <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
-              </label>
-              <ul class="usa-error-message" id="auditee_city-error-message" role="alert">
-                <li id="auditee_city-not-null" hidden>
-                  This field is required
-                </li>
-              </ul>
-              <input class="usa-input" id="auditee_city" name="auditee_city" aria-required="true" required
-                data-validate-not-null="" value="{{ auditee_city | default_if_none:'' }}" />
-            </div>
-
-            <div class="usa-form-group">
-              <label class="usa-label" for="auditee_state">
-                State
-                <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
-              </label>
-              <ul class="usa-error-message" id="auditee_state-error-message" role="alert">
-                <li id="auditee_state-not-null" hidden>
-                  This field is required
-                </li>
-              </ul>
-              <input class="usa-input" id="auditee_state" name="auditee_state" aria-required="true" required
-                data-validate-not-null="" value="{{ auditee_state | default_if_none:'' }}" />
-            </div>
-
-            <div class="usa-form-group">
-              <label class="usa-label" for="auditee_zip">
-                ZIP code
-                <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
-              </label>
-              <ul class="usa-error-message" id="auditee_zip-error-message" role="alert">
-                <li id="auditee_zip-not-null" hidden>
-                  This field is required
-                </li>
-              </ul>
-              <input class="usa-input" id="auditee_zip" name="auditee_zip" aria-required="true" required
-                data-validate-not-null="" value="{{ auditee_zip | default_if_none:'' }}" />
-            </div>
-          </fieldset>
-          <fieldset class="usa-fieldset">
-            <legend class="usa-legend">
-              Auditee Unique Entity Identifier (UEI)
-            </legend>
-            <div class="usa-form-group">
-              <label class="usa-label" for="auditee_uei">
-                Auditee UEI
-                <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
-              </label>
-              <ul class="usa-error-message" id="auditee_uei-error-message" role="alert">
-                <li id="auditee_uei-not-null" hidden>
-                  This field is required
-                </li>
-              </ul>
-              <input class="usa-input" id="auditee_uei" name="auditee_uei" aria-required="true" required
-                data-validate-not-null="" value="{{ auditee_uei | default_if_none:'' }}" />
-            </div>
-            <fieldset class="usa-fieldset radio">
-              <legend class="usa-legend">
-                Are multiple UEIs covered in this report?<abbr title="required"
-                  class="usa-hint usa-hint--required">*</abbr>
-              </legend>
-              <p class="usa-hint margin-0">You'll be able to add additional UEIs later.</p>
-              <ul class="usa-error-message" id="multiple_ueis_covered-error-message" role="alert">
-                <li id="multiple_ueis_covered-not-null" hidden>
-                  This field is required
-                </li>
-              </ul>
-              <div class="usa-radio">
-                <input class="usa-radio__input" type="radio" id="multiple-ueis-yes" name="multiple_ueis_covered"
-                  value="true" required data-validate-not-null="" />
-                <label class="usa-radio__label" for="multiple-ueis-yes">
-                  Yes
-                </label>
-              </div>
-
-              <div class="usa-radio">
-                <input class="usa-radio__input" type="radio" id="multiple-ueis-no" name="multiple_ueis_covered"
-                  value="false" data-validate-not-null="" />
-                <label class="usa-radio__label" for="multiple-ueis-no">
-                  No
-                </label>
-              </div>
-            </fieldset>
-          </fieldset>
-
-          <fieldset class="usa-fieldset" id="auditee-identification-numbers">
-            <legend class="usa-legend">
-              Auditee Employer Identification Number (EIN)</legend>
-            <div class="usa-form-group">
-              <label class="usa-label" for="ein">
-                What is your Auditee EIN?
-                <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
-              </label>
-              <ul class="usa-error-message" id="ein-error-message" role="alert">
-                <li id="ein-not-null" hidden>
-                  This field is required
-                </li>
-              </ul>
-              <input class="usa-input" id="ein" name="ein" aria-required="true" required data-validate-not-null="" />
-            </div>
-
-            <div class="usa-checkbox">
-              <input class="usa-checkbox__input" id="ein_not_an_ssn_attestation" type="checkbox"
-                name="ein_not_an_ssn_attestation" data-validate-not-null="" value="" />
-              <label class="usa-checkbox__label" for="ein_not_an_ssn_attestation">
-                By checking this box, I verify that the Auditee EIN is not a Social Security Number.
-              </label>
-              <ul class="usa-error-message" id="ein_not_an_ssn_attestation-error-message" role="alert">
-                <li id="ein_not_an_ssn_attestation-not-null" hidden>
-                  EIN may not be a social security number
-                </li>
-              </ul>
-            </div>
-
-            <fieldset class="usa-fieldset radio">
-              <legend class="usa-legend">
-                Are multiple EINs covered in this report?<abbr title="required"
-                  class="usa-hint usa-hint--required">*</abbr>
-              </legend>
-              <p class="usa-hint margin-0">You'll be able to add additional EINs later.</p>
-              <ul class="usa-error-message" id="multiple_eins_covered-error-message" role="alert">
-                <li id="multiple_eins_covered-not-null" hidden>
-                  This field is required
-                </li>
-              </ul>
-              <div class="usa-radio">
-                <input class="usa-radio__input" type="radio" id="multiple-eins-yes" name="multiple_eins_covered"
-                  value="true" required data-validate-not-null="" />
-                <label class="usa-radio__label" for="multiple-eins-yes">
-                  Yes
-                </label>
-              </div>
-
-              <div class="usa-radio">
-                <input class="usa-radio__input" type="radio" id="multiple-eins-no" name="multiple_eins_covered"
-                  value="false" data-validate-not-null="" />
-                <label class="usa-radio__label" for="multiple-eins-no">
-                  No
-                </label>
-              </div>
-            </fieldset>
-
-          </fieldset>
-
-          <fieldset class="usa-fieldset">
-            <legend class="usa-legend">
-              Auditee contact information
-            </legend>
-            <div class="usa-form-group">
-              <label class="usa-label" for="auditee_contact_name">
-                Auditee contact's name
-                <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
-              </label>
-              <ul class="usa-error-message" id="auditee_contact_name-error-message" role="alert">
-                <li id="auditee_contact_name-not-null" hidden>
-                  This field is required
-                </li>
-              </ul>
-              <input class="usa-input" id="auditee_contact_name" name="auditee_contact_name" aria-required="true"
-                required data-validate-not-null="" value="{{ auditee_contact_name | default_if_none:'' }}" />
-            </div>
-
-            <div class="usa-form-group">
-              <label class="usa-label" for="auditee_contact_title">
-                Auditee contact's title
-                <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
-              </label>
-              <ul class="usa-error-message" id="auditee_contact_title-error-message" role="alert">
-                <li id="auditee_contact_title-not-null" hidden>
-                  This field is required
-                </li>
-              </ul>
-              <input class="usa-input" id="auditee_contact_title" name="auditee_contact_title" aria-required="true"
-                required data-validate-not-null="" value="{{ auditee_contact_title | default_if_none:'' }}" />
-            </div>
-
-            <div class="usa-form-group">
-              <label class="usa-label" for="auditee_phone">
-                Auditee phone number
-                <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
-              </label>
-              <ul class="usa-error-message" id="auditee_phone-error-message" role="alert">
-                <li id="auditee_phone-not-null" hidden>
-                  This field is required
-                </li>
-              </ul>
-              <input class="usa-input" id="auditee_phone" name="auditee_phone" aria-required="true" required
-                data-validate-not-null="" value="{{ auditee_phone | default_if_none:'' }}" />
-            </div>
-            <div class="usa-form-group">
-              <label class="usa-label" for="auditee_email">
-                Auditee email
-                <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
-              </label>
-              <ul class="usa-error-message" id="auditee_email-error-message" role="alert">
-                <li id="auditee_email-not-null" hidden>
-                  This field is required
-                </li>
-              </ul>
-              <input class="usa-input" id="auditee_email" name="auditee_email" aria-required="true" required
-                data-validate-not-null="" value="{{ auditee_email | default_if_none:'' }}" />
-            </div>
-          </fieldset>
-        </fieldset>
-
-        <fieldset class="usa-fieldset" id="primary-auditor-information">
-          <legend class="usa-legend text-bold">
-            Primary auditor information
-          </legend>
-          <p class="usa-hint">
-            If multiple audit organizations worked on this audit, only include the lead or coordinating auditor's
-            information.
-          </p>
-
-          <fieldset class="usa-fieldset">
-            <legend class="usa-legend">
-              Auditor details
-            </legend>
-
-            <div class="usa-form-group">
-              <label class="usa-label" for="auditor_firm_name">
-                Audit firm/organization name
-                <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
-              </label>
-              <ul class="usa-error-message" id="auditor_firm_name-error-message" role="alert">
-                <li id="auditor_firm_name-not-null" hidden>
-                  This field is required
-                </li>
-              </ul>
-              <input class="usa-input" id="auditor_firm_name" name="auditor_firm_name" aria-required="true" required
-                data-validate-not-null="" value="{{ auditor_firm_name | default_if_none:'' }}" />
-            </div>
-
-            <fieldset class="usa-fieldset" id="audit-firm-organization-address">
-              <legend class="usa-legend">
-                Audit firm/organization address
-              </legend>
-
-              <div class="usa-form-group">
-                <label class="usa-label" for="auditor_country">
-                  Country
-                  <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
-                </label>
-                <ul class="usa-error-message" id="auditor_country-error-message" role="alert">
-                  <li id="auditor_country-not-null" hidden>
-                    This field is required
-                  </li>
+{% block content %}
+    <div class="grid-container margin-top-6">
+        <div class="grid-row grid-gap">
+            <nav class="desktop:grid-col-3 sticky-nav"
+                 aria-label="Secondary navigation">
+                <ul class="usa-sidenav">
+                    <li class="usa-sidenav__item">
+                        <a href="#general-information" class="usa-current">General information</a>
+                        <ul class="usa-sidenav__sublist">
+                            <li class="usa-sidenav__item">
+                                <a href="#audit-type">Type of audit</a>
+                            </li>
+                            <li class="usa-sidenav__item">
+                                <a href="#audit-period">Audit period</a>
+                            </li>
+                            <li class="usa-sidenav__item">
+                                <a href="#fiscal-period-dates">Fiscal period</a>
+                            </li>
+                            <li class="usa-sidenav__item">
+                                <a href="#auditee-information">Auditee information</a>
+                            </li>
+                            <li class="usa-sidenav__item">
+                                <a href="#primary-auditor-information">Primary Auditor Information</a>
+                            </li>
+                        </ul>
+                    </li>
                 </ul>
-                <input class="usa-input" id="auditor_country" name="auditor_country" aria-required="true" required
-                  data-validate-not-null="" value="{{ auditor_country | default_if_none:'' }}" />
-              </div>
-
-              <div class="usa-form-group">
-                <label class="usa-label" for="auditor_address_line_1">
-                  Street
-                  <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
-                </label>
-                <ul class="usa-error-message" id="auditor_address_line_1-error-message" role="alert">
-                  <li id="auditor_address_line_1-not-null" hidden>
-                    This field is required
-                  </li>
-                </ul>
-                <input class="usa-input" id="auditor_address_line_1" name="auditor_address_line_1" aria-required="true"
-                  required data-validate-not-null="" value="{{ auditor_address_line_1 | default_if_none:'' }}" />
-              </div>
-
-              <div class="usa-form-group">
-                <label class="usa-label" for="auditor_city">
-                  City
-                  <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
-                </label>
-                <ul class="usa-error-message" id="auditor_city-error-message" role="alert">
-                  <li id="auditor_city-not-null" hidden>
-                    This field is required
-                  </li>
-                </ul>
-                <input class="usa-input" id="auditor_city" name="auditor_city" aria-required="true" required
-                  data-validate-not-null="" value="{{ auditor_city | default_if_none:'' }}" />
-              </div>
-
-              <div class="usa-form-group">
-                <label class="usa-label" for="auditor_state">
-                  State
-                  <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
-                </label>
-                <ul class="usa-error-message" id="auditor_state-error-message" role="alert">
-                  <li id="auditor_state-not-null" hidden>
-                    This field is required
-                  </li>
-                </ul>
-                <input class="usa-input" id="auditor_state" name="auditor_state" aria-required="true" required
-                  data-validate-not-null="" value="{{ auditor_state | default_if_none:'' }}" />
-              </div>
-
-              <div class="usa-form-group">
-                <label class="usa-label" for="auditor_zip">
-                  ZIP code
-                  <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
-                </label>
-                <ul class="usa-error-message" id="auditor_zip-error-message" role="alert">
-                  <li id="auditor_zip-not-null" hidden>
-                    This field is required
-                  </li>
-                </ul>
-                <input class="usa-input" id="auditor_zip" name="auditor_zip" aria-required="true" required
-                  data-validate-not-null="" value="{{ auditor_zip | default_if_none:'' }}" />
-              </div>
-            </fieldset>
-          </fieldset>
-
-          <fieldset class="usa-fieldset">
-            <legend class="usa-legend">
-              Auditor EIN
-            </legend>
-            <div class="usa-form-group">
-              <label class="usa-label" for="auditor_ein">
-                What is your audit firm/organization's EIN?
-                <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
-              </label>
-              <ul class="usa-error-message" id="auditor_ein-error-message" role="alert">
-                <li id="auditor_ein-not-null" hidden>
-                  This field is required
-                </li>
-              </ul>
-              <input class="usa-input" id="auditor_ein" name="auditor_ein" aria-required="true" required
-                data-validate-not-null="" value="{{ auditor_ein | default_if_none:'' }}" />
-            </div>
-            <div class="usa-checkbox">
-              <input class="usa-checkbox__input" id="auditor_ein_not_an_ssn_attestation" type="checkbox"
-                name="auditor_ein_not_an_ssn_attestation" value="" data-validate-not-null="" />
-              <label class="usa-checkbox__label" for="auditor_ein_not_an_ssn_attestation">
-                By checking this box, I verify that the Auditor EIN is not a Social Security Number.
-              </label>
-              <ul class="usa-error-message" id="auditor_ein_not_an_ssn_attestation-error-message" role="alert">
-                <li id="auditor_ein_not_an_ssn_attestation-not-null" hidden>
-                  EIN may not be a social security number
-                </li>
-              </ul>
-            </div>
-          </fieldset>
-
-          <fieldset class="usa-fieldset">
-            <legend class="usa-legend">
-              Auditor contact information
-            </legend>
-
-            <div class="usa-form-group">
-              <label class="usa-label" for="auditor_contact_name">
-                Auditor name
-                <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
-              </label>
-              <ul class="usa-error-message" id="auditor_contact_name-error-message" role="alert">
-                <li id="auditor_contact_name-not-null" hidden>
-                  This field is required
-                </li>
-              </ul>
-              <input class="usa-input" id="auditor_contact_name" name="auditor_contact_name" aria-required="true"
-                required data-validate-not-null="" value="{{ auditor_contact_name | default_if_none:'' }}" />
-            </div>
-
-            <div class="usa-form-group">
-              <label class="usa-label" for="auditor_contact_title">
-                Auditor title
-                <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
-              </label>
-              <ul class="usa-error-message" id="auditor_contact_title-error-message" role="alert">
-                <li id="auditor_contact_title-not-null" hidden>
-                  This field is required
-                </li>
-              </ul>
-              <input class="usa-input" id="auditor_contact_title" name="auditor_contact_title" aria-required="true"
-                required data-validate-not-null="" value="{{ auditor_contact_title | default_if_none:'' }}" />
-            </div>
-
-            <div class="usa-form-group">
-              <label class="usa-label" for="auditor_phone">
-                Auditor phone number
-                <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
-              </label>
-              <ul class="usa-error-message" id="auditor_phone-error-message" role="alert">
-                <li id="auditor_phone-not-null" hidden>
-                  This field is required
-                </li>
-              </ul>
-              <input class="usa-input" id="auditor_phone" name="auditor_phone" aria-required="true" required
-                data-validate-not-null="" value="{{ auditor_phone | default_if_none:'' }}" />
-            </div>
-
-            <div class="usa-form-group">
-              <label class="usa-label" for="auditor_email">
-                Auditor email<abbr title="required" class="usa-hint usa-hint--required">*</abbr>
-              </label>
-              <ul class="usa-error-message" id="auditor_email-error-message" role="alert">
-                <li id="auditor_email-not-null" hidden>
-                  This field is required
-                </li>
-              </ul>
-              <input class="usa-input" id="auditor_email" name="auditor_email" aria-required="true" required
-                data-validate-not-null="" value="{{ auditor_email | default_if_none:'' }}" />
-            </div>
-          </fieldset>
-        </fieldset>
-        <button class="usa-button" id="continue">
-          Save and continue to next section
-        </button>
-      </fieldset>
-    </form>
-  </div>
-</div>
-
-<div class="audit-metadata">
-  <div class="grid-container">
-    <dl class="grid-row grid-gap">
-      <div class="tablet:grid-col-6">
-        <dt>Entity name</dt>
-        <dd>{{ auditee_name | default_if_none:'' }}</dd>
-      </div>
-      <div class="tablet:grid-col-6">
-        <dt>Report ID</dt>
-        <dd>#{{ report_id | default_if_none:'' }}</dd>
-      </div>
-      <div class="tablet:grid-col-6">
-        <dt>UEI</dt>
-        <dd>{{ auditee_uei | default_if_none:'' }}</dd>
-      </div>
-      <div class="tablet:grid-col-6">
-        <dt>Type of entity</dt>
-        <dd>{{ user_provided_organization_type | default_if_none:'' }}</dd>
-      </div>
-    </dl>
-  </div>
-</div>
-<script src="{% static 'compiled/js/sf-sac.js' %}"></script>
-{% endblock content%}
+            </nav>
+            <form class="desktop:grid-col-9 usa-form usa-form--large sf-sac"
+                  id="general-info"
+                  method="post">
+                {% csrf_token %}
+                <fieldset class="usa-fieldset">
+                    <legend class="usa-legend usa-legend--large" id="general-information">
+                        General information
+                    </legend>
+                    <p>
+                        <abbr title="required" class="usa-hint usa-hint--required">*</abbr>Indicates a required field.
+                    </p>
+                    <fieldset class="usa-fieldset question" id="audit-type">
+                        <legend class="usa-legend">
+                            Type of audit
+                        </legend>
+                        <p id="type_of_audit_instruction">
+                            Which type of Uniform Guidance audit are you filing for? <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
+                        </p>
+                        <ul class="usa-error-message" id="audit_type-error-message" role="alert">
+                            <li id="audit_type-not-null" hidden>This field is required</li>
+                        </ul>
+                        <div class="usa-radio">
+                            <input class="usa-radio__input"
+                                   type="radio"
+                                   id="single-audit"
+                                   name="audit_type"
+                                   value="single-audit"
+                                   required
+                                   data-validate-not-null=""/>
+                            <label class="usa-radio__label" for="single-audit">Single Audit</label>
+                        </div>
+                        <div class="usa-radio">
+                            <input class="usa-radio__input"
+                                   id="program-specific-audit"
+                                   name="audit_type"
+                                   value="program-specific-audit"
+                                   type="radio"
+                                   data-validate-not-null=""/>
+                            <label class="usa-radio__label" for="program-specific-audit">Program-Specific Audit</label>
+                        </div>
+                        <div class="usa-radio">
+                            <input class="usa-radio__input"
+                                   id="alt-compliance-examination"
+                                   name="audit_type"
+                                   value="alt-compliance-examination"
+                                   type="radio"
+                                   data-validate-not-null=""/>
+                            <label class="usa-radio__label" for="alt-compliance-examination">Alternative Compliance Examination</label>
+                        </div>
+                    </fieldset>
+                    <fieldset class="usa-fieldset question" id="audit-period">
+                        <legend class="usa-legend">
+                            Audit period
+                        </legend>
+                        <p id="audit_period_instruction">
+                            How long of an audit period is covered in this report? <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
+                        </p>
+                        <ul class="usa-error-message"
+                            id="audit_period_covered-error-message"
+                            role="alert">
+                            <li id="audit_period_covered-not-null" hidden>This field is required</li>
+                        </ul>
+                        <div class="usa-radio">
+                            <input class="usa-radio__input"
+                                   type="radio"
+                                   id="audit-period-annual"
+                                   name="audit_period_covered"
+                                   value="annual"
+                                   required
+                                   data-validate-not-null=""/>
+                            <label class="usa-radio__label" for="audit-period-annual">Annual</label>
+                        </div>
+                        <div class="usa-radio">
+                            <input class="usa-radio__input"
+                                   id="audit-period-biennial"
+                                   name="audit_period_covered"
+                                   value="biennial"
+                                   type="radio"
+                                   data-validate-not-null=""/>
+                            <label class="usa-radio__label" for="audit-period-biennial">Biennial</label>
+                        </div>
+                        <div class="usa-radio">
+                            <input class="usa-radio__input"
+                                   id="audit-period-other"
+                                   name="audit_period_covered"
+                                   value="other"
+                                   type="radio"
+                                   data-validate-not-null=""/>
+                            <label class="usa-radio__label" for="audit-period-other">Other</label>
+                            <input class="usa-input usa-input--small"
+                                   type="text"
+                                   id="audit_period_covered-other_months"
+                                   disabled/>
+                            <label class="usa-label usa-input--small__label"
+                                   for="audit_period_covered-other_months">months</label>
+                        </div>
+                    </fieldset>
+                    <fieldset class="usa-fieldset question" id="fiscal-period-dates">
+                        <legend class="usa-legend">
+                            Fiscal Period
+                        </legend>
+                        <div class="usa-form-group" id="TEST">
+                            <label class="usa-label" for="auditee_fiscal_period_start">
+                                What is your fiscal period start date?
+                                <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
+                            </label>
+                            <p class="usa-hint margin-0" id="auditee_fiscal_period_start-hint">mm/dd/yyyy</p>
+                            <ul class="usa-error-message"
+                                id="auditee_fiscal_period_start-error-message"
+                                role="alert">
+                                <li id="auditee_fiscal_period_start-not-null" hidden>This field is required</li>
+                            </ul>
+                            <input class="usa-input"
+                                   id="auditee_fiscal_period_start"
+                                   name="auditee_fiscal_period_start"
+                                   aria-required="true"
+                                   required
+                                   data-validate-not-null=""
+                                   value="{{ auditee_fiscal_period_start | default_if_none:'' }}"/>
+                        </div>
+                        <div class="usa-form-group">
+                            <label class="usa-label" for="auditee_fiscal_period_end">
+                                What is your fiscal period end date?
+                                <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
+                            </label>
+                            <p class="usa-hint margin-0" id="auditee_fiscal_period_end-hint">mm/dd/yyyy</p>
+                            <ul class="usa-error-message"
+                                id="auditee_fiscal_period_end-error-message"
+                                role="alert">
+                                <li id="auditee_fiscal_period_end-not-null" hidden>This field is required</li>
+                            </ul>
+                            <input class="usa-input"
+                                   id="auditee_fiscal_period_end"
+                                   name="auditee_fiscal_period_end"
+                                   aria-required="true"
+                                   required
+                                   data-validate-not-null=""
+                                   value="{{ auditee_fiscal_period_end | default_if_none:'' }}"/>
+                        </div>
+                    </fieldset>
+                    <fieldset class="usa-fieldset" id="auditee-information">
+                        <legend class="usa-legend text-bold">
+                            Auditee information
+                        </legend>
+                        <p class="usa-hint margin-0">
+                            Some auditee information is pulled from <a>SAM.gov</a> and is not editable here.
+                        </p>
+                        <fieldset class="usa-fieldset">
+                            <legend class="usa-legend">
+                                Auditee details
+                            </legend>
+                            <div class="usa-form-group">
+                                <label class="usa-label" for="auditee_name">
+                                    Auditee name
+                                    <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
+                                </label>
+                                <ul class="usa-error-message"
+                                    id="auditee_name-error-message"
+                                    role="alert">
+                                    <li id="auditee_name-not-null" hidden>This field is required</li>
+                                </ul>
+                                <input class="usa-input"
+                                       id="auditee_name"
+                                       name="auditee_name"
+                                       aria-required="true"
+                                       required
+                                       data-validate-not-null=""
+                                       value="{{ auditee_name | default_if_none:'' }}"/>
+                            </div>
+                            <div class="usa-form-group">
+                                <label class="usa-label" for="auditee_address_line_1">
+                                    Street
+                                    <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
+                                </label>
+                                <ul class="usa-error-message"
+                                    id="auditee_address_line_1-error-message"
+                                    role="alert">
+                                    <li id="auditee_address_line_1-not-null" hidden>This field is required</li>
+                                </ul>
+                                <input class="usa-input"
+                                       id="auditee_address_line_1"
+                                       name="auditee_address_line_1"
+                                       aria-required="true"
+                                       required
+                                       data-validate-not-null=""
+                                       value="{{ auditee_address_line_1 | default_if_none:'' }}"/>
+                            </div>
+                            <div class="usa-form-group">
+                                <label class="usa-label" for="auditee_city">
+                                    City
+                                    <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
+                                </label>
+                                <ul class="usa-error-message"
+                                    id="auditee_city-error-message"
+                                    role="alert">
+                                    <li id="auditee_city-not-null" hidden>This field is required</li>
+                                </ul>
+                                <input class="usa-input"
+                                       id="auditee_city"
+                                       name="auditee_city"
+                                       aria-required="true"
+                                       required
+                                       data-validate-not-null=""
+                                       value="{{ auditee_city | default_if_none:'' }}"/>
+                            </div>
+                            <div class="usa-form-group">
+                                <label class="usa-label" for="auditee_state">
+                                    State
+                                    <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
+                                </label>
+                                <ul class="usa-error-message"
+                                    id="auditee_state-error-message"
+                                    role="alert">
+                                    <li id="auditee_state-not-null" hidden>This field is required</li>
+                                </ul>
+                                <input class="usa-input"
+                                       id="auditee_state"
+                                       name="auditee_state"
+                                       aria-required="true"
+                                       required
+                                       data-validate-not-null=""
+                                       value="{{ auditee_state | default_if_none:'' }}"/>
+                            </div>
+                            <div class="usa-form-group">
+                                <label class="usa-label" for="auditee_zip">
+                                    ZIP code
+                                    <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
+                                </label>
+                                <ul class="usa-error-message" id="auditee_zip-error-message" role="alert">
+                                    <li id="auditee_zip-not-null" hidden>This field is required</li>
+                                </ul>
+                                <input class="usa-input"
+                                       id="auditee_zip"
+                                       name="auditee_zip"
+                                       aria-required="true"
+                                       required
+                                       data-validate-not-null=""
+                                       value="{{ auditee_zip | default_if_none:'' }}"/>
+                            </div>
+                        </fieldset>
+                        <fieldset class="usa-fieldset">
+                            <legend class="usa-legend">
+                                Auditee Unique Entity Identifier (UEI)
+                            </legend>
+                            <div class="usa-form-group">
+                                <label class="usa-label" for="auditee_uei">
+                                    Auditee UEI
+                                    <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
+                                </label>
+                                <ul class="usa-error-message" id="auditee_uei-error-message" role="alert">
+                                    <li id="auditee_uei-not-null" hidden>
+                                        This field is required
+                                    </li>
+                                </ul>
+                                <input class="usa-input"
+                                       id="auditee_uei"
+                                       name="auditee_uei"
+                                       aria-required="true"
+                                       required
+                                       data-validate-not-null=""
+                                       value="{{ auditee_uei | default_if_none:'' }}"/>
+                            </div>
+                            <fieldset class="usa-fieldset radio">
+                                <legend class="usa-legend">
+                                    Are multiple UEIs covered in this report?<abbr title="required" class="usa-hint usa-hint--required">*</abbr>
+                                </legend>
+                                <p class="usa-hint margin-0">
+                                    You'll be able to add additional UEIs later.
+                                </p>
+                                <ul class="usa-error-message"
+                                    id="multiple_ueis_covered-error-message"
+                                    role="alert">
+                                    <li id="multiple_ueis_covered-not-null" hidden>
+                                        This field is required
+                                    </li>
+                                </ul>
+                                <div class="usa-radio">
+                                    <input class="usa-radio__input"
+                                           type="radio"
+                                           id="multiple-ueis-yes"
+                                           name="multiple_ueis_covered"
+                                           value="true"
+                                           required
+                                           data-validate-not-null=""/>
+                                    <label class="usa-radio__label" for="multiple-ueis-yes">
+                                        Yes
+                                    </label>
+                                </div>
+                                <div class="usa-radio">
+                                    <input class="usa-radio__input"
+                                           type="radio"
+                                           id="multiple-ueis-no"
+                                           name="multiple_ueis_covered"
+                                           value="false"
+                                           data-validate-not-null=""/>
+                                    <label class="usa-radio__label" for="multiple-ueis-no">
+                                        No
+                                    </label>
+                                </div>
+                            </fieldset>
+                        </fieldset>
+                        <fieldset class="usa-fieldset" id="auditee-identification-numbers">
+                            <legend class="usa-legend">
+                                Auditee Employer Identification Number (EIN)
+                            </legend>
+                            <div class="usa-form-group">
+                                <label class="usa-label" for="ein">
+                                    What is your Auditee EIN?
+                                    <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
+                                </label>
+                                <ul class="usa-error-message" id="ein-error-message" role="alert">
+                                    <li id="ein-not-null" hidden>
+                                        This field is required
+                                    </li>
+                                </ul>
+                                <input class="usa-input"
+                                       id="ein"
+                                       name="ein"
+                                       aria-required="true"
+                                       required
+                                       data-validate-not-null=""/>
+                            </div>
+                            <div class="usa-checkbox">
+                                <input class="usa-checkbox__input"
+                                       id="ein_not_an_ssn_attestation"
+                                       type="checkbox"
+                                       name="ein_not_an_ssn_attestation"
+                                       data-validate-not-null=""
+                                       value=""/>
+                                <label class="usa-checkbox__label" for="ein_not_an_ssn_attestation">
+                                    By checking this box, I verify that the Auditee EIN is not a Social Security Number.
+                                </label>
+                                <ul class="usa-error-message"
+                                    id="ein_not_an_ssn_attestation-error-message"
+                                    role="alert">
+                                    <li id="ein_not_an_ssn_attestation-not-null" hidden>
+                                        EIN may not be a social security number
+                                    </li>
+                                </ul>
+                            </div>
+                            <fieldset class="usa-fieldset radio">
+                                <legend class="usa-legend">
+                                    Are multiple EINs covered in this report?<abbr title="required" class="usa-hint usa-hint--required">*</abbr>
+                                </legend>
+                                <p class="usa-hint margin-0">
+                                    You'll be able to add additional EINs later.
+                                </p>
+                                <ul class="usa-error-message"
+                                    id="multiple_eins_covered-error-message"
+                                    role="alert">
+                                    <li id="multiple_eins_covered-not-null" hidden>
+                                        This field is required
+                                    </li>
+                                </ul>
+                                <div class="usa-radio">
+                                    <input class="usa-radio__input"
+                                           type="radio"
+                                           id="multiple-eins-yes"
+                                           name="multiple_eins_covered"
+                                           value="true"
+                                           required
+                                           data-validate-not-null=""/>
+                                    <label class="usa-radio__label" for="multiple-eins-yes">
+                                        Yes
+                                    </label>
+                                </div>
+                                <div class="usa-radio">
+                                    <input class="usa-radio__input"
+                                           type="radio"
+                                           id="multiple-eins-no"
+                                           name="multiple_eins_covered"
+                                           value="false"
+                                           data-validate-not-null=""/>
+                                    <label class="usa-radio__label" for="multiple-eins-no">
+                                        No
+                                    </label>
+                                </div>
+                            </fieldset>
+                        </fieldset>
+                        <fieldset class="usa-fieldset">
+                            <legend class="usa-legend">
+                                Auditee contact information
+                            </legend>
+                            <div class="usa-form-group">
+                                <label class="usa-label" for="auditee_contact_name">
+                                    Auditee contact's name
+                                    <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
+                                </label>
+                                <ul class="usa-error-message"
+                                    id="auditee_contact_name-error-message"
+                                    role="alert">
+                                    <li id="auditee_contact_name-not-null" hidden>
+                                        This field is required
+                                    </li>
+                                </ul>
+                                <input class="usa-input"
+                                       id="auditee_contact_name"
+                                       name="auditee_contact_name"
+                                       aria-required="true"
+                                       required
+                                       data-validate-not-null=""
+                                       value="{{ auditee_contact_name | default_if_none:'' }}"/>
+                            </div>
+                            <div class="usa-form-group">
+                                <label class="usa-label" for="auditee_contact_title">
+                                    Auditee contact's title
+                                    <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
+                                </label>
+                                <ul class="usa-error-message"
+                                    id="auditee_contact_title-error-message"
+                                    role="alert">
+                                    <li id="auditee_contact_title-not-null" hidden>
+                                        This field is required
+                                    </li>
+                                </ul>
+                                <input class="usa-input"
+                                       id="auditee_contact_title"
+                                       name="auditee_contact_title"
+                                       aria-required="true"
+                                       required
+                                       data-validate-not-null=""
+                                       value="{{ auditee_contact_title | default_if_none:'' }}"/>
+                            </div>
+                            <div class="usa-form-group">
+                                <label class="usa-label" for="auditee_phone">
+                                    Auditee phone number
+                                    <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
+                                </label>
+                                <ul class="usa-error-message"
+                                    id="auditee_phone-error-message"
+                                    role="alert">
+                                    <li id="auditee_phone-not-null" hidden>
+                                        This field is required
+                                    </li>
+                                </ul>
+                                <input class="usa-input"
+                                       id="auditee_phone"
+                                       name="auditee_phone"
+                                       aria-required="true"
+                                       required
+                                       data-validate-not-null=""
+                                       value="{{ auditee_phone | default_if_none:'' }}"/>
+                            </div>
+                            <div class="usa-form-group">
+                                <label class="usa-label" for="auditee_email">
+                                    Auditee email
+                                    <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
+                                </label>
+                                <ul class="usa-error-message"
+                                    id="auditee_email-error-message"
+                                    role="alert">
+                                    <li id="auditee_email-not-null" hidden>
+                                        This field is required
+                                    </li>
+                                </ul>
+                                <input class="usa-input"
+                                       id="auditee_email"
+                                       name="auditee_email"
+                                       aria-required="true"
+                                       required
+                                       data-validate-not-null=""
+                                       value="{{ auditee_email | default_if_none:'' }}"/>
+                            </div>
+                        </fieldset>
+                    </fieldset>
+                    <fieldset class="usa-fieldset" id="primary-auditor-information">
+                        <legend class="usa-legend text-bold">
+                            Primary auditor information
+                        </legend>
+                        <p class="usa-hint">
+                            If multiple audit organizations worked on this audit, only include the lead or coordinating auditor's
+                            information.
+                        </p>
+                        <fieldset class="usa-fieldset">
+                            <legend class="usa-legend">
+                                Auditor details
+                            </legend>
+                            <div class="usa-form-group">
+                                <label class="usa-label" for="auditor_firm_name">
+                                    Audit firm/organization name
+                                    <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
+                                </label>
+                                <ul class="usa-error-message"
+                                    id="auditor_firm_name-error-message"
+                                    role="alert">
+                                    <li id="auditor_firm_name-not-null" hidden>
+                                        This field is required
+                                    </li>
+                                </ul>
+                                <input class="usa-input"
+                                       id="auditor_firm_name"
+                                       name="auditor_firm_name"
+                                       aria-required="true"
+                                       required
+                                       data-validate-not-null=""
+                                       value="{{ auditor_firm_name | default_if_none:'' }}"/>
+                            </div>
+                            <fieldset class="usa-fieldset" id="audit-firm-organization-address">
+                                <legend class="usa-legend">
+                                    Audit firm/organization address
+                                </legend>
+                                <div class="usa-form-group">
+                                    <label class="usa-label" for="auditor_country">
+                                        Country
+                                        <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
+                                    </label>
+                                    <ul class="usa-error-message"
+                                        id="auditor_country-error-message"
+                                        role="alert">
+                                        <li id="auditor_country-not-null" hidden>
+                                            This field is required
+                                        </li>
+                                    </ul>
+                                    <input class="usa-input"
+                                           id="auditor_country"
+                                           name="auditor_country"
+                                           aria-required="true"
+                                           required
+                                           data-validate-not-null=""
+                                           value="{{ auditor_country | default_if_none:'' }}"/>
+                                </div>
+                                <div class="usa-form-group">
+                                    <label class="usa-label" for="auditor_address_line_1">
+                                        Street
+                                        <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
+                                    </label>
+                                    <ul class="usa-error-message"
+                                        id="auditor_address_line_1-error-message"
+                                        role="alert">
+                                        <li id="auditor_address_line_1-not-null" hidden>
+                                            This field is required
+                                        </li>
+                                    </ul>
+                                    <input class="usa-input"
+                                           id="auditor_address_line_1"
+                                           name="auditor_address_line_1"
+                                           aria-required="true"
+                                           required
+                                           data-validate-not-null=""
+                                           value="{{ auditor_address_line_1 | default_if_none:'' }}"/>
+                                </div>
+                                <div class="usa-form-group">
+                                    <label class="usa-label" for="auditor_city">
+                                        City
+                                        <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
+                                    </label>
+                                    <ul class="usa-error-message"
+                                        id="auditor_city-error-message"
+                                        role="alert">
+                                        <li id="auditor_city-not-null" hidden>
+                                            This field is required
+                                        </li>
+                                    </ul>
+                                    <input class="usa-input"
+                                           id="auditor_city"
+                                           name="auditor_city"
+                                           aria-required="true"
+                                           required
+                                           data-validate-not-null=""
+                                           value="{{ auditor_city | default_if_none:'' }}"/>
+                                </div>
+                                <div class="usa-form-group">
+                                    <label class="usa-label" for="auditor_state">
+                                        State
+                                        <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
+                                    </label>
+                                    <ul class="usa-error-message"
+                                        id="auditor_state-error-message"
+                                        role="alert">
+                                        <li id="auditor_state-not-null" hidden>
+                                            This field is required
+                                        </li>
+                                    </ul>
+                                    <input class="usa-input"
+                                           id="auditor_state"
+                                           name="auditor_state"
+                                           aria-required="true"
+                                           required
+                                           data-validate-not-null=""
+                                           value="{{ auditor_state | default_if_none:'' }}"/>
+                                </div>
+                                <div class="usa-form-group">
+                                    <label class="usa-label" for="auditor_zip">
+                                        ZIP code
+                                        <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
+                                    </label>
+                                    <ul class="usa-error-message" id="auditor_zip-error-message" role="alert">
+                                        <li id="auditor_zip-not-null" hidden>
+                                            This field is required
+                                        </li>
+                                    </ul>
+                                    <input class="usa-input"
+                                           id="auditor_zip"
+                                           name="auditor_zip"
+                                           aria-required="true"
+                                           required
+                                           data-validate-not-null=""
+                                           value="{{ auditor_zip | default_if_none:'' }}"/>
+                                </div>
+                            </fieldset>
+                        </fieldset>
+                        <fieldset class="usa-fieldset">
+                            <legend class="usa-legend">
+                                Auditor EIN
+                            </legend>
+                            <div class="usa-form-group">
+                                <label class="usa-label" for="auditor_ein">
+                                    What is your audit firm/organization's EIN?
+                                    <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
+                                </label>
+                                <ul class="usa-error-message" id="auditor_ein-error-message" role="alert">
+                                    <li id="auditor_ein-not-null" hidden>
+                                        This field is required
+                                    </li>
+                                </ul>
+                                <input class="usa-input"
+                                       id="auditor_ein"
+                                       name="auditor_ein"
+                                       aria-required="true"
+                                       required
+                                       data-validate-not-null=""
+                                       value="{{ auditor_ein | default_if_none:'' }}"/>
+                            </div>
+                            <div class="usa-checkbox">
+                                <input class="usa-checkbox__input"
+                                       id="auditor_ein_not_an_ssn_attestation"
+                                       type="checkbox"
+                                       name="auditor_ein_not_an_ssn_attestation"
+                                       value=""
+                                       data-validate-not-null=""/>
+                                <label class="usa-checkbox__label" for="auditor_ein_not_an_ssn_attestation">
+                                    By checking this box, I verify that the Auditor EIN is not a Social Security Number.
+                                </label>
+                                <ul class="usa-error-message"
+                                    id="auditor_ein_not_an_ssn_attestation-error-message"
+                                    role="alert">
+                                    <li id="auditor_ein_not_an_ssn_attestation-not-null" hidden>
+                                        EIN may not be a social security number
+                                    </li>
+                                </ul>
+                            </div>
+                        </fieldset>
+                        <fieldset class="usa-fieldset">
+                            <legend class="usa-legend">
+                                Auditor contact information
+                            </legend>
+                            <div class="usa-form-group">
+                                <label class="usa-label" for="auditor_contact_name">
+                                    Auditor name
+                                    <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
+                                </label>
+                                <ul class="usa-error-message"
+                                    id="auditor_contact_name-error-message"
+                                    role="alert">
+                                    <li id="auditor_contact_name-not-null" hidden>
+                                        This field is required
+                                    </li>
+                                </ul>
+                                <input class="usa-input"
+                                       id="auditor_contact_name"
+                                       name="auditor_contact_name"
+                                       aria-required="true"
+                                       required
+                                       data-validate-not-null=""
+                                       value="{{ auditor_contact_name | default_if_none:'' }}"/>
+                            </div>
+                            <div class="usa-form-group">
+                                <label class="usa-label" for="auditor_contact_title">
+                                    Auditor title
+                                    <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
+                                </label>
+                                <ul class="usa-error-message"
+                                    id="auditor_contact_title-error-message"
+                                    role="alert">
+                                    <li id="auditor_contact_title-not-null" hidden>
+                                        This field is required
+                                    </li>
+                                </ul>
+                                <input class="usa-input"
+                                       id="auditor_contact_title"
+                                       name="auditor_contact_title"
+                                       aria-required="true"
+                                       required
+                                       data-validate-not-null=""
+                                       value="{{ auditor_contact_title | default_if_none:'' }}"/>
+                            </div>
+                            <div class="usa-form-group">
+                                <label class="usa-label" for="auditor_phone">
+                                    Auditor phone number
+                                    <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
+                                </label>
+                                <ul class="usa-error-message"
+                                    id="auditor_phone-error-message"
+                                    role="alert">
+                                    <li id="auditor_phone-not-null" hidden>
+                                        This field is required
+                                    </li>
+                                </ul>
+                                <input class="usa-input"
+                                       id="auditor_phone"
+                                       name="auditor_phone"
+                                       aria-required="true"
+                                       required
+                                       data-validate-not-null=""
+                                       value="{{ auditor_phone | default_if_none:'' }}"/>
+                            </div>
+                            <div class="usa-form-group">
+                                <label class="usa-label" for="auditor_email">
+                                    Auditor email<abbr title="required" class="usa-hint usa-hint--required">*</abbr>
+                                </label>
+                                <ul class="usa-error-message"
+                                    id="auditor_email-error-message"
+                                    role="alert">
+                                    <li id="auditor_email-not-null" hidden>
+                                        This field is required
+                                    </li>
+                                </ul>
+                                <input class="usa-input"
+                                       id="auditor_email"
+                                       name="auditor_email"
+                                       aria-required="true"
+                                       required
+                                       data-validate-not-null=""
+                                       value="{{ auditor_email | default_if_none:'' }}"/>
+                            </div>
+                        </fieldset>
+                    </fieldset>
+                    <button class="usa-button" id="continue">
+                        Save and continue to next section
+                    </button>
+                </fieldset>
+            </form>
+        </div>
+    </div>
+    <div class="audit-metadata">
+        <div class="grid-container">
+            <dl class="grid-row grid-gap">
+                <div class="tablet:grid-col-6">
+                    <dt>
+                        Entity name
+                    </dt>
+                    <dd>
+                        {{ auditee_name | default_if_none:'' }}
+                    </dd>
+                </div>
+                <div class="tablet:grid-col-6">
+                    <dt>
+                        Report ID
+                    </dt>
+                    <dd>
+                        #{{ report_id | default_if_none:'' }}
+                    </dd>
+                </div>
+                <div class="tablet:grid-col-6">
+                    <dt>
+                        UEI
+                    </dt>
+                    <dd>
+                        {{ auditee_uei | default_if_none:'' }}
+                    </dd>
+                </div>
+                <div class="tablet:grid-col-6">
+                    <dt>
+                        Type of entity
+                    </dt>
+                    <dd>
+                        {{ user_provided_organization_type | default_if_none:'' }}
+                    </dd>
+                </div>
+            </dl>
+        </div>
+    </div>
+    <script src="{% static 'compiled/js/sf-sac.js' %}"></script>
+{% endblock content %}

--- a/backend/report_submission/templates/sidenav.html
+++ b/backend/report_submission/templates/sidenav.html
@@ -1,42 +1,43 @@
 <!-- Side navigation menu. Highlights based on current URL should be added as URLs are determined. -->
-<nav class="desktop:grid-col-3 sticky-nav" aria-label="Secondary navigation">
+<nav class="desktop:grid-col-3 sticky-nav"
+     aria-label="Secondary navigation">
     <ul class="usa-sidenav margin-bottom-6">
-      <li class="usa-sidenav__item">
-        <a href="#" class="">General information</a>
-      </li>
-      <li class="usa-sidenav__item">
-        {% if 'federal-awards' in request.path %}
-            <a href="#federal-awards" class="usa-current">Federal Awards</a>
-        {% else %}
-            <a href="#federal-awards" class="">Federal Awards</a>
-        {% endif %}
-      </li>
-      <li class="usa-sidenav__item">
-        <a href="#" class="">Notes to SEFA</a>
-      </li>
-      <li class="usa-sidenav__item">
-        <a href="#" class="">Audit information</a>
-      </li>
-      <li class="usa-sidenav__item">
-        <a href="#" class="">Audit findings</a>
-      </li>
-      <li class="usa-sidenav__item">
-        <a href="#" class="">Findings text</a>
-      </li>
-      <li class="usa-sidenav__item">
-        <a href="#" class="">CAP text</a>
-      </li>
-      <li class="usa-sidenav__item">
-        <a href="#" class="">Additional EINs</a>
-      </li>
-      <li class="usa-sidenav__item">
-        <a href="#" class="">Additional UEIs</a>
-      </li>
-      <li class="usa-sidenav__item">
-        <a href="#" class="">Secondary auditors</a>
-      </li>
-      <li class="usa-sidenav__item">
-        <a href="#" class="">Finalize</a>
-      </li>
+        <li class="usa-sidenav__item">
+            <a href="#" class="">General information</a>
+        </li>
+        <li class="usa-sidenav__item">
+            {% if 'federal-awards' in request.path %}
+                <a href="#federal-awards" class="usa-current">Federal Awards</a>
+            {% else %}
+                <a href="#federal-awards" class="">Federal Awards</a>
+            {% endif %}
+        </li>
+        <li class="usa-sidenav__item">
+            <a href="#" class="">Notes to SEFA</a>
+        </li>
+        <li class="usa-sidenav__item">
+            <a href="#" class="">Audit information</a>
+        </li>
+        <li class="usa-sidenav__item">
+            <a href="#" class="">Audit findings</a>
+        </li>
+        <li class="usa-sidenav__item">
+            <a href="#" class="">Findings text</a>
+        </li>
+        <li class="usa-sidenav__item">
+            <a href="#" class="">CAP text</a>
+        </li>
+        <li class="usa-sidenav__item">
+            <a href="#" class="">Additional EINs</a>
+        </li>
+        <li class="usa-sidenav__item">
+            <a href="#" class="">Additional UEIs</a>
+        </li>
+        <li class="usa-sidenav__item">
+            <a href="#" class="">Secondary auditors</a>
+        </li>
+        <li class="usa-sidenav__item">
+            <a href="#" class="">Finalize</a>
+        </li>
     </ul>
-  </nav>
+</nav>

--- a/backend/report_submission/templates/sidenav.html
+++ b/backend/report_submission/templates/sidenav.html
@@ -1,0 +1,42 @@
+<!-- Side navigation menu. Highlights based on current URL should be added as URLs are determined. -->
+<nav class="desktop:grid-col-3 sticky-nav" aria-label="Secondary navigation">
+    <ul class="usa-sidenav margin-bottom-6">
+      <li class="usa-sidenav__item">
+        <a href="#" class="">General information</a>
+      </li>
+      <li class="usa-sidenav__item">
+        {% if 'federal-awards' in request.path %}
+            <a href="#federal-awards" class="usa-current">Federal Awards</a>
+        {% else %}
+            <a href="#federal-awards" class="">Federal Awards</a>
+        {% endif %}
+      </li>
+      <li class="usa-sidenav__item">
+        <a href="#" class="">Notes to SEFA</a>
+      </li>
+      <li class="usa-sidenav__item">
+        <a href="#" class="">Audit information</a>
+      </li>
+      <li class="usa-sidenav__item">
+        <a href="#" class="">Audit findings</a>
+      </li>
+      <li class="usa-sidenav__item">
+        <a href="#" class="">Findings text</a>
+      </li>
+      <li class="usa-sidenav__item">
+        <a href="#" class="">CAP text</a>
+      </li>
+      <li class="usa-sidenav__item">
+        <a href="#" class="">Additional EINs</a>
+      </li>
+      <li class="usa-sidenav__item">
+        <a href="#" class="">Additional UEIs</a>
+      </li>
+      <li class="usa-sidenav__item">
+        <a href="#" class="">Secondary auditors</a>
+      </li>
+      <li class="usa-sidenav__item">
+        <a href="#" class="">Finalize</a>
+      </li>
+    </ul>
+  </nav>

--- a/backend/report_submission/urls.py
+++ b/backend/report_submission/urls.py
@@ -16,4 +16,9 @@ urlpatterns = [
         views.GeneralInformationFormView.as_view(),
         name="general_information",
     ),
+    path(
+        "federal-awards/<str:report_id>",
+        views.FederalAwards.as_view(),
+        name="federal_awards",
+    ),
 ]

--- a/backend/report_submission/views.py
+++ b/backend/report_submission/views.py
@@ -5,12 +5,11 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.exceptions import BadRequest, PermissionDenied, ValidationError
 from django.shortcuts import render, redirect
 from django.urls import reverse
-from django.utils.datastructures import MultiValueDictKeyError
 from django.views import View
 
 from audit.excel import extract_federal_awards
-from audit.models import Access, ExcelFile, SingleAuditChecklist
-from audit.validators import validate_general_information_json, validate_federal_award_json
+from audit.models import Access, SingleAuditChecklist
+from audit.validators import validate_general_information_json
 
 from report_submission.forms import GeneralInformationForm
 

--- a/backend/report_submission/views.py
+++ b/backend/report_submission/views.py
@@ -7,7 +7,6 @@ from django.shortcuts import render, redirect
 from django.urls import reverse
 from django.views import View
 
-from audit.excel import extract_federal_awards
 from audit.models import Access, SingleAuditChecklist
 from audit.validators import validate_general_information_json
 

--- a/backend/report_submission/views.py
+++ b/backend/report_submission/views.py
@@ -210,6 +210,6 @@ class FederalAwards(LoginRequiredMixin, View):
             return redirect(reverse("/"))
 
         except Exception as e:
-            logger.info(f"Unexpected error in FederalAwards post.")
+            logger.info("Unexpected error in FederalAwards post.\n", e)
 
         raise BadRequest()

--- a/backend/report_submission/views.py
+++ b/backend/report_submission/views.py
@@ -171,7 +171,9 @@ class GeneralInformationFormView(LoginRequiredMixin, View):
                     general_information=general_information
                 )
 
-                return redirect("/report_submission/federal-awards/{}".format(report_id))
+                return redirect(
+                    "/report_submission/federal-awards/{}".format(report_id)
+                )
         except SingleAuditChecklist.DoesNotExist:
             raise PermissionDenied("You do not have access to this audit.")
         except ValidationError as e:

--- a/backend/report_submission/views.py
+++ b/backend/report_submission/views.py
@@ -179,6 +179,7 @@ class GeneralInformationFormView(LoginRequiredMixin, View):
 
         raise BadRequest()
 
+
 class FederalAwards(LoginRequiredMixin, View):
     def get(self, request, *args, **kwargs):
         report_id = kwargs["report_id"]

--- a/backend/static/js/federal-awards.js
+++ b/backend/static/js/federal-awards.js
@@ -1,0 +1,23 @@
+const FORM = document.forms[0];
+const fileupload = document.getElementById('file-input-federal-awards-xlsx');
+
+function setFormEnabled(shouldEnable) {
+    const continueBtn = document.getElementById('continue');
+    continueBtn.disabled = !shouldEnable;
+}
+
+function attachEventHandlers() {
+    setFormEnabled(false)
+
+    fileupload.addEventListener('change', (e) => {
+        console.log(e)
+        // FORM.submit();
+        setFormEnabled(true)
+    });
+}
+
+function init() {
+    attachEventHandlers();
+}
+  
+init();

--- a/backend/static/js/federal-awards.js
+++ b/backend/static/js/federal-awards.js
@@ -1,4 +1,3 @@
-const FORM = document.forms[0];
 const fileupload = document.getElementById('file-input-federal-awards-xlsx');
 
 function setFormEnabled(shouldEnable) {

--- a/backend/static/js/federal-awards.js
+++ b/backend/static/js/federal-awards.js
@@ -2,22 +2,37 @@ const FORM = document.forms[0];
 const fileupload = document.getElementById('file-input-federal-awards-xlsx');
 
 function setFormEnabled(shouldEnable) {
-    const continueBtn = document.getElementById('continue');
-    continueBtn.disabled = !shouldEnable;
+  const continueBtn = document.getElementById('continue');
+  continueBtn.disabled = !shouldEnable;
 }
 
 function attachEventHandlers() {
-    setFormEnabled(false)
+  setFormEnabled(false);
 
-    fileupload.addEventListener('change', (e) => {
-        console.log(e)
-        // FORM.submit();
-        setFormEnabled(true)
+  fileupload.addEventListener('change', (e) => {
+    const sac_id = JSON.parse(document.getElementById('sac_id').textContent);
+
+    var data = new FormData();
+    data.append('FILES', e.target.files[0]);
+    data.append('filename', e.target.files[0].name);
+    data.append('sac_id', sac_id);
+
+    fetch(`/audit/excel/${sac_id}`, {
+      method: 'POST',
+      body: data,
+    }).then((response) => {
+      if (response.status == 200) {
+        console.log('Excel file successfully validated.');
+        setFormEnabled(true);
+      } else {
+        console.error('Error when validating excel file.\n', response);
+      }
     });
+  });
 }
 
 function init() {
-    attachEventHandlers();
+  attachEventHandlers();
 }
-  
+
 init();

--- a/backend/templates/includes/nav_primary.html
+++ b/backend/templates/includes/nav_primary.html
@@ -3,7 +3,7 @@
     <div class="usa-navbar">
         <div class="usa-logo" id="basic-logo">
             <em class="usa-logo__text">
-                <a href="javascript:void(0)" title="FAC.gov">
+                <a href="/" title="FAC.gov">
                     <strong>FAC</strong>.gov
                 </a>
             </em>


### PR DESCRIPTION
Relevant to issue https://github.com/GSA-TTS/FAC/issues/945

Implemented the fairly bare bones federal awards upload page. Now,
1. Completing the general info form links to the federal awards upload page
2. You can upload an excel doc and it will shoot off for verification, which can be seen in the docker console
 a. If it fails, a 500 error status comes back, which is visible in the browser console
 b. If it succeeds, a 200 success status comes back, which enables the "save and continue" button

Next steps are to show meaningful content on the front end based on what comes back in that error response.

Example screenshots:
![image](https://user-images.githubusercontent.com/91098850/231202976-e9f8d955-5845-4ea6-98bc-fc2d78851c1c.png)
![image](https://user-images.githubusercontent.com/91098850/231202992-ac18f32c-2269-4f33-8067-2d356a6d0b17.png)

