### PR TITLE
Remove redundant app.fac.gov route

### DIFF
--- a/backend/manifests/manifest-fac.yml
+++ b/backend/manifests/manifest-fac.yml
@@ -15,7 +15,6 @@ applications:
       # DISABLE_COLLECTSTATIC: true
     routes:
       - route: fac-((env_name)).app.cloud.gov
-      - route: ((endpoint))
     instances: ((instances))
     services:
       - fac-db


### PR DESCRIPTION
The route for app.fac.gov is owned/bound via the domain Terraform module, so this is redundant and confusing to Terraform!