### PR TITLE
Remove ref to nonexistent app and insert our own simple storage class

### DIFF
--- a/backend/audit/storages.py
+++ b/backend/audit/storages.py
@@ -1,0 +1,13 @@
+from django.conf import settings
+from storages.backends.s3boto3 import S3Boto3Storage
+
+
+class PrivateS3Storage(S3Boto3Storage):
+    """
+    Our S3 settings as a storage class.
+    """
+
+    bucket_name = settings.AWS_PRIVATE_STORAGE_BUCKET_NAME
+    access_key = settings.AWS_PRIVATE_ACCESS_KEY_ID
+    secret_key = settings.AWS_PRIVATE_SECRET_ACCESS_KEY
+    location = ""

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -258,7 +258,7 @@ else:
             STATIC_URL = f"https://{AWS_S3_CUSTOM_DOMAIN}/{AWS_LOCATION}/"
 
             STATICFILES_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
-            DEFAULT_FILE_STORAGE = "cts_forms.storages.PrivateS3Storage"
+            DEFAULT_FILE_STORAGE = "audit.storages.PrivateS3Storage"
             AWS_IS_GZIPPED = True
 
         elif service["instance_name"] == "fac-private-s3":


### PR DESCRIPTION
No CTS Forms
Because that’s a holdover
So we make our own

-----

We had this stray reference to a module from another project in our settings. Change it to a storage class we add.

The only way to test this is in a cloud.gov environment, so we're testing it on `dev`.
