### PR TITLE
Set https proxys to local and add outputs

### DIFF
--- a/terraform/shared/modules/env/clamav.tf
+++ b/terraform/shared/modules/env/clamav.tf
@@ -16,7 +16,7 @@ module "clamav" {
 
   # The following line is commented out until we have a way to pass the value of
   # the variable to to docker image without it interfering with staging.
-  proxy_server    = module.https-proxy.domain
+  proxy_server   = module.https-proxy.domain
   proxy_port     = module.https-proxy.port
   proxy_username = module.https-proxy.username
   proxy_password = module.https-proxy.password

--- a/terraform/shared/modules/env/clamav.tf
+++ b/terraform/shared/modules/env/clamav.tf
@@ -17,8 +17,8 @@ module "clamav" {
   # The following line is commented out until we have a way to pass the value of
   # the variable to to docker image without it interfering with staging.
   https_proxy    = module.https-proxy.domain
-  proxy_port     = module.https_proxy.port
-  proxy_username = module.https_proxy.username
-  proxy_password = module.https_proxy.password
+  proxy_port     = module.https-proxy.port
+  proxy_username = module.https-proxy.username
+  proxy_password = module.https-proxy.password
 }
 

--- a/terraform/shared/modules/env/clamav.tf
+++ b/terraform/shared/modules/env/clamav.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 module "clamav" {
-  source = "github.com/18f/terraform-cloudgov//clamav?ref=v0.5.1"
+  source = "github.com/18f/terraform-cloudgov//clamav?ref=v0.6.0"
 
   # This generates eg "fac-av-staging.apps.internal", avoiding collisions with routes for other projects and spaces
   name           = local.clam_name

--- a/terraform/shared/modules/env/clamav.tf
+++ b/terraform/shared/modules/env/clamav.tf
@@ -16,9 +16,9 @@ module "clamav" {
 
   # The following line is commented out until we have a way to pass the value of
   # the variable to to docker image without it interfering with staging.
-  # https_proxy   = module.https-proxy.https_proxy
-  # proxy_port     = module.https_proxy.port
-  # proxy_username = module.https_proxy.username
-  # proxy_password = module.https_proxy.password
+  https_proxy    = module.https-proxy.domain
+  proxy_port     = module.https_proxy.port
+  proxy_username = module.https_proxy.username
+  proxy_password = module.https_proxy.password
 }
 

--- a/terraform/shared/modules/env/clamav.tf
+++ b/terraform/shared/modules/env/clamav.tf
@@ -16,7 +16,7 @@ module "clamav" {
 
   # The following line is commented out until we have a way to pass the value of
   # the variable to to docker image without it interfering with staging.
-  https_proxy    = module.https-proxy.domain
+  proxy_server    = module.https-proxy.domain
   proxy_port     = module.https-proxy.port
   proxy_username = module.https-proxy.username
   proxy_password = module.https-proxy.password

--- a/terraform/shared/modules/env/clamav.tf
+++ b/terraform/shared/modules/env/clamav.tf
@@ -17,5 +17,8 @@ module "clamav" {
   # The following line is commented out until we have a way to pass the value of
   # the variable to to docker image without it interfering with staging.
   # https_proxy   = module.https-proxy.https_proxy
+  # proxy_port     = module.https_proxy.port
+  # proxy_username = module.https_proxy.username
+  # proxy_password = module.https_proxy.password
 }
 

--- a/terraform/shared/modules/https-proxy/outputs.tf
+++ b/terraform/shared/modules/https-proxy/outputs.tf
@@ -1,3 +1,23 @@
 output "https_proxy" {
   value = local.https_proxy
 }
+
+output "domain" {
+  value = local.domain
+}
+
+output "username" {
+  value = local.username
+}
+
+output "password" {
+  value = local.password
+}
+
+output "protocol" {
+  value = local.protocol
+}
+
+output "port" {
+  value = local.port
+}


### PR DESCRIPTION
Follow-up from [18f/terraform clamav pr](https://github.com/18F/terraform-cloudgov/pull/25) that supports the proxy configuration for the clamav image, this pr outputs values to use in the clamav module to set the proxy for freshclam usage