### PR TITLE
Add quotation marks to self in Django settings.py for Content Security Policy

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -287,7 +287,7 @@ else:
     # see settings options https://django-csp.readthedocs.io/en/latest/configuration.html#configuration-chapter
     bucket = f"{STATIC_URL}"
     allowed_sources = (
-        "self",
+        "'self'",
         bucket,
         "https://idp.int.identitysandbox.gov/",
         "https://dap.digitalgov.gov",


### PR DESCRIPTION
Use quotation marks
When referring to the self
Identity: weird

-----

Turns out you have to put quotation marks around `self`.