### PR TITLE
Update development docs: remove references to localstack

### DIFF
--- a/backend/docker-compose-web.yml
+++ b/backend/docker-compose-web.yml
@@ -31,7 +31,6 @@ services:
       - "ALLOWED_HOSTS=0.0.0.0 127.0.0.1 localhost"
       - "AV_SCAN_URL=http://clamav-rest:9000/scan"
       - "DISABLE_AUTH=${DISABLE_AUTH:-False}"
-      - "LOCALSTACK_HOST=localstack"
     env_file:
       - ".env"
     ports:

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -31,7 +31,6 @@ services:
       - "ALLOWED_HOSTS=0.0.0.0 127.0.0.1 localhost"
       - "AV_SCAN_URL=http://clamav-rest:9000/scan"
       - "DISABLE_AUTH=${DISABLE_AUTH:-False}"
-      - "LOCALSTACK_HOST=localstack"
     env_file:
       - ".env"
     ports:

--- a/docs/development.md
+++ b/docs/development.md
@@ -21,7 +21,6 @@ We use either [Docker with `docker compose`](#docker) or [local development](#lo
   * [pyenv-virtualenv](https://github.com/pyenv/pyenv-virtualenv) for managing virtual environments
   * [Postgres](https://www.postgresql.org/)
   * [SAM.gov](https://sam.gov/content/home) to validate UEI's
-  * [LocalStack](https://localstack.cloud/) for S3 emulation
 
 ## Setting up your dev environment
 
@@ -202,14 +201,6 @@ will be separate for each user—this command only associates one user with each
 fake submission.
 
 Note that all of these fake submissions use the same UEI.
-
-### Create a test bucket
-
-We need a mocked S3 bucket for testing.
-
-```
-docker compose run web bash -c 'awslocal s3 mb s3://gsa-fac-private-s3'
-```
 
 ### Run tests
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -66,14 +66,6 @@ python -m pip install --upgrade pip
 pip install pip-tools
 ```
 
-### LocalStack
-
-LocalStack is an AWS emulator. We use it to emulate S3 for storing files that users upload.
-
-It will set itself up correctly if you run the app with `docker compose up`. 
-
-If you wish to run the app locally, you'll need to install this locally as well. You can find [installation instructions](https://docs.localstack.cloud/getting-started/installation/) on their website.
-
 ### Django environment variables
 
 We use environment variables to configure much of how Django operates, at a minimum you'll need to configure the uri of your local database.


### PR DESCRIPTION
Noticed these dangling references to localstack that are no longer relevant after moving to minio.