### PR TITLE
Fix bad forwardproxy acl pattern

### DIFF
--- a/terraform/shared/modules/env-egress/env-egress.tf
+++ b/terraform/shared/modules/env-egress/env-egress.tf
@@ -16,7 +16,12 @@ module "egress-proxy" {
       "api.sam.gov:443",
 
       # New Relic telemetry (https://docs.newrelic.com/docs/new-relic-solutions/get-started/networks/#data-ingest)
-      "collector*.newrelic.com:443", "*-api.newrelic.com:443"
+      # 
+      # Note: New Relic says that APM agent data ingests via `collector*.newrelic.com`, but we can't specify that
+      # to the Caddy forwardproxy (https://github.com/caddyserver/forwardproxy/blob/caddy2/README.md#access-control)
+      # because it only allows subdomain wildcards in `*.` as a prefix. So this wildcard is a little broader than
+      # we would prefer, but realistically the tightest domain mask we can specify given our current solution.
+      "*.newrelic.com:443",
     ],
   }
   denylist = {}


### PR DESCRIPTION
Addresses an error when bringing up the reconfigured `egress-proxy` during deploy:
```
2023-05-04T18:10:04.94+0000 [APP/PROC/WEB/0] ERR run: loading initial config: loading new config: loading http app module: provision http: server srv0: setting up route handlers: route 0: loading handler modules: position 0: loading module 'subroute': provision http.handlers.subroute: setting up subroutes: route 0: loading handler modules: position 0: loading module 'forward_proxy': provision http.handlers.forward_proxy: *-api.newrelic.com could not be parsed as either IP, IP network, or domain: character * is not allowed
```

See comments in the PR for what's happening here.