### PR TITLE
Change SAC str representation

### DIFF
--- a/backend/audit/models.py
+++ b/backend/audit/models.py
@@ -114,7 +114,7 @@ class SingleAuditChecklist(models.Model, GeneralInformationMixin):  # type: igno
 
     # Method overrides:
     def __str__(self):
-        return f"#{self.id} - UEI({self.auditee_uei})"
+        return f"#{self.id}--{self.report_id}--{self.auditee_uei}"
 
     def save(self, *args, **kwds):
         """

--- a/backend/audit/test_models.py
+++ b/backend/audit/test_models.py
@@ -23,7 +23,7 @@ class SingleAuditChecklistTests(TestCase):
     def test_str_is_id_and_uei(self):
         """String representation of SAC instance is #{ID} - UEI({UEI})"""
         sac = baker.make(SingleAuditChecklist)
-        self.assertEqual(str(sac), f"#{sac.id} - UEI({sac.auditee_uei})")
+        self.assertEqual(str(sac), f"#{sac.id}--{sac.report_id}--{sac.auditee_uei}")
 
     def test_report_id(self):
         """


### PR DESCRIPTION
Add `report_id`
To represent submissions
Not just UEI.

-----

Changes how submissions look as strings (for example in the Django shell or in Django admin views) from e.g. `#4 - UEI(DJ4KNQ383PH7)` to  e.g. `#4--2023JUL0001000004--DJ4KNQ383PH7`.