### PR TITLE
Build and Publish Web Container

### DIFF
--- a/.github/workflows/build-docker-container.yml
+++ b/.github/workflows/build-docker-container.yml
@@ -34,9 +34,9 @@ on:
         default: gsa-tts/fac
 
 env:
-  DOCKER_NAME: ${{ inputs.docker-name }}
-  IMAGE: ${{ inputs.image-name }}
-  GH_REPO: ${{ inputs.repo-name }}
+  DOCKER_NAME: fac
+  IMAGE: web-container
+  GH_REPO: gsa-tts/fac
 
 jobs:
   build-with-docker:

--- a/.github/workflows/build-docker-container.yml
+++ b/.github/workflows/build-docker-container.yml
@@ -1,0 +1,59 @@
+---
+name: Build and Publish Docker Container
+on:
+  workflow_call:
+    inputs:
+      docker-name:
+        required: true
+        type: string
+        default: fac
+      image-name:
+        required: true
+        type: string
+        default: web-container
+      repo-name:
+        required: true
+        type: string
+        default: gsa-tts/fac
+
+env:
+  DOCKER_NAME: ${{ inputs.docker-name }}
+  IMAGE: ${{ inputs.image-name }}
+  GH_REPO: ${{ inputs.repo-name }}
+
+jobs:
+  build-with-docker:
+    name: Build Docker Container
+    runs-on: ubuntu-latest
+    permissions:
+        contents: read
+        packages: write
+    steps:
+      - name: Get Date
+        shell: bash
+        id: date
+        run: echo "date=$(date +%Y%m%d)" >> $GITHUB_OUTPUT
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build Container
+        working-directory: ./Docker
+        run: docker build -t ${{ env.DOCKER_NAME }}:${{ steps.date.outputs.date }} .
+
+      - name: Tag Image
+        run: docker tag ${{ env.DOCKER_NAME }}:${{ steps.date.outputs.date }} ghcr.io/${{ env.GH_REPO }}/${{ env.IMAGE }}:latest
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+            registry: ghcr.io
+            username: ${{ github.repository_owner }}
+            password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push Web Container
+        run: docker push --all-tags ghcr.io/${{ env.GH_REPO }}/${{ env.IMAGE }}

--- a/.github/workflows/build-docker-container.yml
+++ b/.github/workflows/build-docker-container.yml
@@ -42,10 +42,10 @@ on:
         default: ./backend
 
 env:
-  DOCKER_NAME: fac
-  IMAGE: web-container
-  GH_REPO: gsa-tts/fac
-  WORKING_DIRECTORY: ./backend
+  DOCKER_NAME: ${{ inputs.docker-name }}
+  IMAGE: ${{ inputs.image-name }}
+  GH_REPO: ${{ inputs.repo-name }}
+  WORKING_DIRECTORY: ${{ inputs.work-dir }}
 
 jobs:
   build-with-docker:

--- a/.github/workflows/build-docker-container.yml
+++ b/.github/workflows/build-docker-container.yml
@@ -1,6 +1,9 @@
 ---
 name: Build and Publish Docker Container
 on:
+  pull_request:
+    branches:
+      - main
   workflow_call:
     inputs:
       docker-name:

--- a/.github/workflows/build-docker-container.yml
+++ b/.github/workflows/build-docker-container.yml
@@ -1,6 +1,9 @@
 ---
 name: Build and Publish Docker Container
 on:
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       docker-name:

--- a/.github/workflows/build-docker-container.yml
+++ b/.github/workflows/build-docker-container.yml
@@ -1,9 +1,6 @@
 ---
 name: Build and Publish Docker Container
 on:
-  pull_request:
-    branches:
-      - main
   workflow_dispatch:
     inputs:
       docker-name:

--- a/.github/workflows/build-docker-container.yml
+++ b/.github/workflows/build-docker-container.yml
@@ -1,9 +1,20 @@
 ---
 name: Build and Publish Docker Container
 on:
