### PR TITLE
Stray fix for USWDS sprite

### DIFF
--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -151,7 +151,7 @@ class Sprite(generic.View):
     particular file from Django.
     """
 
-    def get(self):
+    def get(self, _request):
         """Grab the file from static and return its contents as an image."""
         fpath = BASE_DIR / "static" / "img" / "sprite.svg"
         return HttpResponse(


### PR DESCRIPTION
Beware of linters.
For the truth in their warnings
May mask deeper harm.

-----

Fix the method for the USWDS sprite view.