### PR TITLE
Fix progress indicator in pre-SAC steps

### DIFF
--- a/backend/report_submission/templates/report_submission/step-base.html
+++ b/backend/report_submission/templates/report_submission/step-base.html
@@ -18,7 +18,7 @@
                  aria-label="Form progress"
                  aria-valuemin="1"
                  aria-valuemax="4"
-                 aria-valuenow="2">
+                 aria-valuenow="{{ step }}">
                 <ol class="usa-step-indicator__segments">
                     <li class="usa-step-indicator__segment {% if step|add:'0' == 1 %} usa-step-indicator__segment--current {% endif %} {% if step|add:'0' > 1 %} usa-step-indicator__segment--complete {% endif %} ">
                         <span class="usa-step-indicator__segment-label">

--- a/backend/report_submission/templates/report_submission/step-base.html
+++ b/backend/report_submission/templates/report_submission/step-base.html
@@ -29,10 +29,10 @@
                     <li class="usa-step-indicator__segment {% if step|add:'0' == 2 %} usa-step-indicator__segment--current {% endif %} {% if step|add:'0' > 2 %} usa-step-indicator__segment--complete {% endif %} ">
                         <span class="usa-step-indicator__segment-label">Auditee information</span>
                     </li>
-                    <li class="usa-step-indicator__segment  ">
+                    <li class="usa-step-indicator__segment {% if step|add:'0' == 3 %} usa-step-indicator__segment--current {% endif %} {% if step|add:'0' > 3 %} usa-step-indicator__segment--complete {% endif %}  ">
                         <span class="usa-step-indicator__segment-label">Audit submission access</span>
                     </li>
-                    <li class="usa-step-indicator__segment {% if step|add:'0' == 3 %} usa-step-indicator__segment--current {% endif %} {% if step|add:'0' > 3 %} usa-step-indicator__segment--complete {% endif %}  ">
+                    <li class="usa-step-indicator__segment">
                         <span class="usa-step-indicator__segment-label">Create new audit</span>
                     </li>
                 </ol>

--- a/backend/report_submission/views.py
+++ b/backend/report_submission/views.py
@@ -25,7 +25,9 @@ class ReportSubmissionRedirectView(View):
 # Step 1
 class EligibilityFormView(LoginRequiredMixin, View):
     def get(self, request):
-        return render(request, "report_submission/step-1.html")
+        args = {}
+        args['step'] = 1
+        return render(request, "report_submission/step-1.html", args)
 
     # render eligibility form
 
@@ -42,7 +44,9 @@ class EligibilityFormView(LoginRequiredMixin, View):
 # Step 2
 class AuditeeInfoFormView(LoginRequiredMixin, View):
     def get(self, request):
-        return render(request, "report_submission/step-2.html")
+        args = {}
+        args['step'] = 2
+        return render(request, "report_submission/step-2.html", args)
 
     # render auditee info form
 
@@ -80,7 +84,9 @@ class AuditeeInfoFormView(LoginRequiredMixin, View):
 # Step 3
 class AccessAndSubmissionFormView(LoginRequiredMixin, View):
     def get(self, request):
-        return render(request, "report_submission/step-3.html")
+        args = {}
+        args['step'] = 3
+        return render(request, "report_submission/step-3.html", args)
 
     # render access-submission form
 

--- a/backend/report_submission/views.py
+++ b/backend/report_submission/views.py
@@ -26,7 +26,7 @@ class ReportSubmissionRedirectView(View):
 class EligibilityFormView(LoginRequiredMixin, View):
     def get(self, request):
         args = {}
-        args['step'] = 1
+        args["step"] = 1
         return render(request, "report_submission/step-1.html", args)
 
     # render eligibility form
@@ -45,7 +45,7 @@ class EligibilityFormView(LoginRequiredMixin, View):
 class AuditeeInfoFormView(LoginRequiredMixin, View):
     def get(self, request):
         args = {}
-        args['step'] = 2
+        args["step"] = 2
         return render(request, "report_submission/step-2.html", args)
 
     # render auditee info form
@@ -85,7 +85,7 @@ class AuditeeInfoFormView(LoginRequiredMixin, View):
 class AccessAndSubmissionFormView(LoginRequiredMixin, View):
     def get(self, request):
         args = {}
-        args['step'] = 3
+        args["step"] = 3
         return render(request, "report_submission/step-3.html", args)
 
     # render access-submission form


### PR DESCRIPTION
This PR ensures that the current ordinal step of the pre-SAC flow is passed to the appropriate template, allowing the process list component to correctly show the user's progress through the steps.

Fixes #954

<img width="445" alt="image" src="https://user-images.githubusercontent.com/6290/232519005-b3d970b8-6eeb-4541-aeed-3c4504910a80.png">
<img width="460" alt="image" src="https://user-images.githubusercontent.com/6290/232519330-d95023b6-154c-4629-8345-ca99f035b71b.png">
<img width="604" alt="image" src="https://user-images.githubusercontent.com/6290/232520260-23b55c92-ccd1-4466-aa05-d05b32eec42b.png">