-  pull_request:
-    branches:
-      - main
+  workflow_dispatch:
+    inputs:
+      docker-name:
+        required: true
+        type: string
+        default: fac
+      image-name:
+        required: true
+        type: string
+        default: web-container
+      repo-name:
+        required: true
+        type: string
+        default: gsa-tts/fac
   workflow_call:
     inputs:
       docker-name:

--- a/.github/workflows/build-docker-container.yml
+++ b/.github/workflows/build-docker-container.yml
@@ -18,6 +18,10 @@ on:
         required: true
         type: string
         default: gsa-tts/fac
+      work-dir:
+        required: true
+        type: string
+        default: ./backend
   workflow_call:
     inputs:
       docker-name:
@@ -32,11 +36,16 @@ on:
         required: true
         type: string
         default: gsa-tts/fac
+      work-dir:
+        required: true
+        type: string
+        default: ./backend
 
 env:
   DOCKER_NAME: fac
   IMAGE: web-container
   GH_REPO: gsa-tts/fac
+  WORKING_DIRECTORY: ./backend
 
 jobs:
   build-with-docker:
@@ -59,7 +68,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Build Container
-        working-directory: ./Docker
+        working-directory: ${{ env.WORKING_DIRECTORY }}
         run: docker build -t ${{ env.DOCKER_NAME }}:${{ steps.date.outputs.date }} .
 
       - name: Tag Image

--- a/.github/workflows/staging-scheduled-deploy.yml
+++ b/.github/workflows/staging-scheduled-deploy.yml
@@ -1,46 +1,46 @@
 ---
-    name: Scheduled Deploy From Main to Staging
-    on:
-      schedule:
-        - cron: '0 10 * * 1-5'
-      workflow_dispatch:
-    jobs:
-      trivy-scan:
-        uses: ./.github/workflows/trivy.yml
-        secrets: inherit
-        permissions:
-          contents: read
-          packages: write
-          actions: read
-          security-events: write
-        with:
-          work-dir: ./backend
-          docker-name: fac
+name: Scheduled Deploy From Main to Staging
+on:
+  schedule:
+    - cron: '0 10 * * 1-5'
+  workflow_dispatch:
+jobs:
+  trivy-scan:
+    uses: ./.github/workflows/trivy.yml
+    secrets: inherit
+    permissions:
+      contents: read
+      packages: write
+      actions: read
+      security-events: write
+    with:
+      work-dir: ./backend
+      docker-name: fac
 
-      build-container:
-        needs:
-          - trivy-scan
-        uses: ./.github/workflows/build-docker-container.yml
-        secrets: inherit
-        permissions:
-          contents: read
-          packages: write
-        with:
-          docker-name: fac
-          image-name: web-container
-          repo-name: gsa-tts/fac
-          work-dir: ./backend
+  build-container:
+    needs:
+      - trivy-scan
+    uses: ./.github/workflows/build-docker-container.yml
+    secrets: inherit
+    permissions:
+      contents: read
+      packages: write
+    with:
+      docker-name: fac
+      image-name: web-container
+      repo-name: gsa-tts/fac
+      work-dir: ./backend
 
-      test-and-lint:
-        name: Run Django, Lighthouse, a11y and lint
-        needs:
-          - build-container
-        uses: ./.github/workflows/test.yml
-        secrets: inherit
+  test-and-lint:
+    name: Run Django, Lighthouse, a11y and lint
+    needs:
+      - build-container
+    uses: ./.github/workflows/test.yml
+    secrets: inherit
 
-      create-pr:
-        needs:
-          - test-and-lint
-        name: Create Pull Request to Staging
-        uses: ./.github/workflows/auto-create-pr.yml
-        secrets: inherit
+  create-pr:
+    needs:
+      - test-and-lint
+    name: Create Pull Request to Staging
+    uses: ./.github/workflows/auto-create-pr.yml
+    secrets: inherit

--- a/.github/workflows/staging-scheduled-deploy.yml
+++ b/.github/workflows/staging-scheduled-deploy.yml
@@ -2,9 +2,43 @@
     name: Scheduled Deploy From Main to Staging
     on:
         schedule:
-        - cron: '30 4 * * *'
+        - cron: '0 10 * * 1-5'
     jobs:
+      trivy-scan:
+        uses: ./.github/workflows/trivy.yml
+        secrets: inherit
+        permissions:
+          contents: read
+          packages: write
+          actions: read
+          security-events: write
+        with:
+          work-dir: ./backend
+          docker-name: fac
+
+      build-container:
+        needs:
+          - trivy-scan
+        uses: ./.github/workflows/build-docker-container.yml
+        secrets: inherit
+        permissions:
+          contents: read
+          packages: write
+        with:
+          docker-name: fac
+          image-name: web-container
+          repo-name: gsa-tts/fac
+
+      test-and-lint:
+        name: Run Django, Lighthouse, a11y and lint
+        needs:
+          - build-container
+        uses: ./.github/workflows/test.yml
+        secrets: inherit
+
       create-pr:
-        name: Auto Create PR at 430am UTC Daily
+        needs:
+          - test-and-lint
+        name: Create Pull Request to Staging
         uses: ./.github/workflows/auto-create-pr.yml
         secrets: inherit

--- a/.github/workflows/staging-scheduled-deploy.yml
+++ b/.github/workflows/staging-scheduled-deploy.yml
@@ -1,8 +1,9 @@
 ---
     name: Scheduled Deploy From Main to Staging
     on:
-        schedule:
+      schedule:
         - cron: '0 10 * * 1-5'
+      workflow_dispatch:
     jobs:
       trivy-scan:
         uses: ./.github/workflows/trivy.yml

--- a/.github/workflows/staging-scheduled-deploy.yml
+++ b/.github/workflows/staging-scheduled-deploy.yml
@@ -28,6 +28,7 @@
           docker-name: fac
           image-name: web-container
           repo-name: gsa-tts/fac
+          work-dir: ./backend
 
       test-and-lint:
         name: Run Django, Lighthouse, a11y and lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 ---
-name: Runs linting and tests
+name: Run Testing and Linting
 on:
+  workflow_dispatch:
   workflow_call:
 
 jobs:
@@ -56,11 +57,11 @@ jobs:
       - name: Run HTML template linting
         working-directory: ./backend
         run: djlint --lint .
+
   frontend-linting:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
       - name: Restore npm cache
         uses: actions/cache@v3
         id: cache-npm
@@ -79,13 +80,14 @@ jobs:
       - name: Lint JS & SCSS
         working-directory: ./backend
         run: npm run check-all
-  test:
+
+  django-test:
     runs-on: ubuntu-latest
     env:
       ENV: TESTING
-      SAM_API_KEY: ${{ secrets.SAM_API_KEY }}"
+      SAM_API_KEY: ${{ secrets.SAM_API_KEY }}
       DJANGO_BASE_URL: 'http://localhost:8000'
-      DJANGO_SECRET_LOGIN_KEY: ${{ secrets.DJANGO_SECRET_LOGIN_KEY }}"
+      DJANGO_SECRET_LOGIN_KEY: ${{ secrets.DJANGO_SECRET_LOGIN_KEY }}
       SECRET_KEY: ${{ secrets.SECRET_KEY }}
       ALLOWED_HOSTS: '0.0.0.0 127.0.0.1 localhost'
       DISABLE_AUTH: False
@@ -94,24 +96,24 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16
-      - name: Pull Docker Hub images
+      - name: Create .env file
         working-directory: ./backend
-        run: touch .env && docker-compose pull
-      - name: Start services
+        run: touch .env
+      - name: Start Services
         working-directory: ./backend
-        run: docker-compose up -d
+        run: docker compose -f docker-compose-web.yml up -d
       - name: Run Django test suite
         working-directory: ./backend
-        run:
-          docker-compose run web bash -c 'coverage run --parallel-mode --concurrency=multiprocessing manage.py test --parallel &&
-          coverage combine && coverage report -m --fail-under=90'
+        run: |
+          docker compose -f docker-compose-web.yml run web bash -c 'coverage run --parallel-mode --concurrency=multiprocessing manage.py test --parallel && coverage combine && coverage report -m --fail-under=90'
+
   a11y-testing:
     runs-on: ubuntu-20.04
     env:
       ENV: TESTING
