### PR TITLE
Add ability to handle email addresses to `load_fixtures` Django command

### DIFF
--- a/backend/audit/fixtures/__init__.py
+++ b/backend/audit/fixtures/__init__.py
@@ -3,4 +3,4 @@ from .single_audit_checklist import (
     load_single_audit_checklists_for_email_address,
 )
 
-__all__ = [load_single_audit_checklists]
+__all__ = [load_single_audit_checklists, load_single_audit_checklists_for_email_address]

--- a/backend/audit/fixtures/__init__.py
+++ b/backend/audit/fixtures/__init__.py
@@ -1,3 +1,6 @@
-from .single_audit_checklist import load_single_audit_checklists
+from .single_audit_checklist import (
+    load_single_audit_checklists,
+    load_single_audit_checklists_for_email_address,
+)
 
 __all__ = [load_single_audit_checklists]

--- a/backend/audit/management/commands/load_fixtures.py
+++ b/backend/audit/management/commands/load_fixtures.py
@@ -7,15 +7,29 @@ import logging
 
 from django.core.management.base import BaseCommand
 
-from audit.fixtures import load_single_audit_checklists
+from audit.fixtures import (
+    load_single_audit_checklists,
+    load_single_audit_checklists_for_email_address,
+)
+
 from users.fixtures import load_users
 
 logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
+    """Django management command for loading fixtures."""
+
+    def add_arguments(self, parser):
+        parser.add_argument("email_addresses", nargs="*", type=str)
+
     def handle(self, *args, **options):
         # load users first so later fixtures will load items for them
-        load_users()
-        load_single_audit_checklists()
-        logger.info("All fixtures loaded.")
+        if not options.get("email_addresses"):
+            load_users()
+            load_single_audit_checklists()
+            logger.info("All fixtures loaded.")
+        else:
+            # We assume each arg is an email address:
+            for email_address in options["email_addresses"]:
+                load_single_audit_checklists_for_email_address(email_address)

--- a/backend/users/fixtures/user_fixtures.py
+++ b/backend/users/fixtures/user_fixtures.py
@@ -2,7 +2,6 @@
 
 import logging
 
-from django.apps import apps
 from django.conf import settings
 from django.contrib.auth import get_user_model
 

--- a/backend/users/fixtures/user_fixtures.py
+++ b/backend/users/fixtures/user_fixtures.py
@@ -10,9 +10,12 @@ logger = logging.getLogger(__name__)
 
 # list of users that should be auto-created.
 # username here is the UUID for this person's Login.gov user
+
+test_username = getattr(settings, "TEST_USERNAME", None)
+
 USERS = [
     {
-        "username": settings.TEST_USERNAME,
+        "username": test_username,
     },
     {
         "username": "b276a5b3-2d2a-42a3-a078-ad57a36975d4",
@@ -27,6 +30,9 @@ def load_users():
     User = get_user_model()
     for item_info in USERS:
         username = item_info["username"]
+        if username is None:
+            logger.info("username is None, no TEST_USERNAME in settings")
+            continue
         if not User.objects.filter(username=username).exists():
             # need to make this user
             logger.info("Creating username %s", username)

--- a/docs/development.md
+++ b/docs/development.md
@@ -188,6 +188,21 @@ one of the Cloud.gov environments with `cf run-task` like
 cf run-task ENVIRONMENT --command "./manage.py load_fixtures" --name fixtures
 ```
 
+You can also run this command for users by email address(es). These users do
+not have to be present in
+[`backend/users/fixtures/user_fixtures.py`](/backend/users/fixtures/user_fixtures.py),
+but must have logged into the system in order for this to work.
+
+```shell
+docker compose run web python manage.py load_fixtures userone@example.com usertwo@example.com
+```
+
+This will create a fake submission for each of the users. These submissions
+will be separate for each user—this command only associates one user with each
+fake submission.
+
+Note that all of these fake submissions use the same UEI.
+
 ### Create a test bucket
 
 We need a mocked S3 bucket for testing.


### PR DESCRIPTION
UUIDs: hard.
Email addresses: easy.
Scope creep: ongoing.

-----

Tweak `load_fixtures` to also accept email addresses as arguments, hopefully removing the need to scrape login.gov UUIDs out of the logs.

Also some linter appeasement tweaks.