### PR TITLE
Check for existing users at Access instance creation

### DIFF
--- a/backend/audit/models.py
+++ b/backend/audit/models.py
@@ -466,12 +466,13 @@ class AccessManager(models.Manager):
         instance creation would have to log out and in again to get the new
         access.
         """
-        try:
-            acc_user = User.objects.get(email=obj_data["email"])
-        except User.DoesNotExist:
-            acc_user = None
-        if acc_user:
-            obj_data["user"] = acc_user
+        if obj_data["email"]:
+            try:
+                acc_user = User.objects.get(email=obj_data["email"])
+            except User.DoesNotExist:
+                acc_user = None
+            if acc_user:
+                obj_data["user"] = acc_user
         return super().create(**obj_data)
 
 


### PR DESCRIPTION
Requiring logout
When new access is granted
Doesn't seem friendly

-----

We currently associate `User` instances—as opposed to email addresses—with `Access` instances only whenever a user logs in. So:

1.  User A logs in.
2.  User B creates a submission X and adds User A in some role.

User A would not be able to access submission X unless they log out and in again.

This PR looks for matching user objects based on email address at time of access creation (the machinery for doing this at login is unchanged).

Also adds a quick test checking that this occurs via the path currently used to create `Access` instances.