### PR TITLE
Disable schedule for auto-deploy

### DIFF
--- a/.github/workflows/staging-scheduled-deploy.yml
+++ b/.github/workflows/staging-scheduled-deploy.yml
@@ -1,9 +1,10 @@
 ---
 name: Scheduled Deploy From Main to Staging
 on:
-  schedule:
-    - cron: '0 10 * * 1-5'
-  workflow_dispatch:
+  # schedule:
+  #   - cron: '0 10 * * 1-5'
+  # Disable Schedule for Pen Testing
+  workflow_dispatch: null
 jobs:
   trivy-scan:
     uses: ./.github/workflows/trivy.yml


### PR DESCRIPTION
Disable Auto Deploy for 10 days for pentesting