### PR TITLE
Restore BPMN checks

### DIFF
--- a/.github/workflows/triggers-PR.yml
+++ b/.github/workflows/triggers-PR.yml
@@ -5,8 +5,10 @@ on:
     branches:
       - main
       - prod
-    paths-ignore:
-      - 'docs/**'
+    paths:
+      - '**'
+      - '!docs/**'
+      - 'docs/bpmn-workflow-models/**'
   workflow_dispatch: null
 
 jobs:


### PR DESCRIPTION
We want to ignore _most_ documentation changes, but BPMN source changes should trigger diagram updates, for example. 

This commit flips our trigger from using `paths-ignore:` to `paths:` to enable more flexible specification of exceptions. [See docs on this pattern here.](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-and-excluding-paths)