-      SAM_API_KEY: ${{ secrets.SAM_API_KEY }}"
+      SAM_API_KEY: ${{ secrets.SAM_API_KEY }}
       DJANGO_BASE_URL: 'http://localhost:8000'
-      DJANGO_SECRET_LOGIN_KEY: ${{ secrets.DJANGO_SECRET_LOGIN_KEY }}"
+      DJANGO_SECRET_LOGIN_KEY: ${{ secrets.DJANGO_SECRET_LOGIN_KEY }}
       SECRET_KEY: ${{ secrets.SECRET_KEY }}
       ALLOWED_HOSTS: '0.0.0.0 127.0.0.1 localhost'
       DISABLE_AUTH: True
@@ -120,12 +122,12 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16
-      - name: Pull Docker Hub images
+      - name: Create .env file
         working-directory: ./backend
-        run: touch .env && docker-compose pull
-      - name: Start services
+        run: touch .env
+      - name: Start Services
         working-directory: ./backend
-        run: docker-compose up -d
+        run: docker compose -f docker-compose-web.yml up -d
       - name: run Lighthouse CI
         run: |
           npm install -g @lhci/cli@0.8.x
@@ -134,5 +136,6 @@ jobs:
         run: |
           npm i -g pa11y-ci
           pa11y-ci
+
   validate-terraform:
     uses: ./.github/workflows/terraform-lint.yml

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,66 @@
+---
+name: Trivy Scan
+on:
+  workflow_dispatch:
+    inputs:
+      work-dir:
+        required: true
+        type: string
+        default: ./Docker
+      docker-name:
+        required: true
+        type: string
+        default: fac
+  workflow_call:
+    inputs:
+      work-dir:
+        required: true
+        type: string
+        default: ./backend
+      docker-name:
+        required: true
+        type: string
+        default: fac
+
+permissions:
+  contents: read
+
+env:
+    DOCKER_NAME: ${{ inputs.docker-name }}
+    WORKING_DIRECTORY: ${{ inputs.work-dir }}
+
+jobs:
+    trivy:
+      permissions:
+        contents: read
+        security-events: write
+        actions: read
+      name: Trivy Scan
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v3
+
+        - name: Get Date
+          shell: bash
+          id: date
+          run: |
+            echo "date=$(date +%Y%m%d%H%M%S)" >> $GITHUB_OUTPUT
+
+        - name: Build Container
+          working-directory: ${{ env.WORKING_DIRECTORY }}
+          run: docker build -t ${{ env.DOCKER_NAME }}:${{ steps.date.outputs.date }} .
+
+        - name: Run Trivy vulnerability scanner
+          uses: aquasecurity/trivy-action@0.11.2
+          with:
+            image-ref: '${{ env.DOCKER_NAME }}:${{ steps.date.outputs.date }}'
+            format: 'sarif'
+            output: 'trivy-results.sarif'
+            severity: 'CRITICAL,HIGH'
+            exit-code: 1
+
+        - name: Upload Trivy scan results to GitHub Security tab
+          uses: github/codeql-action/upload-sarif@v2
+          with:
+            sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -58,10 +58,12 @@ jobs:
           uses: aquasecurity/trivy-action@master
           with:
             image-ref: '${{ env.DOCKER_NAME }}:${{ steps.date.outputs.date }}'
+            scan-type: 'fs'
+            hide-progress: false
             format: 'sarif'
+            output: 'trivy-results.sarif'
             exit-code: '1'
             ignore-unfixed: true
-            vuln-type: 'os,library'
             severity: 'CRITICAL,HIGH'
 
         - name: Upload Trivy scan results to GitHub Security tab

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -21,13 +21,16 @@ on:
         required: true
         type: string
         default: fac
+  pull_request:
+    branches:
+      - main
 
 permissions:
   contents: read
 
 env:
