### PR TITLE
Account for whitespace differences breaking deploy.sh in the GitHub action

### DIFF
--- a/bin/ops/deploy.sh
+++ b/bin/ops/deploy.sh
@@ -14,12 +14,14 @@ curlurl="/v3/apps/${appguid}/relationships/current_droplet"
 echo "curl URL: ${curlurl}"
 before_data=$(cf curl "/v3/apps/${appguid}/relationships/current_droplet")
 echo "Before data: ${before_data}"
-before_sha=$(echo "${before_data}"|head -n 3|tail -n 1|cut -d':' -f2|xargs)
+before_sha=$(echo "${before_data}"|xargs|cut -d'}' -f1|cut -d':' -f3|xargs)
 echo "Before SHA: ${before_sha}"
+echo "cf comand on next line:"
+echo cf push -f backend/manifests/manifest-fac.yml --vars-file backend/manifests/vars/vars-"${cfspace}".yml --strategy rolling
 cf push -f backend/manifests/manifest-fac.yml --vars-file backend/manifests/vars/vars-"${cfspace}".yml --strategy rolling
 after_data=$(cf curl "/v3/apps/${appguid}/relationships/current_droplet")
 echo "After data: ${after_data}"
-after_sha=$(echo "${after_data}"|head -n 3|tail -n 1|cut -d':' -f2|xargs)
+after_sha=$(echo "${after_data}"|xargs|cut -d'}' -f1|cut -d':' -f3|xargs)
 echo "After SHA: ${after_sha}"
 if [[ "${before_sha}" == "${after_sha}" ]]; then
     echo "Failed due to unchanged droplet SHA."


### PR DESCRIPTION
With all on one line
Linebreaks no longer matter.
Maybe that’s the fix.

-----

Apparently the GitHub environment condenses the response to one line, so we do that anyway and handle the resulting output to get the GUID in `deploy.sh`