### PR TITLE
Add postgrest to docker-compose

### DIFF
--- a/backend/data_distro/api_views/sql_migrations/001_initial_migration.sql
+++ b/backend/data_distro/api_views/sql_migrations/001_initial_migration.sql
@@ -36,6 +36,7 @@ begin
         to anon;
 
         -- Grant access to sequences, if we have them
+        grant usage on schema api to anon;
         grant select, usage on all sequences in schema api to anon;
         alter default privileges
             in schema api

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -67,16 +67,6 @@ services:
       PGRST_DB_ANON_ROLE: anon
     depends_on:
       - db
-  swagger:
-    image: swaggerapi/swagger-ui
-    ports:
-      - "8080:8080"
-    expose:
-      - "8080"
-    environment:
-      API_URL: http://localhost:3000/
-    depends_on:
-      - db
 volumes:
   postgres-data:
   localstack-vol:

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -55,6 +55,28 @@ services:
       - SERVICES=s3
     volumes:
       - "localstack-vol:/tmp/localstack"
+  api:
+    image: postgrest/postgrest:v10.1.2
+    ports:
+      - "3000:3000"
+    expose:
+      - "3000"
+    environment:
+      PGRST_DB_URI: postgres://postgres:${SECRET_KEY}@db:5432/postgres
+      PGRST_OPENAPI_SERVER_PROXY_URI: http://127.0.0.1:3000
+      PGRST_DB_ANON_ROLE: anon
+    depends_on:
+      - db
+  swagger:
+    image: swaggerapi/swagger-ui
+    ports:
+      - "8080:8080"
+    expose:
+      - "8080"
+    environment:
+      API_URL: http://localhost:3000/
+    depends_on:
+      - db
 volumes:
   postgres-data:
   localstack-vol:

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -39,8 +39,7 @@ services:
       - /src/node_modules
       - /src/staticfiles
   clamav-rest:
-    image: ajilaag/clamav-rest:20230220
-    # image: ghcr.io/gsa-tts/fac/clamav:latest
+    image: ghcr.io/gsa-tts/fac/clamav:latest
     environment:
       - MAX_FILE_SIZE=25M
       - SIGNATURE_CHECKS=1
@@ -56,15 +55,16 @@ services:
     volumes:
       - "localstack-vol:/tmp/localstack"
   api:
-    image: postgrest/postgrest:v10.1.2
+    image: ghcr.io/gsa-tts/fac/postgrest:latest
     ports:
       - "3000:3000"
     expose:
       - "3000"
     environment:
-      PGRST_DB_URI: postgres://postgres:${SECRET_KEY}@db:5432/postgres
+      PGRST_DB_URI: postgres://postgres@db:5432/postgres
       PGRST_OPENAPI_SERVER_PROXY_URI: http://127.0.0.1:3000
       PGRST_DB_ANON_ROLE: anon
+      PGRST_DB_SCHEMAS: api
     depends_on:
       - db
 volumes:


### PR DESCRIPTION
Add PostgREST container to `docker-compose.yml` for use in local development.