### PR TITLE
Use production domain

### DIFF
--- a/.github/workflows/triggers-prod.yml
+++ b/.github/workflows/triggers-prod.yml
@@ -42,5 +42,5 @@ jobs:
       - deploy-production
     uses: ./.github/workflows/zap-scan.yml
     with:
-      url: "https://fac-prod.app.cloud.gov/"
+      url: "https://app.fac.gov/"
       

--- a/backend/manifests/manifest-fac.yml
+++ b/backend/manifests/manifest-fac.yml
@@ -8,12 +8,13 @@ applications:
     timeout: 180
     env:
       ENV: ((cf_env_name))
-      DJANGO_BASE_URL: https://fac-((env_name)).app.cloud.gov
-      ALLOWED_HOSTS: fac-((env_name)).app.cloud.gov
+      DJANGO_BASE_URL: https://((endpoint))
+      ALLOWED_HOSTS: ((endpoint)) fac-((env_name)).app.cloud.gov
       AV_SCAN_URL: https://fac-av-((service_name)).apps.internal:61443/scan
       # DISABLE_COLLECTSTATIC: true
     routes:
       - route: fac-((env_name)).app.cloud.gov
+      - route: ((endpoint))
     instances: ((instances))
     services:
       - fac-db

--- a/backend/manifests/vars/vars-dev.yml
+++ b/backend/manifests/vars/vars-dev.yml
@@ -3,4 +3,5 @@ mem_amount: 512M
 cf_env_name: DEVELOPMENT
 env_name: dev
 service_name: dev
+endpoint: fac-dev.app.cloud.gov
 instances: 1

--- a/backend/manifests/vars/vars-production.yml
+++ b/backend/manifests/vars/vars-production.yml
@@ -3,4 +3,5 @@ mem_amount: 512M
 cf_env_name: PRODUCTION
 env_name: prod
 service_name: production
+endpoint: app.fac.gov
 instances: 2

--- a/backend/manifests/vars/vars-staging.yml
+++ b/backend/manifests/vars/vars-staging.yml
@@ -3,4 +3,5 @@ mem_amount: 512M
 cf_env_name: STAGING
 env_name: staging
 service_name: staging
+endpoint: fac-staging.app.cloud.gov
 instances: 1

--- a/docs/branching.md
+++ b/docs/branching.md
@@ -11,7 +11,7 @@ There are two long-lived branches:
  Three app environments:
  - dev [https://fac-dev.app.cloud.gov/](https://fac-dev.app.cloud.gov/)
  - staging [https://fac-staging.app.cloud.gov/](https://fac-staging.app.cloud.gov/)
- - production [https://fac-prod.app.cloud.gov/](https://fac-prod.app.cloud.gov/) production is auto-deployed by using version tags
+ - production [https://app.fac.gov/](https://app.fac.gov/) production is auto-deployed by using version tags
  
 
 ## Timeline

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -90,7 +90,7 @@ cf push -f manifests/manifest-dev.yml
 3.  Wait for the checks to pass.
 4.  If checks fail, or if reviewers request changes, something has gone awry. Investigation and/or starting over from a branch and making a PR against `main` may be required.
 5.  Verify that the deploy steps all passed.
-6.  After deployment, the changes should be on https://fac-prod.app.cloud.gov/.
+6.  After deployment, the changes should be on https://app.fac.gov/.
 7.  If anything was merged directly into the `prod` branch, such as a hotfix, merge `prod` back into `main`.
 
 To see more about branching and the deployment steps, see the [Branching](branching.md) page.


### PR DESCRIPTION
This change makes the application _additionally_ available under `https://app.fac.gov`. We will remove the `fac-production.app.cloud.gov` domain once we've let users know about the new location and given them a chance to switch. (cc @jadudm for the comms part)