### PR TITLE
Add set -e to .profile to catch Django setup/migration errors

### DIFF
--- a/backend/.profile
+++ b/backend/.profile
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 export REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt


### PR DESCRIPTION
Sometimes when things change
The changes break the DB.
And we need to know.

-----

Currently, `python manage.py migrate` breaks due to a dissemination migration issue, and this wasn’t showing up as a deployment error. This change should make that error visible.