### PR TITLE
Set up production app.fac.gov domain service

### DIFF
--- a/terraform/production/production.tf
+++ b/terraform/production/production.tf
@@ -5,3 +5,16 @@ module "production" {
   postgrest_image       = var.postgrest_image
   clamav_image          = var.clamav_image
 }
+
+module "domain" {
+  source = "github.com/18f/terraform-cloudgov//domain?ref=v0.6.0"
+
+  cf_org_name    = "gsa-tts-oros-fac"
+  cf_space_name  = "production"
+  app_name_or_id = "gsa-fac"
+  cdn_plan_name  = "domain"
+  domain_name    = "app.fac.gov"
+  depends_on = [
+    module.production
+  ]
+}


### PR DESCRIPTION
Once this commit is included in a release tag, `gsa-fac` should be available via `https://app.fac.gov`.