### PR TITLE
Switch to CAPI v3 "rolling" app deployment strategy

### DIFF
--- a/terraform/shared/modules/egress-proxy/egress-proxy.tf
+++ b/terraform/shared/modules/egress-proxy/egress-proxy.tf
@@ -61,7 +61,7 @@ resource "cloudfoundry_app" "egress_app" {
   command          = "./caddy run --config Caddyfile"
   memory           = var.egress_memory
   instances        = var.https_proxy_instances
-  strategy         = "blue-green"
+  strategy         = "rolling"
 
   routes {
     route = cloudfoundry_route.egress_route.id

--- a/terraform/shared/modules/env/postgrest.tf
+++ b/terraform/shared/modules/env/postgrest.tf
@@ -27,7 +27,7 @@ resource "cloudfoundry_app" "postgrest" {
   memory       = 128
   disk_quota   = 256
   instances    = var.postgrest_instances
-  strategy     = "blue-green"
+  strategy     = "rolling"
   routes {
     route = cloudfoundry_route.postgrest.id
   }

--- a/terraform/shared/modules/env/swagger.tf
+++ b/terraform/shared/modules/env/swagger.tf
@@ -17,7 +17,7 @@ resource "cloudfoundry_app" "swagger" {
   memory            = 256
   disk_quota        = 256
   instances         = var.swagger_instances
-  strategy          = "blue-green"
+  strategy          = "rolling"
   routes {
     route = cloudfoundry_route.swagger.id
   }


### PR DESCRIPTION
The "blue-green" deployment strategy predates CAPI v3, when the built-in "rolling" strategy became available. The blue-green method deploys an entirely new app _with its own unique GUID_ before taking down the older app. This is a problem because without the same GUID, things start to break in subtle ways. For example, a Terraform-created `cloudfoundry_network_policy` resource might refer to the old GUID and therefore the network policy would simply evaporate when the old app is deleted... That appears to be what's happening here.

The CF terraform provider [provides a way to cope with this](https://registry.terraform.io/providers/cloudfoundry-community/cloudfoundry/latest/docs/resources/app#update-resource-using-blue-green-app-id), but it's not necessary if we just use the built-in "rolling" deployment strategy, which keeps the same GUID.