### PR TITLE
Update submission progress check to work as a validation function, and related changes.

### DIFF
--- a/backend/audit/cross_validation/__init__.py
+++ b/backend/audit/cross_validation/__init__.py
@@ -59,9 +59,13 @@ from .additional_ueis import additional_ueis
 from .auditee_ueis_match import auditee_ueis_match
 from .audit_findings import audit_findings
 from .sac_validation_shape import sac_validation_shape  # noqa: F401
+from .submission_progress_check import submission_progress_check
+from .tribal_data_sharing_consent import tribal_data_sharing_consent
 
 functions = [
     audit_findings,
     auditee_ueis_match,
     additional_ueis,
+    submission_progress_check,
+    tribal_data_sharing_consent,
 ]

--- a/backend/audit/cross_validation/additional_ueis.py
+++ b/backend/audit/cross_validation/additional_ueis.py
@@ -5,7 +5,7 @@ from .errors import (
 )
 
 
-def additional_ueis(sac_dict):
+def additional_ueis(sac_dict, *_args, **_kwargs):
     """
     Checks that there are additional UEIs if
     general_information.multiple_ueis_covered is True, and that there are

--- a/backend/audit/cross_validation/audit_findings.py
+++ b/backend/audit/cross_validation/audit_findings.py
@@ -1,4 +1,4 @@
-def audit_findings(sac_dict):
+def audit_findings(sac_dict, *_args, **_kwargs):
     """
     Checks that the number of audit findings in the Federal Awards and Audit Findings
     sections are consistent.

--- a/backend/audit/cross_validation/auditee_ueis_match.py
+++ b/backend/audit/cross_validation/auditee_ueis_match.py
@@ -1,7 +1,7 @@
 from .errors import err_auditee_ueis_match
 
 
-def auditee_ueis_match(sac_dict):
+def auditee_ueis_match(sac_dict, *_args, **_kwargs):
     """Checks that the auditee_uei values in each sheet are the same."""
     all_sections = sac_dict["sf_sac_sections"]
     sections = filter(None, all_sections.values())

--- a/backend/audit/cross_validation/submission_progress_check.py
+++ b/backend/audit/cross_validation/submission_progress_check.py
@@ -1,0 +1,131 @@
+def submission_progress_check(sac, sar=None, crossval=True):
+    """
+    Because this function was initially created in a view and not as a
+    cross-validation function, it needs the crossval argument to distinguish between
+    running in a cross-validation context and running in the context of needing to
+    return progress information to the submission progress view.
+
+    crossval defaults to True because we don't want to have to change all the calls to
+    the validation functions to include this argument.
+
+    Given a SingleAuditChecklist instance and a SingleAuditReportFile instance,
+    return information about submission progress.
+
+    Returns this shape:
+
+        {
+            "complete": [bool],
+            "single_audit_report": [progress_dict],
+            "additional_ueis": [progress_dict],
+            ...
+            "general_information": [progress_dict],
+        }
+
+    Where each of the sections is represented at the top level, along with
+    single_audit_report, and [progress_dict] is:
+
+        {
+            "display": "hidden"/"incomplete"/"complete",
+            "completed": [bool],
+            "completed_by": [email],
+            "completed_date": [date],
+        }
+    """
+    sections = sac["sf_sac_sections"]
+    # TODO: remove these once Notes to SEFA and tribal data consent are implemented
+    del sections["notes_to_sefa"]
+    del sections["tribal_data_consent"]
+    result = {k: None for k in sections}  # type: ignore
+    progress = {
+        "display": None,
+        "completed": None,
+        "completed_by": None,
+        "completed_date": None,
+    }
+
+    cond_keys = _conditional_keys_progress_check(sections)
+    for ckey, cvalue in cond_keys.items():
+        result[ckey] = progress | cvalue
+
+    mandatory_keys = _mandatory_keys_progress_check(sections, cond_keys)
+    for mkey, mvalue in mandatory_keys.items():
+        result[mkey] = progress | mvalue
+
+    sar_progress = {
+        "display": "complete" if bool(sar) else "incomplete",
+        "completed": bool(sar),
+    }
+
+    result["single_audit_report"] = progress | sar_progress  # type: ignore
+
+    complete = False
+
+    def cond_pass(cond_key):
+        passing = ("hidden", "complete")
+        return result.get(cond_key, {}).get("display") in passing
+
+    error_keys = (
+        list(mandatory_keys.keys()) + list(cond_keys.keys()) + ["single_audit_report"]
+    )
+
+    # Need this to return useful errors in cross-validation:
+    incomplete_sections = [
+        k for k in error_keys if result[k].get("display") == "incomplete"
+    ]
+
+    if all(bool(sections[k]) for k in mandatory_keys):
+        if all(cond_pass(j) for j in cond_keys):
+            complete = True
+
+    result["complete"] = complete  # type: ignore
+
+    if not crossval:
+        return result  # return the cross-validation shape
+
+    if complete:
+        return []
+
+    return [
+        {
+            "error": f"The following sections are incomplete: {', '.join(incomplete_sections)}."
+        }
+    ]
+
+
+def _conditional_keys_progress_check(sections):
+    """
+    Support function for submission_progress_check; handles the conditional sections.
+    """
+    general_info = sections.get("general_information") or {}
+    conditional_keys = {
+        "additional_ueis": general_info.get("multiple_ueis_covered"),
+        # Update once we have the question in. This may be handled in the gen info form rather than as a workbook.
+        "additional_eins": False,
+        # "additional_eins": sac.multiple_eins_covered,
+        "secondary_auditors": False,  # update this once we have the question in.
+    }
+    output = {}
+    for key, value in conditional_keys.items():
+        current = "incomplete"
+        if not value:
+            current = "hidden"
+        elif sections.get(key):
+            current = "complete"
+        info = {"display": current, "completed": current == "complete"}
+        output[key] = info
+    return output
+
+
+def _mandatory_keys_progress_check(sections, conditional_keys):
+    """
+    Support function for submission_progress_check; handles the mandatory sections.
+    """
+    other_keys = [k for k in sections if k not in conditional_keys]
+    output = {}
+    for k in other_keys:
+        if bool(sections[k]):
+            info = {"display": "complete", "completed": True}
+        else:
+            info = {"display": "incomplete", "completed": False}
+        output[k] = info
+    return output

