### PR TITLE
Stop spurious swagger deploys

### DIFF
--- a/terraform/shared/modules/env/swagger.tf
+++ b/terraform/shared/modules/env/swagger.tf
@@ -11,7 +11,7 @@ resource "cloudfoundry_route" "swagger" {
 resource "cloudfoundry_app" "swagger" {
   name              = local.swagger_name
   space             = data.cloudfoundry_space.apps.id
-  docker_image      = "swaggerapi/swagger-ui"
+  docker_image      = "swaggerapi/swagger-ui:latest"
   health_check_type = "process"
   timeout           = 20
   memory            = 256


### PR DESCRIPTION
This should put an end to the unnecessary redeployments of swagger (see [here](https://github.com/GSA-TTS/FAC/pull/1113#issuecomment-1544492671) for example)