### PR TITLE
Selects active API schema

### DIFF
--- a/terraform/shared/modules/env/postgrest.tf
+++ b/terraform/shared/modules/env/postgrest.tf
@@ -28,7 +28,7 @@ resource "cloudfoundry_app" "postgrest" {
 
   environment = {
     PGRST_DB_URI : cloudfoundry_service_key.postgrest.credentials.uri
-    PGRST_DB_SCHEMAS : "api"
+    PGRST_DB_SCHEMAS : "api_v1_0_0_beta"
     PGRST_DB_ANON_ROLE : "anon"
   }
 }


### PR DESCRIPTION
We should always follow our lifecycle rules.

https://github.com/GSA-TTS/FAC/discussions/1465

In this case, we're still not at v1.

This selects the schemas that are avaialble for use. PostgREST expects a comma-separated list of schemas; the first one is the default. (See our docs and PostgREST's docs for more info.)

https://postgrest.org/en/stable/references/api/schemas.html