### PR TITLE
Add private S3 bucket to manifest.

### DIFF
--- a/backend/manifests/manifest-fac.yml
+++ b/backend/manifests/manifest-fac.yml
@@ -19,6 +19,7 @@ applications:
     services:
       - fac-db
       - fac-public-s3
+      - fac-private-s3
       - fac-key-service
       - newrelic-creds
       - https-proxy-creds


### PR DESCRIPTION
[Bret said](https://github.com/GSA-TTS/FAC/issues/1352#issuecomment-1613918754) to add this
To manifest services.
Thus I make it so.

-----

Add `fac-private-s3` to the list of services in the cloud.gov manifest so that we don’t need to remember to do it manually for each environment.