### PR TITLE
1027 validate image in ghcr

### DIFF
--- a/.github/workflows/scan-images.yml
+++ b/.github/workflows/scan-images.yml
@@ -30,20 +30,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Fetch refresh token artifact
+      - name: Fetch version number artifact
         uses: dawidd6/action-download-artifact@v2
         with:
           name: ${{ matrix.image.tname }}
         continue-on-error: true
 
-      - name: Initialize refresh token
+      - name: Initialize version number
         shell: bash
         run: |
           current_date=$(date +%s)
           start_date=$((current_date - 31536000))
-          echo The default is $start_date
           value=`cat ${{ matrix.image.tname }}.txt || echo $start_date`
-          echo The result is $value
           touch  ${{ matrix.image.tname }}.txt
           echo $value > ${{ matrix.image.tname }}.txt
 
@@ -65,11 +63,12 @@ jobs:
 
       - name: Scan Image
         run: docker run aquasec/trivy:latest  image --timeout 5m --scanners vuln --exit-code 1 --severity CRITICAL,HIGH  ${{ matrix.image.name }}:${{ matrix.image.tag }}
+
       - name: Tag Image
         run: |
           image_creation_date=$(date -d "$(docker inspect -f '{{ .Created }}' ${{ matrix.image.name }}:${{ matrix.image.tag }})" +%s)
-          docker tag ${{ matrix.image.name }}:${{ matrix.image.tag }} ghcr.io/${{ env.GH_REPO }}/${{ matrix.image.name }}:${{ matrix.image.tag }}
-          docker tag ${{ matrix.image.name }}:${{ matrix.image.tag }} ghcr.io/${{ env.GH_REPO }}/${{ matrix.image.name }}:$image_creation_date
+          docker tag ${{ matrix.image.name }}:${{ matrix.image.tag }} ghcr.io/${{ env.GH_REPO }}/${{ matrix.image.tname }}:${{ matrix.image.tag }}
+          docker tag ${{ matrix.image.name }}:${{ matrix.image.tag }} ghcr.io/${{ env.GH_REPO }}/${{ matrix.image.tname }}:$image_creation_date
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
@@ -81,7 +80,7 @@ jobs:
       - name: Push Image
         run: docker push --all-tags ghcr.io/${{ env.GH_REPO }}/${{ matrix.image.name }}
 
-      - name: Upload refresh token
+      - name: Upload version number
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.image.tname }}

--- a/.github/workflows/scan-images.yml
+++ b/.github/workflows/scan-images.yml
@@ -78,7 +78,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push Image
-        run: docker push --all-tags ghcr.io/${{ env.GH_REPO }}/${{ matrix.image.name }}
+        run: docker push --all-tags ghcr.io/${{ env.GH_REPO }}/${{ matrix.image.tname }}
 
       - name: Upload version number
         uses: actions/upload-artifact@v3

--- a/.github/workflows/scan-images.yml
+++ b/.github/workflows/scan-images.yml
@@ -13,21 +13,55 @@ jobs:
     env:
       GH_REPO: gsa-tts/fac
     strategy:
+      fail-fast: false
       matrix:
         image:
           - name: postgrest/postgrest
             tag: latest
+            tname: postgrest
           - name: swaggerapi/swagger-ui
             tag: latest
+            tname: swagger
           - name: clamav/clamav
             tag: latest
+            tname: clamav
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Fetch refresh token artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          name: ${{ matrix.image.tname }}
+        continue-on-error: true
+
+      - name: Initialize refresh token
+        shell: bash
+        run: |
+          current_date=$(date +%s)
+          start_date=$((current_date - 31536000))
+          echo The default is $start_date
+          value=`cat ${{ matrix.image.tname }}.txt || echo $start_date`
+          echo The result is $value
+          touch  ${{ matrix.image.tname }}.txt
+          echo $value > ${{ matrix.image.tname }}.txt
+
       - name: Pull Docker Image
         run: docker pull ${{ matrix.image.name }}:${{ matrix.image.tag }}
