### PR TITLE
Adding a script to migrate public PDFs to the public bucket

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -323,6 +323,14 @@ else:
     # Will not be enabled in cloud environments
     DISABLE_AUTH = False
 
+# Remove once all Census data has been migrated
+# Add these as env vars, look at the bucket for values
+AWS_CENSUS_ACCESS_KEY_ID = secret("AWS_CENSUS_ACCESS_KEY_ID", "")
+AWS_CENSUS_SECRET_ACCESS_KEY = secret("AWS_CENSUS_SECRET_ACCESS_KEY", "")
+AWS_CENSUS_STORAGE_BUCKET_NAME = secret("AWS_CENSUS_STORAGE_BUCKET_NAME", "")
+AWS_S3_CENSUS_REGION_NAME = secret("AWS_S3_CENSUS_REGION_NAME", "")
+
+
 ADMIN_URL = "admin/"
 
 # Default primary key field type

--- a/backend/data_distro/management/commands/add_pdfs.py
+++ b/backend/data_distro/management/commands/add_pdfs.py
@@ -1,0 +1,114 @@
+import os
+import logging
+import boto3
+from botocore.exceptions import ClientError
+
+from django.core.management.base import BaseCommand
+from django.conf import settings
+
+from data_distro import models as mods
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = """
+    Moves PDFs from source bucket to the bucket in the env.
+
+    To run the script, add the Census AWS values to the environment.
+    In cloud.gov use UUPS, you will need to include the existing env in
+    the commands https://cli.cloudfoundry.org/en-US/v6/update-user-provided-service.html.
+
+    Then, you can run the script by pushing a task runner to cloud.gov and giving ith the add_pdfs
+    management command.
+
+    Update public_doc_query once we know how to determine the mapping of records to PDFs.
+    Create a private_doc_query() and call add_to_private() for non-public PDFs.
+    """
+
+    def handle(self, *args, **kwargs):
+        public_doc_records = public_doc_query()
+        for doc in public_doc_records:
+            pdf_name = doc["pdf_name"]
+            # We don't want to delete the original so we are not moving and we can't rename and copy at the same time
+            try:
+                temp_name = grab_doc(pdf_name)
+                add_me = True
+            except ClientError:
+                add_me = False
+                logger.error(f"DOWNLOAD FAILED: {pdf_name}")
+
+            if add_me is True:
+                url = add_to_public(
+                    pdf_name, doc["audit_year"], doc["dbkey"], temp_name
+                )
+                add_to_model(doc["id"], url)
+
+
+def public_doc_query():
+    # UPDATE THIS to mapping of PDF url
+    # Filter out records that already have pdfs
+    # records = mods.General.objects.filter(is_public=True).values('audit_year', 'dbkey', 'id')
+
+    # Bogus Test record
+    test_records = [
+        {
+            "audit_year": "2022",
+            "dbkey": "101786",
+            "pdf_name": "1002792007.pdf",
+            "id": 1,
+        }
+    ]
+    return test_records
+
+
+def grab_doc(pdf_name):
+    temp_name = "data_distro/data_to_load/{}".format(pdf_name)
+    census_bucket = settings.AWS_CENSUS_STORAGE_BUCKET_NAME
+    AWS_S3_CREDS = {
+        "aws_access_key_id": settings.AWS_CENSUS_ACCESS_KEY_ID,
+        "aws_secret_access_key": settings.AWS_CENSUS_SECRET_ACCESS_KEY,
+        "region_name": settings.AWS_S3_CENSUS_REGION_NAME,
+    }
+    s3 = boto3.client("s3", **AWS_S3_CREDS)
+    s3.download_file(census_bucket, pdf_name, temp_name)
+
+    return temp_name
+
+
+def add_to_public(pdf_name, audit_year, dbkey, temp_name):
+    public_bucket = settings.AWS_STORAGE_BUCKET_NAME
+    AWS_S3_CREDS = {
+        "aws_access_key_id": settings.AWS_ACCESS_KEY_ID,
+        "aws_secret_access_key": settings.AWS_SECRET_ACCESS_KEY,
+        "region_name": settings.AWS_S3_REGION_NAME,
+    }
+    s3_client = boto3.client("s3", **AWS_S3_CREDS)
+    new_file_name = f"collections/{audit_year}/pdf/{dbkey}-{pdf_name}"
+    s3_client.upload_file(temp_name, public_bucket, new_file_name)
+    os.remove(new_file_name)
+
+    url = f"https://{public_bucket}.s3.{settings.AWS_S3_REGION_NAME}.amazonaws.com/{new_file_name}"
+    return url
+
+
+def add_to_private(pdf_name, audit_year, dbkey, temp_name):
+    private_bucket = settings.AWS_PRIVATE_STORAGE_BUCKET_NAME
+    AWS_S3_CREDS = {
+        "aws_access_key_id": settings.AWS_PRIVATE_ACCESS_KEY_ID,
+        "aws_secret_access_key": settings.AWS_PRIVATE_SECRET_ACCESS_KEY,
+        "region_name": settings.AWS_S3_PRIVATE_REGION_NAME,
+    }
+    s3_client = boto3.client("s3", **AWS_S3_CREDS)
+    new_file_name = f"collections/{audit_year}/pdf/{dbkey}-{pdf_name}"
+    s3_client.upload_file(temp_name, private_bucket, new_file_name)
+    os.remove(new_file_name)
+
+    url = f"https://{private_bucket}.s3.{settings.AWS_S3_PRIVATE_REGION_NAME}.amazonaws.com/{new_file_name}"
+    return url
+
+
+def add_to_model(id, url):
+    record = mods.General.objects.get(id=id)
+    record.pdf_urls = [url]
+    record.save()

--- a/backend/data_distro/models.py
+++ b/backend/data_distro/models.py
@@ -545,6 +545,7 @@ class Note(models.Model):
         max_length=40,
         help_text=docs.dbkey_notes,
     )
+    # consider changing these to numeric
     audit_year = models.CharField(
         "Audit Year and DBKEY (database key) combined make up the primary key.",
         max_length=40,

--- a/backend/manifests/task-manifest-staging.yml
+++ b/backend/manifests/task-manifest-staging.yml
@@ -11,12 +11,12 @@ applications:
     ENV: STAGING
     DJANGO_BASE_URL: https://fac-staging.app.cloud.gov
   services:
-  - fac-db-new
+  - fac-db
   - fac-public-s3
   - fac-key-service
   command: (python manage.py public_data_loader -y 20 && echo SUCCESS || echo TASK_FAIL) && sleep infinity
 
   # run with
-  # cf push -f manifests/task-manifest-staging.yaml --no-route
+  # cf push -f manifests/task-manifest-staging.yml --no-route
   #
   # This is an example task, you can modify the command to run other tasks

--- a/docs/data_loading.md
+++ b/docs/data_loading.md
@@ -52,3 +52,6 @@ Example commits where we updated names for [fields](https://github.com/GSA-TTS/F
 ## Update docs
 
 Create an updated csv data dictionary and add comments to the fields in postgres. Do that by running `manage.py create_docs`.
+
+# Upload PDFs
+Once we confirm we have all the PDFs and have data to link PDFs to their record, we can load PDFs to their respective public and private buckets. I created a management command that does the loading. You will need to update the logic to query for the id of the general record and the name of the PDF file. 


### PR DESCRIPTION
- Creates the scaffolding to upload PDFs to public and private buckets, once we have a mapping, we will be able to update so that we pull the records we need.
- Upload and add to model framework for PDF workflows
- Add documentation on how to modify the script once we have the data we need