### PR TITLE
Add Schedule and environment input

### DIFF
--- a/.github/workflows/daily-regression-tests.yml
+++ b/.github/workflows/daily-regression-tests.yml
@@ -1,0 +1,14 @@
+---
+name: Run Daily Regression Tests
+on:
+  schedule:
+    - cron: '0 9 * * 1-5'
+
+jobs:
+  regression-test:
+    name: Run Regression Tests
+    uses: ./.github/workflows/regression-tests.yml
+    secrets: inherit
+    with:
+      url: "https://fac-staging.app.cloud.gov"
+      environment: "staging"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -55,3 +55,4 @@ jobs:
     secrets: inherit
     with:
       url: "https://fac-staging.app.cloud.gov"
+      environment: "staging"

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -7,19 +7,23 @@ on:
         description: "Base URL for Cypress"
         required: true
         type: string
+      environment:
+        required: true
+        type: string
   workflow_call:
     inputs:
       url:
         description: "Base URL for Cypress"
         required: true
         type: string
-  schedule:
-    - cron: '0 9 * * 1-5'
+      environment:
+        required: true
+        type: string
 
 jobs:
   regression-testing:
     runs-on: ubuntu-latest
-    environment: staging
+    environment: ${{ inputs.environment }}
     env:
       CYPRESS_BASE_URL: ${{ inputs.url }}
       CYPRESS_LOGIN_TEST_EMAIL: ${{ secrets.CYPRESS_LOGIN_TEST_EMAIL }}


### PR DESCRIPTION
Fixes the schedule to allow inputs, without removing core functionality.
Adds `environment` input for future

Schedule does not natively support inputs, only `workflow_call` and `workflow_dispatch` do. The schedule saw `${{ inputs.url }}` as a `null` value. 