### PR TITLE
Restore dropped newrelic-creds UPSI

### DIFF
--- a/terraform/shared/modules/env/newrelic.tf
+++ b/terraform/shared/modules/env/newrelic.tf
@@ -1,0 +1,7 @@
+resource "cloudfoundry_user_provided_service" "credentials" {
+  name  = "newrelic-creds"
+  space = data.cloudfoundry_space.apps.id
+  credentials = {
+    "NEW_RELIC_LICENSE_KEY" = var.new_relic_license_key
+  }
+}


### PR DESCRIPTION
We lost this resource when refactoring the env module across branches