### PR TITLE
Remove spurious dependency on deployer service

### DIFF
--- a/backend/manifests/manifest-fac.yml
+++ b/backend/manifests/manifest-fac.yml
@@ -19,4 +19,3 @@ applications:
       - fac-db
       - fac-public-s3
       - fac-key-service
-      - ((service_name))-deployer


### PR DESCRIPTION
The FAC app doesn't need to manipulate other apps or services in the space on cloud.gov, so it shouldn't be bound to the deployer credential service instance.