### PR TITLE
Pretty sure we want the private S3 bucket for default file storage.

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -233,7 +233,7 @@ if ENVIRONMENT not in ["DEVELOPMENT", "STAGING", "PRODUCTION"]:
 else:
     # One of the Cloud.gov environments
     STATICFILES_STORAGE = "storages.backends.s3boto3.S3ManifestStaticStorage"
-    DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
+    DEFAULT_FILE_STORAGE = "report_submission.storages.S3PrivateStorage"
     vcap = json.loads(env.str("VCAP_SERVICES"))
     for service in vcap["s3"]:
         if service["instance_name"] == "fac-public-s3":


### PR DESCRIPTION
Uploads are private
So we shouldn’t use the default.
At least I hope not.

-----

Change the value for DEFAULT_FILE_STORAGE in `settings.py` to use the custom storage, which is just a wrapper around the private S3 URLs, rather than the boto default, which uses the public URLs, AFAICT.