### PR TITLE
Update actions to non-deprecated versions

### DIFF
--- a/.github/workflows/deploy-apps.yml
+++ b/.github/workflows/deploy-apps.yml
@@ -16,7 +16,7 @@ jobs:
       space: ${{ inputs.environment }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Restore npm cache
         uses: actions/cache@v3
         id: cache-npm

--- a/.github/workflows/terraform-apply-env.yml
+++ b/.github/workflows/terraform-apply-env.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: terraform apply ( ${{ inputs.environment }} )
         uses: dflook/terraform-apply@v1
         with:

--- a/.github/workflows/terraform-commit.yml
+++ b/.github/workflows/terraform-commit.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: terraform fmt
         uses: dflook/terraform-fmt-check@v1

--- a/.github/workflows/terraform-lint.yml
+++ b/.github/workflows/terraform-lint.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: terraform fmt
         uses: dflook/terraform-fmt-check@v1

--- a/.github/workflows/terraform-plan-env.yml
+++ b/.github/workflows/terraform-plan-env.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         # Plan output will be posted as a comment on the PR to aid with review.
         # The post includes a link to the workflow run where the plan was
         # generated, and the same comment will be updated each time a new commit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,8 +90,8 @@ jobs:
       ALLOWED_HOSTS: '0.0.0.0 127.0.0.1 localhost'
       DISABLE_AUTH: False
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
       - name: Pull Docker Hub images

--- a/.github/workflows/zap-scan.yml
+++ b/.github/workflows/zap-scan.yml
@@ -15,7 +15,7 @@ jobs:
       url: ${{ inputs.url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: grab docker container
         run: docker pull owasp/zap2docker-stable
       - name: run command


### PR DESCRIPTION
[node 12 is deprecated, and actions that were using it have newer versions out.](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)

We're still using older versions of those actions and as a result we're seeing messages like the following in our GitHub Action runs:
```
test-and-lint / test
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-node@v1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```

This changes upgrades the versions of the actions we're using to ones that use node 16.