### PR TITLE
Refactor form section name handling

### DIFF
--- a/backend/audit/fixtures/excel.py
+++ b/backend/audit/fixtures/excel.py
@@ -1,3 +1,4 @@
+from collections import namedtuple
 from django.conf import settings
 
 SHEETS_DIR = settings.XLSX_TEMPLATE_SHEET_DIR
@@ -37,7 +38,19 @@ FEDERAL_AWARDS_ENTRY_FIXTURES = (
 
 SIMPLE_CASES_TEST_FILE = settings.AUDIT_TEST_DATA_ENTRY_DIR / "simple-cases.json"
 
-FEDERAL_AWARDS_EXPENDED = "FederalAwardsExpended"
-CORRECTIVE_ACTION_PLAN = "CorrectiveActionPlan"
-FINDINGS_TEXT = "FindingsText"
-FINDINGS_UNIFORM_GUIDANCE = "FindingsUniformGuidance"
+# Make FORM_SECTIONS convenient to both iterate over and access by field name:
+FormSections = namedtuple(
+    "FormSections",
+    (
+        "CORRECTIVE_ACTION_PLAN",
+        "FEDERAL_AWARDS_EXPENDED",
+        "FINDINGS_TEXT",
+        "FINDINGS_UNIFORM_GUIDANCE",
+    ),
+)
+FORM_SECTIONS = FormSections(
+    CORRECTIVE_ACTION_PLAN="CorrectiveActionPlan",
+    FEDERAL_AWARDS_EXPENDED="FederalAwardsExpended",
+    FINDINGS_TEXT="FindingsText",
+    FINDINGS_UNIFORM_GUIDANCE="FindingsUniformGuidance",
+)

--- a/backend/audit/test_views.py
+++ b/backend/audit/test_views.py
@@ -22,10 +22,7 @@ from .fixtures.excel import (
     FINDINGS_TEXT_ENTRY_FIXTURES,
     FINDINGS_UNIFORM_GUIDANCE_ENTRY_FIXTURES,
     FEDERAL_AWARDS_ENTRY_FIXTURES,
-    FEDERAL_AWARDS_EXPENDED,
-    CORRECTIVE_ACTION_PLAN,
-    FINDINGS_TEXT,
-    FINDINGS_UNIFORM_GUIDANCE,
+    FORM_SECTIONS,
 )
 from .models import Access, SingleAuditChecklist
 from .views import MySubmissions
@@ -55,13 +52,6 @@ VALID_ACCESS_AND_SUBMISSION_DATA = {
     "auditee_contacts": ["c@c.com"],
     "auditor_contacts": ["d@d.com"],
 }
-
-EXCEL_FILES = [
-    CORRECTIVE_ACTION_PLAN,
-    FEDERAL_AWARDS_EXPENDED,
-    FINDINGS_UNIFORM_GUIDANCE,
-    FINDINGS_TEXT,
-]
 
 
 # Mocking the user login and file scan functions
@@ -262,7 +252,7 @@ class ExcelFileHandlerViewTests(TestCase):
     def test_login_required(self):
         """When an unauthenticated request is made"""
 
-        for form_section in EXCEL_FILES:
+        for form_section in FORM_SECTIONS:
             response = self.client.post(
                 reverse(
                     f"audit:{form_section}",
@@ -278,7 +268,7 @@ class ExcelFileHandlerViewTests(TestCase):
 
         self.client.force_login(user)
 
-        for form_section in EXCEL_FILES:
+        for form_section in FORM_SECTIONS:
             response = self.client.post(
                 reverse(
                     f"audit:{form_section}",
@@ -296,7 +286,7 @@ class ExcelFileHandlerViewTests(TestCase):
         user, sac = _make_user_and_sac()
 
         self.client.force_login(user)
-        for form_section in EXCEL_FILES:
+        for form_section in FORM_SECTIONS:
             response = self.client.post(
                 reverse(
                     f"audit:{form_section}",
@@ -313,7 +303,7 @@ class ExcelFileHandlerViewTests(TestCase):
 
         self.client.force_login(user)
 
-        for form_section in EXCEL_FILES:
+        for form_section in FORM_SECTIONS:
             response = self.client.post(
                 reverse(
                     f"audit:{form_section}",
@@ -332,7 +322,7 @@ class ExcelFileHandlerViewTests(TestCase):
 
         file = SimpleUploadedFile("not-excel.txt", b"asdf", "text/plain")
 
-        for form_section in EXCEL_FILES:
+        for form_section in FORM_SECTIONS:
             response = self.client.post(
                 reverse(
                     f"audit:{form_section}",
@@ -365,10 +355,10 @@ class ExcelFileHandlerViewTests(TestCase):
             with open(tmp.name, "rb") as excel_file:
                 response = self.client.post(
                     reverse(
-                        f"audit:{EXCEL_FILES[1]}",
+                        f"audit:{FORM_SECTIONS.FEDERAL_AWARDS_EXPENDED}",
                         kwargs={
                             "report_id": sac.report_id,
-                            "form_section": EXCEL_FILES[1],
+                            "form_section": FORM_SECTIONS.FEDERAL_AWARDS_EXPENDED,
                         },
                     ),
                     data={"FILES": excel_file},
@@ -488,10 +478,10 @@ class ExcelFileHandlerViewTests(TestCase):
             with open(tmp.name, "rb") as excel_file:
                 response = self.client.post(
                     reverse(
-                        f"audit:{EXCEL_FILES[0]}",
+                        f"audit:{FORM_SECTIONS.CORRECTIVE_ACTION_PLAN}",
                         kwargs={
                             "report_id": sac.report_id,
-                            "form_section": EXCEL_FILES[0],
+                            "form_section": FORM_SECTIONS.CORRECTIVE_ACTION_PLAN,
                         },
                     ),
                     data={"FILES": excel_file},
@@ -554,10 +544,10 @@ class ExcelFileHandlerViewTests(TestCase):
             with open(tmp.name, "rb") as excel_file:
                 response = self.client.post(
                     reverse(
-                        f"audit:{EXCEL_FILES[2]}",
+                        f"audit:{FORM_SECTIONS.FINDINGS_UNIFORM_GUIDANCE}",
                         kwargs={
                             "report_id": sac.report_id,
-                            "form_section": EXCEL_FILES[2],
+                            "form_section": FORM_SECTIONS.FINDINGS_UNIFORM_GUIDANCE,
                         },
                     ),
                     data={"FILES": excel_file},
@@ -632,10 +622,10 @@ class ExcelFileHandlerViewTests(TestCase):
             with open(tmp.name, "rb") as excel_file:
                 response = self.client.post(
                     reverse(
-                        f"audit:{EXCEL_FILES[3]}",
+                        f"audit:{FORM_SECTIONS.FINDINGS_TEXT}",
                         kwargs={
                             "report_id": sac.report_id,
-                            "form_section": EXCEL_FILES[3],
+                            "form_section": FORM_SECTIONS.FINDINGS_TEXT,
                         },
                     ),
                     data={"FILES": excel_file},

--- a/backend/audit/urls.py
+++ b/backend/audit/urls.py
@@ -1,20 +1,17 @@
 from django.urls import path
 
-from .fixtures.excel import (
-    CORRECTIVE_ACTION_PLAN,
-    FEDERAL_AWARDS_EXPENDED,
-    FINDINGS_TEXT,
-    FINDINGS_UNIFORM_GUIDANCE,
-)
+from .fixtures.excel import FORM_SECTIONS
 from . import views
 
 app_name = "audit"
-form_sections = [
-    CORRECTIVE_ACTION_PLAN,
-    FEDERAL_AWARDS_EXPENDED,
-    FINDINGS_TEXT,
-    FINDINGS_UNIFORM_GUIDANCE,
-]
+
+
+def camel_to_hyphen(raw: str) -> str:
+    """Convert camel case to hyphen-delimited."""
+    text = f"{raw[0].lower()}{raw[1:]}"
+    return "".join(c if c.islower() else f"-{c.lower()}" for c in text)
+
+
 urlpatterns = [
     path("", views.MySubmissions.as_view(), name="MySubmissions"),
     path("<str:report_id>", views.EditSubmission.as_view(), name="EditSubmission"),
@@ -50,10 +47,10 @@ urlpatterns = [
     ),
 ]
 
-for form_section in form_sections:
+for form_section in FORM_SECTIONS:
     urlpatterns.append(
         path(
-            f"excel/{form_section}/<str:report_id>",
+            f"excel/{camel_to_hyphen(form_section)}/<str:report_id>",
             views.ExcelFileHandlerView.as_view(),
             name=form_section,
             kwargs={"form_section": form_section},

--- a/backend/audit/views.py
+++ b/backend/audit/views.py
@@ -10,12 +10,7 @@ from django.urls import reverse
 from django.utils.datastructures import MultiValueDictKeyError
 from django.utils.decorators import method_decorator
 
-from .fixtures.excel import (
-    FEDERAL_AWARDS_EXPENDED,
-    CORRECTIVE_ACTION_PLAN,
-    FINDINGS_TEXT,
-    FINDINGS_UNIFORM_GUIDANCE,
-)
+from .fixtures.excel import FORM_SECTIONS
 
 from audit.excel import (
     extract_federal_awards,
@@ -104,25 +99,25 @@ class ExcelFileHandlerView(SingleAuditChecklistAccessRequiredMixin, generic.View
             excel_file.full_clean()
             excel_file.save()
 
-            if form_section == FEDERAL_AWARDS_EXPENDED:
+            if form_section == FORM_SECTIONS.FEDERAL_AWARDS_EXPENDED:
                 audit_data = extract_federal_awards(excel_file.file)
                 validate_federal_award_json(audit_data)
                 SingleAuditChecklist.objects.filter(pk=sac.id).update(
                     federal_awards=audit_data
                 )
-            elif form_section == CORRECTIVE_ACTION_PLAN:
+            elif form_section == FORM_SECTIONS.CORRECTIVE_ACTION_PLAN:
                 audit_data = extract_corrective_action_plan(excel_file.file)
                 validate_corrective_action_plan_json(audit_data)
                 SingleAuditChecklist.objects.filter(pk=sac.id).update(
                     corrective_action_plan=audit_data
                 )
-            elif form_section == FINDINGS_UNIFORM_GUIDANCE:
+            elif form_section == FORM_SECTIONS.FINDINGS_UNIFORM_GUIDANCE:
                 audit_data = extract_findings_uniform_guidance(excel_file.file)
                 validate_findings_uniform_guidance_json(audit_data)
                 SingleAuditChecklist.objects.filter(pk=sac.id).update(
                     findings_uniform_guidance=audit_data
                 )
-            elif form_section == FINDINGS_TEXT:
+            elif form_section == FORM_SECTIONS.FINDINGS_TEXT:
                 audit_data = extract_findings_text(excel_file.file)
                 validate_findings_text_json(audit_data)
                 SingleAuditChecklist.objects.filter(pk=sac.id).update(


### PR DESCRIPTION
Python has tuples.
And named tuples are better.
So let’s use them here.

-----

I have to do some things with form sections as part of making Excel files have singular names, and am separating this bit of refactoring for that out.

This makes importing and handling the name of the sections easier.

It also changes the URL paths for the sections (that is, the sections under `/audit/excel/`) to bring them into line with the casing of our URLs.