+      - name: Check Image Creation Date
+        run: |
+          last_image_date=`cat ${{ matrix.image.tname }}.txt`
+          image_creation_date=$(date -d "$(docker inspect -f '{{ .Created }}' ${{ matrix.image.name }}:${{ matrix.image.tag }})" +%s)
+          echo $last_image_date
+          echo $image_creation_date
+          if [[ $image_creation_date -le $last_image_date ]]; then
+            echo "We have the latest version already"
+            exit 1
+          else
+            echo "We have an updated version"
+            echo $image_creation_date > ${{ matrix.image.tname }}.txt
+          fi
 
       - name: Scan Image
         run: docker run aquasec/trivy:latest image --scanners vuln ${{ matrix.image.name }}:${{ matrix.image.tag }}
@@ -44,3 +78,9 @@ jobs:
 
       - name: Push Image
         run: docker push ghcr.io/${{ env.GH_REPO }}/${{ matrix.image.name }}:${{ matrix.image.tag }}
+
+      - name: Upload refresh token
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.image.tname }}
+          path: ${{ matrix.image.tname }}.txt

--- a/.github/workflows/scan-images.yml
+++ b/.github/workflows/scan-images.yml
@@ -64,10 +64,12 @@ jobs:
           fi
 
       - name: Scan Image
-        run: docker run aquasec/trivy:latest image --scanners vuln ${{ matrix.image.name }}:${{ matrix.image.tag }}
-
+        run: docker run aquasec/trivy:latest  image --timeout 5m --scanners vuln --exit-code 1 --severity CRITICAL,HIGH  ${{ matrix.image.name }}:${{ matrix.image.tag }}
       - name: Tag Image
-        run: docker tag ${{ matrix.image.name }}:${{ matrix.image.tag }} ghcr.io/${{ env.GH_REPO }}/${{ matrix.image.name }}:${{ matrix.image.tag }}
+        run: |
+          image_creation_date=$(date -d "$(docker inspect -f '{{ .Created }}' ${{ matrix.image.name }}:${{ matrix.image.tag }})" +%s)
+          docker tag ${{ matrix.image.name }}:${{ matrix.image.tag }} ghcr.io/${{ env.GH_REPO }}/${{ matrix.image.name }}:${{ matrix.image.tag }}
+          docker tag ${{ matrix.image.name }}:${{ matrix.image.tag }} ghcr.io/${{ env.GH_REPO }}/${{ matrix.image.name }}:$image_creation_date
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
@@ -77,7 +79,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push Image
-        run: docker push ghcr.io/${{ env.GH_REPO }}/${{ matrix.image.name }}:${{ matrix.image.tag }}
+        run: docker push --all-tags ghcr.io/${{ env.GH_REPO }}/${{ matrix.image.name }}
 
       - name: Upload refresh token
         uses: actions/upload-artifact@v3

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -77,7 +77,6 @@ docker-nctest:
 	docker compose run web python manage.py migrate
 	docker compose run web bash -c 'awslocal s3 mb s3://gsa-fac-private-s3'
 	docker compose run web python manage.py test --parallel ${fac.test.scope}
-	docker compose run web bash -c 'npm install -g \@lhci/cli\@0.8.x && lhci autorun'
 
 docker-clean:
 	docker compose down

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -77,6 +77,7 @@ docker-nctest:
 	docker compose run web python manage.py migrate
 	docker compose run web bash -c 'awslocal s3 mb s3://gsa-fac-private-s3'
 	docker compose run web python manage.py test --parallel ${fac.test.scope}
+	docker compose run web bash -c 'npm install -g \@lhci/cli\@0.8.x && lhci autorun'
 
 docker-clean:
 	docker compose down

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -39,8 +39,8 @@ services:
       - /src/node_modules
       - /src/staticfiles
   clamav-rest:
-    # image: ajilaag/clamav-rest:20230220
-    image: ghcr.io/gsa-tts/fac/clamav/clamav:latest
+    image: ajilaag/clamav-rest:20230220
+    # image: ghcr.io/gsa-tts/fac/clamav:latest
     environment:
       - MAX_FILE_SIZE=25M
       - SIGNATURE_CHECKS=1

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -39,7 +39,8 @@ services:
       - /src/node_modules
       - /src/staticfiles
   clamav-rest:
-    image: ajilaag/clamav-rest:20230220
+    # image: ajilaag/clamav-rest:20230220
+    image: ghcr.io/gsa-tts/fac/clamav/clamav:latest
     environment:
       - MAX_FILE_SIZE=25M
       - SIGNATURE_CHECKS=1


### PR DESCRIPTION
This PR addresses severity check levels, adding a second image tag for TF, and using a simple name  (like clamav instead of clamav.ckamav) in ghcr.