### PR TITLE
Workaround for SAM.gov in OpenSSL v3

### DIFF
--- a/backend/api/test_serializers.py
+++ b/backend/api/test_serializers.py
@@ -71,7 +71,7 @@ class UEIValidatorStepTests(SimpleTestCase):
         valid = {"auditee_uei": "ZQGGHJH74DW7"}
 
         # Valid
-        with patch("api.uei.requests.get") as mock_get:
+        with patch("api.uei.SESSION.get") as mock_get:
             mock_get.return_value.status_code = 200  # Mock the status code
             mock_get.return_value.json.return_value = json.loads(
                 valid_uei_results
@@ -80,7 +80,7 @@ class UEIValidatorStepTests(SimpleTestCase):
             self.assertTrue(UEISerializer(data=valid).is_valid())
 
         # Has errors
-        with patch("api.uei.requests.get") as mock_get:
+        with patch("api.uei.SESSION.get") as mock_get:
             mock_get.return_value.status_code = 200  # Mock the status code
             mock_get.return_value.json.return_value = {"errors": [1, 2, 3]}
             self.assertFalse(UEISerializer(data=valid).is_valid())

--- a/backend/api/test_uei.py
+++ b/backend/api/test_uei.py
@@ -291,7 +291,7 @@ class UtilsTesting(TestCase):
         test_uei = "ZQGGHJH74DW7"
 
         # Valid
-        with patch("api.uei.requests.get") as mock_get:
+        with patch("api.uei.SESSION.get") as mock_get:
             mock_get.return_value.status_code = 200  # Mock the status code
             mock_get.return_value.json.return_value = json.loads(
                 valid_uei_results
@@ -306,7 +306,7 @@ class UtilsTesting(TestCase):
             )
 
         # Invalid Status Code
-        with patch("api.uei.requests.get") as mock_get:
+        with patch("api.uei.SESSION.get") as mock_get:
             mock_get.return_value.status_code = 400  # Mock the status code
             results = get_uei_info_from_sam_gov(uei=test_uei)
 
@@ -318,7 +318,7 @@ class UtilsTesting(TestCase):
             )
 
         # Timeout
-        with patch("api.uei.requests.get") as mock_get:
+        with patch("api.uei.SESSION.get") as mock_get:
 
             def bad_timeout(*args, **kwds):
                 raise requests.exceptions.Timeout
@@ -331,7 +331,7 @@ class UtilsTesting(TestCase):
             self.assertEquals(results["errors"], ["SAM.gov API timeout"])
 
         # TooManyRedirects
-        with patch("api.uei.requests.get") as mock_get:
+        with patch("api.uei.SESSION.get") as mock_get:
 
             def bad_redirects(*args, **kwds):
                 raise requests.exceptions.TooManyRedirects
@@ -346,7 +346,7 @@ class UtilsTesting(TestCase):
             )
 
         # RequestException
-        with patch("api.uei.requests.get") as mock_get:
+        with patch("api.uei.SESSION.get") as mock_get:
 
             def bad_reqexception(*args, **kwds):
                 raise requests.exceptions.RequestException
@@ -362,7 +362,7 @@ class UtilsTesting(TestCase):
             )
 
         # UEI registrationStatus not active
