### PR TITLE
Remove randomness from report_id

### DIFF
--- a/backend/audit/models.py
+++ b/backend/audit/models.py
@@ -1,6 +1,6 @@
+import calendar
 import logging
 
-from secrets import choice
 from django.db import models
 from django.db.models import Q
 from django.contrib.auth import get_user_model
@@ -33,19 +33,17 @@ class SingleAuditChecklistManager(models.Manager):
 
         Currently only used for report_id, a 17-character value consisting of:
             -   Four-digit year of start of audit period.
-            -   Three-digit char (but without I or O) random.
+            -   Three-character all-caps month abbrevation (start of audit period)
             -   10-digit numeric monotonically increasing, but starting from
                 0001000001 because the Census numbers are six-digit values. The
                 formula for creating this is basically "how many non-legacy
-                entries there are in the system plus one plus 1,000,000".
-
-
+                entries there are in the system plus 1,000,000".
         """
-        year = obj_data["general_information"]["auditee_fiscal_period_start"][:4]
-        chars = "ABCDEFGHJKLMNPQRSTUVWXYZ1234567890"
-        trichar = "".join(choice(chars) for _ in range(3))
+        fiscal_start = obj_data["general_information"]["auditee_fiscal_period_start"]
+        year = fiscal_start[:4]
+        month = calendar.month_abbr[int(fiscal_start[5:7])].upper()
         count = SingleAuditChecklist.objects.count() + 1_000_001
-        report_id = f"{year}{trichar}{str(count).zfill(10)}"
+        report_id = f"{year}{month}{str(count).zfill(10)}"
         updated = obj_data | {"report_id": report_id}
         return super().create(**updated)
 

--- a/backend/audit/test_models.py
+++ b/backend/audit/test_models.py
@@ -23,8 +23,8 @@ class SingleAuditChecklistTests(TestCase):
         -   There is a report_id value
         -   The report_id value consists of:
             -   Four-digit year of start of audit period.
-            -   Three-digit char (but without I or O) random.
-            -   10-digit numeric (monotonically increasing, but starting from
+            -   Three-character all-caps month abbrevation (start of audit period)
+            -   10-digit numeric monotonically increasing, but starting from
                 0001000001 because the Census numbers are six-digit values. The
                 formula for creating this is basically "how many non-legacy
                 entries there are in the system plus 1,000,000".
@@ -43,9 +43,7 @@ class SingleAuditChecklistTests(TestCase):
         )
         self.assertEqual(len(sac.report_id), 17)
         self.assertEqual(sac.report_id[:4], "2022")
-        self.assertIn(sac.report_id[4], "ABCDEFGHJKLMNPQRSTUVWXYZ1234567890")
-        self.assertIn(sac.report_id[5], "ABCDEFGHJKLMNPQRSTUVWXYZ1234567890")
-        self.assertIn(sac.report_id[6], "ABCDEFGHJKLMNPQRSTUVWXYZ1234567890")
+        self.assertEqual(sac.report_id[4:7], "NOV")
         # This one is a little dubious because it assumes this will always be
         # the first entry in the test database:
         self.assertEqual(sac.report_id[7:], "0001000001")


### PR DESCRIPTION
`report_id` but
Without the randomness, so
We use month instead

-----

Use all-caps three-character month abbreviation instead of the prior three random characters in the middle of `report_id`. The month, as with the year, corresponds to the start of the submission's audit period.

Addresses #1261 