### PR TITLE
Actually get the CSRF token we need to send the UEI check to our own endpoint

### DIFF
--- a/backend/api/uei.py
+++ b/backend/api/uei.py
@@ -1,5 +1,4 @@
 from typing import Optional
-import environs
 import ssl
 import urllib3
 import requests
@@ -16,12 +15,9 @@ class CustomHttpAdapter(requests.adapters.HTTPAdapter):
 
     def proxy_manager_for(self, *args, **kwargs):
         kwargs["ssl_context"] = self.ssl_context
-        proxy = environs.Env().get("https_proxy")
-        if proxy:
-            return super().proxy_manager_for(proxy, *args, **kwargs)
         return super().proxy_manager_for(*args, **kwargs)
 
-    def init_poolmanager(self, connections, maxsize, block=False, *args, **kwargs):
+    def init_poolmanager(self, connections, maxsize, block=False):
         self.poolmanager = urllib3.poolmanager.PoolManager(
             num_pools=connections,
             maxsize=maxsize,

--- a/backend/static/js/csrft.js
+++ b/backend/static/js/csrft.js
@@ -1,15 +1,3 @@
 export const getCookie = (name) => {
-  let cookieValue = null;
-  if (document.cookie && document.cookie !== '') {
-    const cookies = document.cookie.split(';');
-    for (let i = 0; i < cookies.length; i++) {
-      const cookie = cookies[i].trim();
-      // Does this cookie string begin with the name we want?
-      if (cookie.substring(0, name.length + 1) === name + '=') {
-        cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
-        break;
-      }
-    }
-  }
-  return cookieValue;
+  return document.querySelector('[name=csrfmiddlewaretoken]').value;
 };

--- a/backend/static/js/csrft.js
+++ b/backend/static/js/csrft.js
@@ -1,3 +1,3 @@
-export const getCookie = (name) => {
+export const getCookie = () => {
   return document.querySelector('[name=csrfmiddlewaretoken]').value;
 };


### PR DESCRIPTION
Wild geese, red herrings
And, of course, cookie settings.
Will it work this time?

-----

The last set of SSL-related changes were incorrect; the regression test failures—this time—were likely caused by a long-standing cookie/CSRF issue preventing the form page from talking to another page in our app via XHR.
