### PR TITLE
We need a null check

### DIFF
--- a/backend/static/js/csrft.js
+++ b/backend/static/js/csrft.js
@@ -1,3 +1,7 @@
 export const getCookie = () => {
-  return document.querySelector('[name=csrfmiddlewaretoken]').value;
+  const csrfInput = document.querySelector('[name=csrfmiddlewaretoken]');
+  if (csrfInput !== null) {
+    return document.querySelector('[name=csrfmiddlewaretoken]').value;
+  }
+  return null;
 };


### PR DESCRIPTION
Omitting null checks:
The gift that keeps on giving.
I should know better.

-----

I didn’t include a `null` check here first time around because I verified that the function that ultimately uses this one isn’t called anywhere except on a page that has the element in question (and if that weren’t true, we’d want to know)—but the way the JS is actually structured means that `getCookie` gets loaded and called on every page regardless, so the check is necessary.