### PR TITLE
Ignore changes to ASGs outside Terraform

### DIFF
--- a/terraform/management/main.tf
+++ b/terraform/management/main.tf
@@ -18,6 +18,14 @@ resource "cloudfoundry_space" "space" {
   allow_ssh = each.key != "production"
 
   asgs = [for d in data.cloudfoundry_asg.asgs : d.id]
+
+  # Until the CF provider can properly handle ASGs, we're handling removal of the public_egress ASG manually outside of Terraform.
+  # https://github.com/cloudfoundry-community/terraform-provider-cloudfoundry/issues/405
+  lifecycle {
+    ignore_changes = [
+      asgs,
+    ]
+  }
 }
 
 resource "cloudfoundry_space_users" "space_permissions" {


### PR DESCRIPTION
Until the Terraform provider enables fine-grained manipulation of a space's ASGs by an OrgManager, we have to do it manually. Ignoring changes here using the `lifecycle` attribute will prevent Terraform from trying to undo changes made manually (eg removal of the public egress ASGs on the non-egress spaces).