### PR TITLE
Add testing banner

### DIFF
--- a/backend/static/scss/_header.scss
+++ b/backend/static/scss/_header.scss
@@ -107,3 +107,9 @@
     }
   }
 }
+
+.fac-beta-banner {
+    background-color: color('gold-5v');
+    font-size: .88rem;
+    padding-block: .2rem;
+}

--- a/backend/templates/includes/header.html
+++ b/backend/templates/includes/header.html
@@ -76,6 +76,9 @@
         </div>
     </div>
 </section>
+<section class="fac-beta-banner">
+  <div class="grid-container">This application is currently under active development. Thank you for helping to improve the FAC by participating in user testing.</div>
+</section>
 <div class="usa-overlay"></div>
 <header class="usa-header usa-header--basic">
     {% include "includes/nav_primary.html" %}


### PR DESCRIPTION
This PR just adds a banner to the header to indicate that the app is under development. Closes #1297.

<img width="1014" alt="image" src="https://github.com/GSA-TTS/FAC/assets/6290/419d124f-fa44-4d0c-9512-5086d20ad2fd">
