### PR TITLE
Add MinIO dependency to `web` for Docker development

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -17,6 +17,7 @@ services:
     command: /src/run.sh
     depends_on:
       - db
+      - minio
     environment:
       - "DATABASE_URL=postgres://postgres@db/postgres"
       - "DJANGO_DEBUG=true"


### PR DESCRIPTION
We need MinIO
When we’re running locally
So add `depends_on`
