### PR TITLE
Fix `data_distro` migration error

### DIFF
--- a/backend/data_distro/migrations/0032_update_API.py
+++ b/backend/data_distro/migrations/0032_update_API.py
@@ -10,13 +10,6 @@ from django.core.management import call_command
 
 
 def update_docs_and_views(apps, schema_editor):
-    """Runs our management command to add documentation to sql"""
-    call_command(
-        "create_docs",
-        stdout="",
-        stderr=StringIO(),
-    )
-
     # Recreating the API views where the names were updated
     call_command(
         "create_distro_api",
@@ -30,6 +23,13 @@ def update_docs_and_views(apps, schema_editor):
         stdout="",
         stderr=StringIO(),
         **{"file": "sql_migrations/003_findings.sql"},
+    )
+
+    """Runs our management command to add documentation to sql"""
+    call_command(
+        "create_docs",
+        stdout="",
+        stderr=StringIO(),
     )
 
     # Adding high-level docs for the views


### PR DESCRIPTION
Names are important
And renaming doubly so—
But order matters

-----




When rebuilding our local Docker environments from scratch, both Tim and I ran into the following error when trying to apply migration 0032 in `data_distro`:

```
backend-web-1          |   Applying data_distro.0031_rename_seqence_number_to_sequence_number... OK
backend-db-1           | 2023-04-17 17:39:46.248 UTC [178] ERROR:  column "sequence_number" of relation "api.vw_auditor" does not exist
backend-db-1           | 2023-04-17 17:39:46.248 UTC [178] STATEMENT:  COMMENT ON COLUMN api.vw_auditor."sequence_number" is 'Order that Auditors were reported on page 5 of SF-SAC (only for secondary_auditors)   Census mapping: GENERAL, SEQNUM (AND) Census mapping: MULTIPLE CPAS INFO, SEQNUM';
backend-web-1          |   Applying data_distro.0032_update_API...Traceback (most recent call last):
backend-web-1          |   File "/src/manage.py", line 22, in <module>
backend-web-1          |     main()
backend-web-1          |   File "/src/manage.py", line 18, in main
backend-web-1          |     execute_from_command_line(sys.argv)
backend-web-1          |   File "/usr/local/lib/python3.10/site-packages/django/core/management/__init__.py", line 446, in execute_from_command_line
backend-web-1          |     utility.execute()
backend-web-1          |   File "/usr/local/lib/python3.10/site-packages/django/core/management/__init__.py", line 440, in execute
backend-web-1          |     self.fetch_command(subcommand).run_from_argv(self.argv)
backend-web-1          |   File "/usr/local/lib/python3.10/site-packages/django/core/management/base.py", line 402, in run_from_argv
backend-web-1          |     self.execute(*args, **cmd_options)
backend-web-1          |   File "/usr/local/lib/python3.10/site-packages/django/core/management/base.py", line 448, in execute
backend-web-1          |     output = self.handle(*args, **options)
backend-web-1          |   File "/usr/local/lib/python3.10/site-packages/django/core/management/base.py", line 96, in wrapped
backend-web-1          |     res = handle_func(*args, **kwargs)
backend-web-1          |   File "/usr/local/lib/python3.10/site-packages/django/core/management/commands/migrate.py", line 349, in handle
backend-web-1          |     post_migrate_state = executor.migrate(
backend-web-1          |   File "/usr/local/lib/python3.10/site-packages/django/db/migrations/executor.py", line 135, in migrate
backend-web-1          |     state = self._migrate_all_forwards(
backend-web-1          |   File "/usr/local/lib/python3.10/site-packages/django/db/migrations/executor.py", line 167, in _migrate_all_forwards
backend-web-1          |     state = self.apply_migration(
backend-web-1          |   File "/usr/local/lib/python3.10/site-packages/django/db/migrations/executor.py", line 252, in apply_migration
backend-web-1          |     state = migration.apply(state, schema_editor)
backend-web-1          |   File "/usr/local/lib/python3.10/site-packages/django/db/migrations/migration.py", line 130, in apply
backend-web-1          |     operation.database_forwards(
backend-web-1          |   File "/usr/local/lib/python3.10/site-packages/django/db/migrations/operations/special.py", line 193, in database_forwards
backend-web-1          |     self.code(from_state.apps, schema_editor)
backend-web-1          |   File "/src/data_distro/migrations/0032_update_API.py", line 14, in update_docs_and_views
backend-web-1          |     call_command(
backend-web-1          |   File "/usr/local/lib/python3.10/site-packages/django/core/management/__init__.py", line 198, in call_command
backend-web-1          |     return command.execute(*args, **defaults)
backend-web-1          |   File "/usr/local/lib/python3.10/site-packages/django/core/management/base.py", line 448, in execute
backend-web-1          |     output = self.handle(*args, **options)
backend-web-1          |   File "/src/data_distro/management/commands/create_docs.py", line 22, in handle
backend-web-1          |     create_sql_comments(distro_classes, definations)
backend-web-1          |   File "/src/data_distro/management/commands/create_docs.py", line 154, in create_sql_comments
backend-web-1          |     curs.execute(
backend-web-1          | psycopg2.errors.UndefinedColumn: column "sequence_number" of relation "api.vw_auditor" does not exist
```

This appears to be due to a renaming of `seqence_number` to `sequence_number`, which is applied to the Django model (and its corresponding Postgres table) in the 0031 migration. That migration does not however recreate the `api.va_auditor` view, which happens in the 0032 migration. But in 0032, the `create_docs` command is invoked prior to the recreation of the views, so the documentation creation process is trying to find every field in the Django model in the Postgres table, but `sequence_number` has not yet been created in the view, because the views haven’t yet been recreated from the model that has the correct `sequence_number` spelling.

Rearranging the order of the commands in the 0032 migration appears to solve this problem.

It’s not clear to me why this error hasn’t shown up in any of our deploys, but rather only locally, and, even then, only after complete volume rebuilds.