-    DOCKER_NAME: ${{ inputs.docker-name }}
-    WORKING_DIRECTORY: ${{ inputs.work-dir }}
+    DOCKER_NAME: fac
+    WORKING_DIRECTORY: ./backend
 
 jobs:
     trivy:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -55,13 +55,12 @@ jobs:
           uses: aquasecurity/trivy-action@master
           with:
             image-ref: '${{ env.DOCKER_NAME }}:${{ steps.date.outputs.date }}'
-            scan-type: 'fs'
+            scan-type: 'image'
             hide-progress: false
             format: 'sarif'
             output: 'trivy-results.sarif'
             exit-code: '1'
             ignore-unfixed: true
-            severity: 'CRITICAL,HIGH'
 
         - name: Upload Trivy scan results to GitHub Security tab
           uses: github/codeql-action/upload-sarif@v2

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -58,10 +58,10 @@ jobs:
           uses: aquasecurity/trivy-action@master
           with:
             image-ref: '${{ env.DOCKER_NAME }}:${{ steps.date.outputs.date }}'
-            scan-type: 'fs'
-            ignore-unfixed: true
             format: 'sarif'
-            output: 'trivy-results.sarif'
+            exit-code: '1'
+            ignore-unfixed: true
+            vuln-type: 'os,library'
             severity: 'CRITICAL,HIGH'
 
         - name: Upload Trivy scan results to GitHub Security tab

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -21,13 +21,16 @@ on:
         required: true
         type: string
         default: ./backend
+  pull_request:
+    branches:
+      - main
 
 permissions:
   contents: read
 
 env:
-    DOCKER_NAME: ${{ inputs.docker-name }}
-    WORKING_DIRECTORY: ${{ inputs.work-dir }}
+    DOCKER_NAME: fac
+    WORKING_DIRECTORY: ./backend
 
 jobs:
     trivy:
@@ -52,13 +55,14 @@ jobs:
           run: docker build -t ${{ env.DOCKER_NAME }}:${{ steps.date.outputs.date }} .
 
         - name: Run Trivy vulnerability scanner
-          uses: aquasecurity/trivy-action@0.11.2
+          uses: aquasecurity/trivy-action@master
           with:
             image-ref: '${{ env.DOCKER_NAME }}:${{ steps.date.outputs.date }}'
+            scan-type: 'fs'
+            ignore-unfixed: true
             format: 'sarif'
             output: 'trivy-results.sarif'
             severity: 'CRITICAL,HIGH'
-            exit-code: 1
 
         - name: Upload Trivy scan results to GitHub Security tab
           uses: github/codeql-action/upload-sarif@v2

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -3,24 +3,24 @@ name: Trivy Scan
 on:
   workflow_dispatch:
     inputs:
-      work-dir:
-        required: true
-        type: string
-        default: ./Docker
       docker-name:
         required: true
         type: string
         default: fac
-  workflow_call:
-    inputs:
       work-dir:
         required: true
         type: string
         default: ./backend
+  workflow_call:
+    inputs:
       docker-name:
         required: true
         type: string
         default: fac
+      work-dir:
+        required: true
+        type: string
+        default: ./backend
 
 permissions:
   contents: read

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -21,16 +21,13 @@ on:
         required: true
         type: string
         default: fac
-  pull_request:
-    branches:
-      - main
 
 permissions:
   contents: read
 
 env:
-    DOCKER_NAME: fac
-    WORKING_DIRECTORY: ./backend
+    DOCKER_NAME: ${{ inputs.docker-name }}
+    WORKING_DIRECTORY: ${{ inputs.work-dir }}
 
 jobs:
     trivy:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -21,16 +21,13 @@ on:
         required: true
         type: string
         default: ./backend
-  pull_request:
-    branches:
-      - main
 
 permissions:
   contents: read
 
 env:
-    DOCKER_NAME: fac
-    WORKING_DIRECTORY: ./backend
+    DOCKER_NAME: ${{ inputs.docker-name }}
+    WORKING_DIRECTORY: ${{ inputs.work-dir }}
 
 jobs:
     trivy:

