### PR TITLE
Extract users from Access to improve tests

### DIFF
--- a/backend/audit/mixins.py
+++ b/backend/audit/mixins.py
@@ -49,9 +49,8 @@ class SingleAuditChecklistAccessRequiredMixin(LoginRequiredMixin):
 
 
 class CertifyingAuditeeRequiredMixin(LoginRequiredMixin):
-    role = "certifying_auditee_contact"
-
     def dispatch(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
+        role = "certifying_auditee_contact"
         try:
             report_id = kwargs["report_id"]
             sac = SingleAuditChecklist.objects.get(report_id=report_id)


### PR DESCRIPTION
Permission mixins
With eligibility
For the roles and stuff

-----

Supply the users who are allowed to perform the attempted action so that the error messages can include this (and so the tests can pass).