### PR TITLE
Add S3 bucket URLs and apps.internal to `no_proxy` env var

### DIFF
--- a/backend/.profile
+++ b/backend/.profile
@@ -7,6 +7,11 @@ export https_proxy="$(echo "$VCAP_SERVICES" | jq --raw-output --arg service_name
 export smtp_proxy_domain="$(echo "$VCAP_SERVICES" | jq --raw-output --arg service_name "smtp-proxy-creds" ".[][] | select(.name == \$service_name) | .credentials.domain")"
 export smtp_proxy_port="$(echo "$VCAP_SERVICES" | jq --raw-output --arg service_name "smtp-proxy-creds" ".[][] | select(.name == \$service_name) | .credentials.port")"
 
+S3_ENDPOINT_FOR_NO_PROXY="$(echo $VCAP_SERVICES | jq --raw-output --arg service_name "fac-public-s3" ".[][] | select(.name == \$service_name) | .credentials.endpoint")"
+S3_FIPS_ENDPOINT_FOR_NO_PROXY="$(echo $VCAP_SERVICES | jq --raw-output --arg service_name "fac-public-s3" ".[][] | select(.name == \$service_name) | .credentials.fips_endpoint")"
+export no_proxy="${S3_ENDPOINT_FOR_NO_PROXY},${S3_FIPS_ENDPOINT_FOR_NO_PROXY},apps.internal"
+
+
 # Grab the New Relic license key from the newrelic-creds user-provided service instance
 export NEW_RELIC_LICENSE_KEY="$(echo "$VCAP_SERVICES" | jq --raw-output --arg service_name "newrelic-creds" ".[][] | select(.name == \$service_name) | .credentials.NEW_RELIC_LICENSE_KEY")"
 


### PR DESCRIPTION
Sometimes the proxy
Can be a bit too zealous.
Make some exceptions

-----


Add S3 bucket URLs and apps.internal to `no_proxy` env var in cloud.gov `.profile` so that Django can talk to services without getting blocked by the HTTPS proxy.