-        with patch("api.uei.requests.get") as mock_get:
+        with patch("api.uei.SESSION.get") as mock_get:
             mock_get.return_value.status_code = 200  # Mock the status code
             mock_get.return_value.json.return_value = json.loads(
                 invalid_uei_results
@@ -373,7 +373,7 @@ class UtilsTesting(TestCase):
             self.assertTrue(results["errors"])
 
         # No matching UEI's found
-        with patch("api.uei.requests.get") as mock_get:
+        with patch("api.uei.SESSION.get") as mock_get:
             mock_get.return_value.status_code = 200  # Mock the status code
             mock_get.return_value.json.return_value = json.loads(
                 missing_uei_results
@@ -388,7 +388,7 @@ class UtilsTesting(TestCase):
             )
 
         # Invalid number of SAM.gov entries
-        with patch("api.uei.requests.get") as mock_get:
+        with patch("api.uei.SESSION.get") as mock_get:
             mock_get.return_value.status_code = 200  # Mock the status code
             mock_get.return_value.json.return_value = json.loads(
                 lying_uei_results
@@ -404,7 +404,7 @@ class UtilsTesting(TestCase):
             )
 
         # Invalid number of SAM.gov entries
-        with patch("api.uei.requests.get") as mock_get:
+        with patch("api.uei.SESSION.get") as mock_get:
             mock_get.return_value.status_code = 200  # Mock the status code
             mock_get.return_value.json.return_value = json.loads(
                 misshapen_uei_results
@@ -420,7 +420,7 @@ class UtilsTesting(TestCase):
             )
 
         # Inactive entry
-        with patch("api.uei.requests.get") as mock_get:
+        with patch("api.uei.SESSION.get") as mock_get:
             mock_get.return_value.status_code = 200  # Mock the status code
             mock_get.return_value.json.return_value = json.loads(
                 inactive_uei_results

--- a/backend/api/uei.py
+++ b/backend/api/uei.py
@@ -21,6 +21,11 @@ class CustomHttpAdapter(requests.adapters.HTTPAdapter):
             ssl_context=self.ssl_context,
         )
 
+_ctx = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+_ctx.options |= 0x4  # OP_LEGACY_SERVER_CONNECT
+SESSION = requests.session()
+SESSION.mount("https://", CustomHttpAdapter(_ctx))
+
 
 def call_sam_api(
     sam_api_url: str, params: dict, headers: dict
@@ -33,12 +38,8 @@ def call_sam_api(
     ssl.OP_LEGACY_SERVER_CONNECT for the SSL context.
     """
     try:
-        ctx = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
-        ctx.options |= 0x4  # OP_LEGACY_SERVER_CONNECT
-        session = requests.session()
-        session.mount("https://", CustomHttpAdapter(ctx))
         return (
-            session.get(sam_api_url, params=params, headers=headers, timeout=15),
+            SESSION.get(sam_api_url, params=params, headers=headers, timeout=15),
             None,
         )
 

--- a/backend/api/uei.py
+++ b/backend/api/uei.py
@@ -5,8 +5,9 @@ import urllib3
 
 from config.settings import SAM_API_URL, SAM_API_KEY
 
-class CustomHttpAdapter (requests.adapters.HTTPAdapter):
-    '''Transport adapter that allows us to use custom ssl_context.'''
+
+class CustomHttpAdapter(requests.adapters.HTTPAdapter):
+    """Transport adapter that allows us to use custom ssl_context."""
 
     def __init__(self, ssl_context=None, **kwargs):
         self.ssl_context = ssl_context
@@ -14,8 +15,11 @@ class CustomHttpAdapter (requests.adapters.HTTPAdapter):
 
     def init_poolmanager(self, connections, maxsize, block=False):
         self.poolmanager = urllib3.poolmanager.PoolManager(
-            num_pools=connections, maxsize=maxsize,
-            block=block, ssl_context=self.ssl_context)
+            num_pools=connections,
+            maxsize=maxsize,
+            block=block,
+            ssl_context=self.ssl_context,
+        )
 
 
 def call_sam_api(
@@ -24,15 +28,15 @@ def call_sam_api(
     """
     Call the SAM.gov API and return the response and/or error string
 
-	SAM.gov uses a legacy version of SSL that OpenSSL 3 rejects. We specify
+    SAM.gov uses a legacy version of SSL that OpenSSL 3 rejects. We specify
     just in this one spot the magic flag 0x04 corresponding to
-	ssl.OP_LEGACY_SERVER_CONNECT for the SSL context.
+    ssl.OP_LEGACY_SERVER_CONNECT for the SSL context.
     """
     try:
         ctx = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
         ctx.options |= 0x4  # OP_LEGACY_SERVER_CONNECT
         session = requests.session()
-        session.mount('https://', CustomHttpAdapter(ctx))
+        session.mount("https://", CustomHttpAdapter(ctx))
         return (
             session.get(sam_api_url, params=params, headers=headers, timeout=15),
             None,

--- a/backend/api/uei.py
+++ b/backend/api/uei.py
@@ -21,6 +21,7 @@ class CustomHttpAdapter(requests.adapters.HTTPAdapter):
             ssl_context=self.ssl_context,
         )
 
+
 _ctx = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
 _ctx.options |= 0x4  # OP_LEGACY_SERVER_CONNECT
 SESSION = requests.session()


### PR DESCRIPTION
There is a backend error where the application can't contact SAM.gov because of an SSL error: `SSLError(1, '[SSL: UNSAFE_LEGACY_RENEGOTIATION_DISABLED] unsafe legacy renegotiation disabled (_ssl.c:1007)')`. Following this Stack Overflow https://stackoverflow.com/questions/71603314/ssl-error-unsafe-legacy-renegotiation-disabled, this implements a python-level solution by specifying a specific SSL context that allows this ONLY when we are calling SAM.gov.

@danswick and @jadudm worked out an OS-level solution so they could take a look at this, and @mogul should probably notice that we are making the possibly insecure accommodation for a limitation of SAM.gov.

To test this, visit http://localhost:8000/api/sac/ueivalidation and POST a payload of `{"auditee_uei": "nonemptystring"}` and look for a successful `"UEI was not found in [SAM.gov](http://sam.gov/)"` error.