### PR TITLE
Update validation rules for Federal Awards so that test file passes

### DIFF
--- a/backend/audit/test_schemas.py
+++ b/backend/audit/test_schemas.py
@@ -1,6 +1,7 @@
 # Even though the schemas are not Django views or modules etc., we test them
 # here for CI/CD integration.
 import json
+import random
 import string
 from collections import deque
 from random import choice, randrange
@@ -599,7 +600,6 @@ class FederalAwardsSchemaValidityTest(SimpleTestCase):
                 "three_digit_extension": "123",
                 "program_name": "Bob",
                 "is_major": "Y",
-                "audit_report_type": "Z",
                 "number_of_audit_findings": 0,
                 "amount_expended": 42,
             }
@@ -681,7 +681,7 @@ class FederalAwardsSchemaValidityTest(SimpleTestCase):
             validate(simple_case, schema)
 
         for report_type in ["U", "D"]:
-            # major_audit_report_type of U or D requires zero number_of_audit_findings
+            # major_audit_report_type of U or D can be zero or greater
             simple_case["FederalAwards"]["federal_awards"][0]["program"][
                 "audit_report_type"
             ] = report_type
@@ -692,8 +692,8 @@ class FederalAwardsSchemaValidityTest(SimpleTestCase):
 
             simple_case["FederalAwards"]["federal_awards"][0]["program"][
                 "number_of_audit_findings"
-            ] = 1
-            self.assertRaises(exceptions.ValidationError, validate, simple_case, schema)
+            ] = random.randint(1, 100)
+            validate(simple_case, schema)
 
 
 class CorrectiveActionPlanSchemaValidityTest(SimpleTestCase):

--- a/backend/schemas/output/sections/FederalAwards.schema.json
+++ b/backend/schemas/output/sections/FederalAwards.schema.json
@@ -360,6 +360,14 @@
                         "additionalProperties": false,
                         "allOf": [
                            {
+                              "properties": {
+                                 "number_of_audit_findings": {
+                                    "minimum": 0,
+                                    "type": "integer"
+                                 }
+                              }
+                           },
+                           {
                               "if": {
                                  "properties": {
                                     "is_major": {
@@ -368,25 +376,6 @@
                                  }
                               },
                               "then": {
-                                 "else": {
-                                    "properties": {
-                                       "audit_report_type": {
-                                          "description": "Major program report types",
-                                          "enum": [
-                                             "U",
-                                             "Q",
-                                             "A",
-                                             "D"
-                                          ],
-                                          "title": "MajorProgramAuditReportType",
-                                          "type": "string"
-                                       },
-                                       "number_of_audit_findings": {
-                                          "const": 0,
-                                          "type": "integer"
-                                       }
-                                    }
-                                 },
                                  "if": {
                                     "properties": {
                                        "audit_report_type": {
@@ -428,9 +417,6 @@
                                           "null"
                                        ],
                                        "title": "EmptyString_Null"
-                                    },
-                                    "number_of_audit_findings": {
-                                       "const": 0
                                     }
                                  }
                               }
@@ -568,7 +554,6 @@
                            "federal_agency_prefix",
                            "three_digit_extension",
                            "is_major",
-                           "audit_report_type",
                            "number_of_audit_findings"
                         ],
                         "type": "object"

--- a/backend/schemas/source/sections/FederalAwards.schema.jsonnet
+++ b/backend/schemas/source/sections/FederalAwards.schema.jsonnet
@@ -109,6 +109,13 @@ local Validations = {
   ],
   ProgramValidations: [
     {
+      properties: {
+        number_of_audit_findings: Types.integer {
+          minimum: 0,
+        },
+      },
+    },
+    {
       'if': {
         properties: {
           is_major: {
@@ -138,14 +145,6 @@ local Validations = {
             },
           },
         },
-        'else': {
-          properties: {
-            audit_report_type: Base.Enum.MajorProgramAuditReportType,
-            number_of_audit_findings: Types.integer {
-              const: 0,
-            },
-          },
-        },
       },
     },
     {
@@ -163,9 +162,7 @@ local Validations = {
       'then': {
         properties: {
           audit_report_type: Base.Enum.EmptyString_Null,
-          number_of_audit_findings: { const: 0 },
         },
-
       },
     },
     Base.Validation.AdditionalAwardIdentificationValidation[0],
@@ -214,7 +211,7 @@ local Parts = {
         },
         'then': {
           required: [
-          'state_cluster_name',
+            'state_cluster_name',
           ],
           allOf: [
             {
@@ -240,8 +237,8 @@ local Parts = {
         },
         'then': {
           required: [
-          'other_cluster_name',
-          ],          
+            'other_cluster_name',
+          ],
           allOf: [
             {
               properties: {
@@ -316,7 +313,7 @@ local Parts = {
       audit_report_type: Types.string,
       number_of_audit_findings: Types.integer,
     },
-    required: ['program_name', 'federal_agency_prefix', 'three_digit_extension', 'is_major', 'audit_report_type', 'number_of_audit_findings'],
+    required: ['program_name', 'federal_agency_prefix', 'three_digit_extension', 'is_major', 'number_of_audit_findings'],
     allOf: Validations.ProgramValidations,
   },
 };


### PR DESCRIPTION
Should it be zero?
Nay! It should be _at least_ that!
Or so we now think.

-----

Validation updates to make our current Federal Awards workbook test file pass validation.

I was just the typist; actual work here done by @jadudm @sambodeme @neilmb

I also ran the file through `jsonnetfmt`, which is why there are a couple of minor stray whitespace changes.