--- a/backend/docker-compose-web.yml
+++ b/backend/docker-compose-web.yml
@@ -1,0 +1,71 @@
+---
+version: "3.7"
+
+services:
+  db:
+    image: "postgres:12"
+    environment:
+      - "POSTGRES_HOST_AUTH_METHOD=trust"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data/
+    ports:
+      - "5432:5432"
+
+  web:
+    image: ghcr.io/gsa-tts/fac/web-container:latest
+    command: /src/run.sh
+    depends_on:
+      - db
+      - minio
+    environment:
+      - "DATABASE_URL=postgres://postgres@db/postgres"
+      - "DJANGO_DEBUG=true"
+      - "SAM_API_KEY=${SAM_API_KEY}"
+      - "DJANGO_BASE_URL=http://localhost:8000"
+      - "DJANGO_SECRET_LOGIN_KEY=${DJANGO_SECRET_LOGIN_KEY}"
+      - "ENV=${ENV}"
+      - "SECRET_KEY=${SECRET_KEY}"
+      - "ALLOWED_HOSTS=0.0.0.0 127.0.0.1 localhost"
+      - "AV_SCAN_URL=http://clamav-rest:9000/scan"
+      - "DISABLE_AUTH=${DISABLE_AUTH:-False}"
+      - "LOCALSTACK_HOST=localstack"
+    env_file:
+      - ".env"
+    ports:
+      - "8000:8000"
+    volumes:
+      - .:/src
+      - /src/node_modules
+      - /src/staticfiles
+  clamav-rest:
+    image: ghcr.io/gsa-tts/fac/clamav:latest
+    environment:
+      - MAX_FILE_SIZE=25M
+      - SIGNATURE_CHECKS=1
+    ports:
+      - "9000:9000"
+  minio:
+    container_name: "minio"
+    image: minio/minio
+    command: server /tmp/minio --console-address ":9002"
+    ports:
+      - "9001:9000"
+      - "9002:9002"
+    volumes:
+      - "minio-vol:/tmp/minio"
+  api:
+    image: ghcr.io/gsa-tts/fac/postgrest:latest
+    ports:
+      - "3000:3000"
+    expose:
+      - "3000"
+    environment:
+      PGRST_DB_URI: postgres://postgres@db:5432/postgres
+      PGRST_OPENAPI_SERVER_PROXY_URI: http://127.0.0.1:3000
+      PGRST_DB_ANON_ROLE: anon
+      PGRST_DB_SCHEMAS: api
+    depends_on:
+      - db
+volumes:
+  postgres-data:
+  minio-vol:


### PR DESCRIPTION
```mermaid
graph TD;
  A[Schedule 6a EST M-F]--> B[Trivy Scan];
  B-->C[Publish To Security Tab];
  A-->D[Build Web Container];
  D-->E[Publish Container to ghcr];
  A-->F[Lint Code];
  F-->G[Pull Container from ghcr];
  G-->H[Run Django Tests];
  H-->I[Run Lighthouse Tests];
  I-->J[Run a11y Tests];
  A-->K[Create Pull Request to Staging];
  K-->L[No Action - Exit 1];
  K-->M[Pull Request Created];
  M-->N[Ready for Review];
```

### Note:
- Using `docker-compose-web.yml` for now, just to ensure that there are two `docker-compose` files. One for locally building the image if one chooses, and the other to pull the image from `ghcr.io/gsa-tts/fac/web-container:latest`
- Current Trivy Scan in `scan-images.yml` only checks for `postgrest` and `clamav` running on a weekly schedule, adding `trivy.yml` to scan the web container before building and publishing to `fac ghcr` as this will run daily (weekdays only). 
- `fac/web-container` will not be version controlled by `YYYYMMDD` and opts for `:latest` only.

### Required inputs:
- Trivy
    -  work-dir: ./backend
    - docker-name: fac
- Build Container
    - docker-name: fac
    - image-name: web-container
    - repo-name: gsa-tts/fac
    - work-dir: ./backend