### PR TITLE
Fix test for https-proxy

### DIFF
--- a/terraform/shared/modules/https-proxy/test/.profile
+++ b/terraform/shared/modules/https-proxy/test/.profile
@@ -13,7 +13,7 @@ function vcap_get_service () {
   path="$2"
   echo $VCAP_SERVICES | jq --raw-output --arg service_name "$name" ".[][] | select(.name == \$service_name) | $path"
 }
-export https_proxy=$(vcap_get_service egress-creds .credentials.uri)
+export https_proxy=$(vcap_get_service https-egress-creds .credentials.uri)
 
 # Should fail via deny-all
 echo www.yahoo.com: $(curl -s -o /dev/null -I -L  -w "%{http_connect}" https://www.yahoo.com)

--- a/terraform/shared/modules/https-proxy/test/README.md
+++ b/terraform/shared/modules/https-proxy/test/README.md
@@ -1,6 +1,7 @@
 # Test the https-proxy module
 1. Authenticate with cloud.gov (`cf login -a api.fr.cloud.gov --sso`)
 2. Copy `terraform.tfvars-template` to `terraform.tfvars` and edit to taste
+3. Run `terraform init` to configure Terraform with the necessary providers
 3. Run `terraform apply` to deploy a test fixture app and the proxy
 4. Verify success
 5. Run `terraform destroy` to tear everything down


### PR DESCRIPTION
the name of the creds changed based on the name of the proxy app changing.