### PR TITLE
Make Excel file saving set unique filename

### DIFF
--- a/backend/audit/models.py
+++ b/backend/audit/models.py
@@ -475,12 +475,22 @@ class Access(models.Model):
         ]
 
 
+def excel_file_path(instance, filename):
+    """
+    We want the actual filename in the filesystem to be unique and determined
+    by report_id and form_section--not the user-provided filename.
+    """
+    base_path = "excel"
+    report_id = SingleAuditChecklist.objects.get(id=instance.sac.id).report_id
+    return f"{base_path}/{report_id}--{instance.form_section}.xlsx"
+
+
 class ExcelFile(models.Model):
     """
     Data model to track uploaded Excel files and associate them with SingleAuditChecklists
     """
 
-    file = models.FileField(upload_to="excel", validators=[validate_excel_file])
+    file = models.FileField(upload_to=excel_file_path, validators=[validate_excel_file])
     filename = models.CharField(max_length=255)
     form_section = models.CharField(max_length=255)
     sac = models.ForeignKey(SingleAuditChecklist, on_delete=models.CASCADE)

--- a/backend/audit/models.py
+++ b/backend/audit/models.py
@@ -475,14 +475,12 @@ class Access(models.Model):
         ]
 
 
-def excel_file_path(instance, filename):
+def excel_file_path(instance, _filename):
     """
     We want the actual filename in the filesystem to be unique and determined
     by report_id and form_section--not the user-provided filename.
     """
-    base_path = "excel"
-    report_id = SingleAuditChecklist.objects.get(id=instance.sac.id).report_id
-    return f"{base_path}/{report_id}--{instance.form_section}.xlsx"
+    return f"excel/{instance.sac.report_id}--{instance.form_section}.xlsx"
 
 
 class ExcelFile(models.Model):
@@ -498,6 +496,5 @@ class ExcelFile(models.Model):
     date_created = models.DateTimeField(auto_now_add=True)
 
     def save(self, *args, **kwargs):
-        report_id = SingleAuditChecklist.objects.get(id=self.sac.id).report_id
-        self.filename = f"{report_id}--{self.form_section}.xlsx"
+        self.filename = f"{self.sac.report_id}--{self.form_section}.xlsx"
         super(ExcelFile, self).save(*args, **kwargs)

--- a/backend/audit/validators.py
+++ b/backend/audit/validators.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 
 MAX_EXCEL_FILE_SIZE_MB = 25
 
-ALLOWED_EXCEL_FILE_EXTENSIONS = [".xls", ".xlsx"]
+ALLOWED_EXCEL_FILE_EXTENSIONS = [".xlsx"]
 
 ALLOWED_EXCEL_CONTENT_TYPES = [
     "application/vnd.ms-excel",


### PR DESCRIPTION
Set our own filenames.
Even in the filesystem.
We mean it this time.

-----

Actually set the filesystem name for the file, not just the attribute in the database model.