### PR TITLE
Missing ampersand FTW

### DIFF
--- a/backend/.profile
+++ b/backend/.profile
@@ -42,7 +42,7 @@ if [[ "$CF_INSTANCE_INDEX" == 0 ]]; then
     echo 'Finished API schema deprecation' &&
     echo 'Dropping API schema' &&
 	python manage.py drop_api_schema &&
-	echo 'Finished dropping API schema' &
+	echo 'Finished dropping API schema' &&
     echo 'Starting API schema creation' &&
     python manage.py create_api_schema &&
     echo 'Finished API schema creation' &&


### PR DESCRIPTION
Trailing ampersands
Must always travel in pairs
Or they will recede.

-----

A lone trailing ampersand here may be causing these database commands to be run in incorrect order.