### PR TITLE
Turn https proxy back on

### DIFF
--- a/backend/.profile
+++ b/backend/.profile
@@ -1,6 +1,9 @@
 #!/bin/bash
 
+export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 export REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+
+export https_proxy="$(echo "$VCAP_SERVICES" | jq --raw-output --arg service_name "egress-creds" ".[][] | select(.name == \$service_name) | .credentials.uri")"
 
 # Grab the New Relic license key from the newrelic-creds user-provided service instance
 export NEW_RELIC_LICENSE_KEY="$(echo "$VCAP_SERVICES" | jq --raw-output --arg service_name "newrelic-creds" ".[][] | select(.name == \$service_name) | .credentials.NEW_RELIC_LICENSE_KEY")"
@@ -16,8 +19,6 @@ export NEW_RELIC_LOG=stdout
 
 # Logging level, (critical, error, warning, info and debug). Default to info
 #export NEW_RELIC_LOG_LEVEL=
-
-# export https_proxy="$(echo "$VCAP_SERVICES" | jq --raw-output --arg service_name "egress-creds" ".[][] | select(.name == \$service_name) | .credentials.uri")"
 
 # We only want to run migrate and collecstatic for the first app instance, not
 # for additional app instances, so we gate all of this behind CF_INSTANCE_INDEX


### PR DESCRIPTION
This also adds the Cloud Foundry-supplied certificate authority bundle as described here:
https://cloud.gov/docs/management/container-to-container/#addressing-certificate-validation-errors