--- a/backend/audit/cross_validation/tribal_data_sharing_consent.py
+++ b/backend/audit/cross_validation/tribal_data_sharing_consent.py
@@ -1,7 +1,7 @@
 from .errors import err_missing_tribal_data_sharing_consent
 
 
-def tribal_data_sharing_consent(sac_dict):
+def tribal_data_sharing_consent(sac_dict, *_args, **_kwargs):
     """
     Checks that if the user identified as a tribal organization
     then there must be a completed data sharing consent form associated with the submission

--- a/backend/audit/models.py
+++ b/backend/audit/models.py
@@ -315,9 +315,17 @@ class SingleAuditChecklist(models.Model, GeneralInformationMixin):  # type: igno
         themselves.
         """
         shaped_sac = audit.cross_validation.sac_validation_shape(self)
+        try:
+            sar = SingleAuditReportFile.objects.filter(sac_id=self.id).latest(
+                "date_created"
+            )
+        except SingleAuditReportFile.DoesNotExist:
+            sar = None
         validation_functions = audit.cross_validation.functions
         errors = list(
-            chain.from_iterable([func(shaped_sac) for func in validation_functions])
+            chain.from_iterable(
+                [func(shaped_sac, sar=sar) for func in validation_functions]
+            )
         )
         if errors:
             return {"errors": errors, "data": shaped_sac}

--- a/backend/audit/templates/audit/submission_checklist/submission-checklist.html
+++ b/backend/audit/templates/audit/submission_checklist/submission-checklist.html
@@ -290,19 +290,13 @@
                                 <p class="text-bold text-underline margin-0">Pre-submission validation (Complete)</p>
                                 <p class="margin-0">Before submitting your audit, use our validation tool to check your workbooks for errors.</p>
                             </div>
-                        {% elif complete %}
+                        {% else %}
                             {% include './icon-list-icon.html' with completed=pre_submission_validation.completed %}
                             <div>
                                 <p class="text-bold margin-0">
                                     <a class="usa-link"
                                        href="{% url 'audit:CrossValidation' report_id %}">Pre-submission validation</a>
                                 </p>
-                                <p class="margin-0">Before submitting your audit, use our validation tool to check your workbooks for errors.</p>
-                            </div>
-                        {% else %}
-                            {% include './icon-list-icon.html' with completed=pre_submission_validation.completed %}
-                            <div>
-                                <p class="text-bold margin-0">Pre-submission validation</p>
                                 <p class="margin-0">Before submitting your audit, use our validation tool to check your workbooks for errors.</p>
                             </div>
                         {% endif %}


### PR DESCRIPTION
Certification
Is wrapped up with submission.
Try to advance both.

-----

Fixes the conditional display of the pre-submission check.

Moves the function for checking the progress of a submission into cross-validation, because it turns out that checking to see if there are any incomplete sections is also something we need to do at cross-validation time. Also change the signatures of the cross-validation functions to accommodate other arguments, here so that we’re able to send `SingleAuditReportFile` to `submission_progress_check`, but also in case there are other outliers in future (the most likely candidate being having to also pass `Access` objects for some reason.)

Adds `tribal_data_sharing_consent` and `submission_progress_check` to the list of functions run at cross-validation time.

Updates the tests to work with these changes.
