### PR TITLE
Revert "Merge pull request #1060 from GSA-TTS/1015-create-egress-spaces"

### DIFF
--- a/.github/workflows/terraform-apply-env.yml
+++ b/.github/workflows/terraform-apply-env.yml
@@ -20,8 +20,7 @@ jobs:
       TF_VAR_cf_password: ${{ secrets.CF_PASSWORD }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       TERRAFORM_PRE_RUN: |
-          apt-get update
-          apt-get install -y zip
+          echo any precursor steps go here, eg installing CLIs
 
     steps:
       - name: checkout

--- a/.github/workflows/terraform-plan-env.yml
+++ b/.github/workflows/terraform-plan-env.yml
@@ -20,8 +20,7 @@ jobs:
       TF_VAR_cf_password: ${{ secrets.CF_PASSWORD }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       TERRAFORM_PRE_RUN: |
-          apt-get update
-          apt-get install -y zip
+          echo any precursor steps go here, eg installing CLIs
 
     steps:
       - name: checkout

--- a/terraform/management/main.tf
+++ b/terraform/management/main.tf
@@ -8,55 +8,22 @@ data "cloudfoundry_asg" "asgs" {
   name     = each.key
 }
 
-locals {
-  egress_spaces = [for s in local.spaces : "${s}-egress"]
-  all_spaces    = setunion(local.spaces, local.egress_spaces)
-}
-
 # Ensure spaces exist
 resource "cloudfoundry_space" "space" {
-  for_each = toset(local.all_spaces)
+  for_each = toset(local.spaces)
   name     = each.key
   org      = data.cloudfoundry_org.org.id
 
-  # Disallow SSH access in production and production-egress
-  allow_ssh = (each.key != "production" && each.key != "production-egress")
+  # Disallow SSH access in production
+  allow_ssh = each.key != "production"
 
   asgs = [for d in data.cloudfoundry_asg.asgs : d.id]
 }
 
-# Grant the expected people access
 resource "cloudfoundry_space_users" "space_permissions" {
-  for_each   = toset(local.all_spaces)
+  for_each   = toset(local.spaces)
   space      = cloudfoundry_space.space[each.key].id
   developers = local.developers
   managers   = local.managers
 }
 
-### 
-# Ensure a deployer account exists in each space, and that it has the
-# SpaceDeveloper role on the corresponding -egress space
-###
-
-data "cloudfoundry_service" "service-account" {
-  name = "cloud-gov-service-account"
-}
-
-resource "cloudfoundry_service_instance" "space-deployer" {
-  for_each     = toset(local.spaces)
-  name         = "${each.key}-deployer"
-  space        = cloudfoundry_space.space[each.key].id
-  service_plan = "space-deployer"
-}
-
-resource "cloudfoundry_service_key" "space-deployer-key" {
-  for_each         = toset(local.spaces)
-  name             = "${each.key}-deployer-key"
-  service_instance = cloudfoundry_service_instance.space-deployer[each.key].id
-}
-
-resource "cloudfoundry_space_users" "egress-deployer" {
-  for_each   = toset(local.spaces)
-  space      = cloudfoundry_space.space["${each.key}-egress"].id
-  developers = [cloudfoundry_service_key.space-deployer-key[each.key].credentials.username]
-}


### PR DESCRIPTION
We merged #1060 trying to unblock #1059, but it failed to deploy from `main` to `dev` for Reasons. We then chose the alternative of removing the dependency on the deployer account in https://github.com/GSA-TTS/FAC/pull/1061 to unblock #1059 and merged that. However, _that_ PR also failed to deploy because it was based on #1060 and the root cause of the failed deploy there was not yet resolved.

This reverts commit 74a405149ffeb7fc04b27d422ebbc6b39003a885, reversing changes made to acd0da7472ba90edf1a3d505f036dab53b045ec8, effectively rolling #1060 back out of `main` until we have restored sanity and enabled deployment of non-infra-related branches.

