### PR TITLE
Certification workflow cleanup

### DIFF
--- a/backend/audit/models.py
+++ b/backend/audit/models.py
@@ -179,7 +179,7 @@ class SingleAuditChecklist(models.Model):
 
     @transition(
         field="submission_status",
-        source=STATUS.CERTIFIED,
+        source=[STATUS.AUDITEE_CERTIFIED, STATUS.CERTIFIED],
         target=STATUS.SUBMITTED,
     )
     def transition_to_submitted(self):

--- a/backend/audit/templates/audit/submission-progress.html
+++ b/backend/audit/templates/audit/submission-progress.html
@@ -35,14 +35,14 @@
   </div>
   <div class="grid-row grid-gap">
     <div class="usa-checkbox">
-      <input type="checkbox" disabled {% if certification.auditee_certified is True %}checked{% endif %} />
-      <a href="{% url 'audit:AuditeeCertification' report_id=report_id %}">Auditee Certification</a>
+      <input type="checkbox" disabled {% if certification.auditor_certified is True %}checked{% endif %} />
+      <a href="{% url 'audit:AuditorCertification' report_id=report_id %}">Auditor Certification</a>
     </div>
   </div>
   <div class="grid-row grid-gap">
     <div class="usa-checkbox">
-      <input type="checkbox" disabled {% if certification.auditor_certified is True %}checked{% endif %} />
-      <a href="{% url 'audit:AuditorCertification' report_id=report_id %}">Auditor Certification</a>
+      <input type="checkbox" disabled {% if certification.auditee_certified is True %}checked{% endif %} />
+      <a href="{% url 'audit:AuditeeCertification' report_id=report_id %}">Auditee Certification</a>
     </div>
   </div>
   <div class="grid-row grid-gap">

--- a/backend/audit/views.py
+++ b/backend/audit/views.py
@@ -177,7 +177,7 @@ class ReadyForCertificationView(LoginRequiredMixin, generic.View):
             sac.transition_to_ready_for_certification()
             sac.save()
 
-            return redirect(reverse("audit:AuditorCertification", args=[report_id]))
+            return redirect(reverse("audit:SubmissionProgress", args=[report_id]))
 
         except SingleAuditChecklist.DoesNotExist:
             raise PermissionDenied("You do not have access to this audit.")
@@ -218,7 +218,7 @@ class AuditorCertificationView(LoginRequiredMixin, generic.View):
             sac.transition_to_auditor_certified()
             sac.save()
 
-            return redirect(reverse("audit:AuditeeCertification", args=[report_id]))
+            return redirect(reverse("audit:SubmissionProgress", args=[report_id]))
 
         except SingleAuditChecklist.DoesNotExist:
             raise PermissionDenied("You do not have access to this audit.")
@@ -259,7 +259,7 @@ class AuditeeCertificationView(LoginRequiredMixin, generic.View):
             sac.transition_to_auditee_certified()
             sac.save()
 
-            return redirect(reverse("audit:Certification", args=[report_id]))
+            return redirect(reverse("audit:SubmissionProgress", args=[report_id]))
 
         except SingleAuditChecklist.DoesNotExist:
             raise PermissionDenied("You do not have access to this audit.")
@@ -300,7 +300,7 @@ class CertificationView(LoginRequiredMixin, generic.View):
             sac.transition_to_certified()
             sac.save()
 
-            return redirect(reverse("audit:Submission", args=[report_id]))
+            return redirect(reverse("audit:SubmissionProgress", args=[report_id]))
 
         except SingleAuditChecklist.DoesNotExist:
             raise PermissionDenied("You do not have access to this audit.")
@@ -341,7 +341,7 @@ class SubmissionView(LoginRequiredMixin, generic.View):
             sac.transition_to_submitted()
             sac.save()
 
-            return redirect(reverse("audit:Submission", args=[report_id]))
+            return redirect(reverse("audit:SubmissionProgress", args=[report_id]))
 
         except SingleAuditChecklist.DoesNotExist:
             raise PermissionDenied("You do not have access to this audit.")


### PR DESCRIPTION
- Certification steps redirect back to submission progress page
- Re-order submission progress steps to align with allowed transitions
- Allow transition from `auditee_certified` to `submitted` (bypass `certified`)