### PR TITLE
Fix Excel file upload field error reporting in frontend

### DIFF
--- a/backend/static/js/upload-page.js
+++ b/backend/static/js/upload-page.js
@@ -132,7 +132,7 @@ function attachFileUploadHandler() {
                   handleErrorOnUpload(new Error(data.errors[0]));
                 info_box.innerHTML = get_error_table(data);
               } else if (data.type === 'error_field') {
-                info_box.innerHTML = `Field Error: ${res.errors}`;
+                info_box.innerHTML = `Field Error: ${data.errors}`;
               } else {
                 throw new Error('Returned error type is missing!');
               }


### PR DESCRIPTION
`res` already read
Thus it no longer exists
So don’t read from it.

-----

Field-specific Excel errors were showing up as `undefined` instead of passing the actual error through from the backend. This should fix that error.
