### PR TITLE
Fix tasklist defaults

### DIFF
--- a/.github/ISSUE_TEMPLATE/story-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/story-issue-template.md
@@ -40,7 +40,7 @@ We use [DRY](https://docs.behat.org/en/latest/user_guide/writing_scenarios.html#
 [comment]: # "Each task should be a verifiable outcome"
 ```[tasklist]
 ### then... 
-- [ ] 
+- [ ] [a thing happens]
 ```
 
 ### Shepherd
@@ -68,7 +68,7 @@ We're thinking we'll try implementing A and then changing B.
 
 ```[tasklist]
 # Tasks
-- [ ] 
+- [ ] [something we'll definitely have to do]
 ```
 
 ---


### PR DESCRIPTION
GitHub will throw a scary error message when it tries to render a malformed tasklist. Empty tasks are not permitted! Fixing the template here will encourage people to use tasklists as intended rather than just skip or remove them when they create new issues.