### PR TITLE
Explicitly apt-get npm in Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -20,6 +20,7 @@ RUN \
     apt-get install -y gcc && \
     curl -fsSL https://deb.nodesource.com/setup_14.x | bash - && \
     apt-get install -y nodejs && \
+    apt-get install -y npm && \
     npm i -g npm@^8
 
 COPY requirements.txt /tmp/requirements.txt


### PR DESCRIPTION
`apt-get nodejs`
Now doesn't get `npm`;
Make it explicit.

-----

No idea why this worked fine until today. It's possible we'll have to change it back at some point in the future.