### PR TITLE
Fix submitter-only bug on audits table view

### DIFF
--- a/backend/audit/views.py
+++ b/backend/audit/views.py
@@ -24,7 +24,7 @@ from audit.mixins import (
     CertifyingAuditorRequiredMixin,
     SingleAuditChecklistAccessRequiredMixin,
 )
-from audit.models import ExcelFile, SingleAuditChecklist
+from audit.models import Access, ExcelFile, SingleAuditChecklist
 from audit.validators import (
     validate_federal_award_json,
     validate_corrective_action_plan_json,
@@ -53,18 +53,17 @@ class MySubmissions(LoginRequiredMixin, generic.View):
 
     @classmethod
     def fetch_my_submissions(cls, user):
-        data = (
-            SingleAuditChecklist.objects.all()
-            .values(
-                "report_id",
-                "submission_status",
-                auditee_uei=F("general_information__auditee_uei"),
-                auditee_name=F("general_information__auditee_name"),
-                fiscal_year_end_date=F(
-                    "general_information__auditee_fiscal_period_end"
-                ),
-            )
-            .filter(submitted_by=user)
+        """
+        Get all submissions the user is associated with via Access objects.
+        """
+        accesses = Access.objects.filter(user=user)
+        sac_ids = [access.sac.id for access in accesses]
+        data = SingleAuditChecklist.objects.filter(id__in=sac_ids).values(
+            "report_id",
+            "submission_status",
+            auditee_uei=F("general_information__auditee_uei"),
+            auditee_name=F("general_information__auditee_name"),
+            fiscal_year_end_date=F("general_information__auditee_fiscal_period_end"),
         )
         return data
 


### PR DESCRIPTION
Let every role see
Their current submission list
Not just creators.

-----

It turns out that the **In-progress Audit Submissions** table at `/audit` was only showing users the submissions they themselves created, not all of the submissions they’re associated with. This should fix that.

We should probably also have tests for this.
