### PR TITLE
We're not USWDS

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-template.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-template.yaml
@@ -1,5 +1,5 @@
 name: Bug Report 🐞
-description: Report a bug and help USWDS improve.
+description: Report a bug and help the FAC improve.
 title: "FAC - Bug: [YOUR TITLE]"
 labels: ['Type: Bug','Status: Triage','Needs: Confirmation']
 body:


### PR DESCRIPTION
Since we are the FAC
Our bug templates should say so.
The perils of paste.

-----

Remove reference to USWDS in our bug report GitHub issue template.

Feel free to make this ticket a key battleground in various struggles about whether or not we should use the definite article, spell out the full acronym, specify “GSA”, etc.