### PR TITLE
Add deploy script

### DIFF
--- a/.github/workflows/deploy-application.yml
+++ b/.github/workflows/deploy-application.yml
@@ -77,3 +77,4 @@ jobs:
           cf_space: ${{ env.space }}
           cf_manifest: backend/manifests/manifest-fac.yml
           cf_vars_file: backend/manifests/vars/vars-${{ env.space }}.yml
+          command: bin/ops/deploy.sh

--- a/bin/ops/deploy.sh
+++ b/bin/ops/deploy.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+usage="
+Checks droplet GUID before and after cf push to assert that the running application actually changed.
+"
+
+set -e
+
+cfspace=$(cf target |tail -1|cut -d':' -f2|xargs)
+appguid=$(cf app gsa-fac --guid)
+before_sha=$(cf curl /v3/apps/"${appguid}"/relationships/current_droplet | jq -r .data.guid)
+echo "${before_sha}"
+cf push -f backend/manifests/manifest-fac.yml --vars-file backend/manifests/vars/vars-"${cfspace}".yml --strategy rolling
+after_sha=$(cf curl /v3/apps/"${appguid}"/relationships/current_droplet | jq -r .data.guid)
+echo "${after_sha}"
+if [[ "${before_sha}" == "${after_sha}" ]]; then
+    exit 1
+fi


### PR DESCRIPTION
Is the thing before
The same as the thing after?
If so, it should fail

-----

Add a deploy script to check that the pre- and post-deployment droplets are different, and make GitHub Actions use this script.