### PR TITLE
Don't override `DEFAULT_FILE_STORAGE` in cloud.gov environments

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -258,7 +258,6 @@ else:
             STATIC_URL = f"https://{AWS_S3_CUSTOM_DOMAIN}/{AWS_LOCATION}/"
 
             STATICFILES_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
-            DEFAULT_FILE_STORAGE = "audit.storages.PrivateS3Storage"
             AWS_IS_GZIPPED = True
 
         elif service["instance_name"] == "fac-private-s3":


### PR DESCRIPTION
Confusing logic
In the settings file: oh no!
Let's not override.

-----

The original intent seems to have been to change `DEFAULT_FILE_STORAGE` when working against the public S3 bucket, but the old version doesn’t actually do that, it just sets the `DEFAULT_FILE_STORAGE` value at startup time if there’s any `fac-public-s3` setting in `VCAP_SERVICES`—which there always will be.

Removing the line should result in the value for `DEFAULT_FILE_STORAGE` to remain as what it should be in the cloud.gov environments.