### PR TITLE
Auditee info form server side validation

### DIFF
--- a/backend/report_submission/forms.py
+++ b/backend/report_submission/forms.py
@@ -10,20 +10,21 @@ def validate_uei(value):
 
 
 class AuditeeInfoForm(forms.Form):
-    auditee_uei = forms.CharField(validators=[validate_uei])
-    auditee_fiscal_period_start = forms.DateField()
-    auditee_fiscal_period_end = forms.DateField()
+    auditee_uei = forms.CharField(required=True, validators=[validate_uei])
+    auditee_fiscal_period_start = forms.DateField(required=True)
+    auditee_fiscal_period_end = forms.DateField(required=True)
 
     def clean(self):
-        cleaned_data = super().clean()
+        if self.is_valid():
+            cleaned_data = super().clean()
 
-        auditee_fiscal_period_start = cleaned_data["auditee_fiscal_period_start"]
-        auditee_fiscal_period_end = cleaned_data["auditee_fiscal_period_end"]
+            auditee_fiscal_period_start = cleaned_data["auditee_fiscal_period_start"]
+            auditee_fiscal_period_end = cleaned_data["auditee_fiscal_period_end"]
 
-        if auditee_fiscal_period_start >= auditee_fiscal_period_end:
-            raise forms.ValidationError(
-                "Auditee fiscal period end date must be later than auditee fiscal period start date"
-            )
+            if auditee_fiscal_period_start >= auditee_fiscal_period_end:
+                raise forms.ValidationError(
+                    "Auditee fiscal period end date must be later than auditee fiscal period start date"
+                )
 
 
 # The general information fields are currently specified in two places:

--- a/backend/report_submission/templates/report_submission/step-2.html
+++ b/backend/report_submission/templates/report_submission/step-2.html
@@ -13,6 +13,7 @@
                     <legend class="usa-legend usa-legend--large">
                         Auditee information
                     </legend>
+                    {{ form.non_field_errors }}
                     <p>
                         <abbr title="required" class="usa-hint usa-hint--required">*</abbr>Indicates a required field.
                     </p>
@@ -36,6 +37,7 @@
                             <li id="auditee_uei-not-null" hidden>Can&#39;t be null</li>
                             <li id="auditee_uei-length" hidden>UEI is twelve characters long</li>
                         </ul>
+                        {{ form.auditee_uei.errors }}
                         <div class="usa-search" role="search">
                             <label class="usa-sr-only" for="auditee_uei">Search</label>
                             <input class="usa-input"

--- a/backend/report_submission/templates/report_submission/step-2.html
+++ b/backend/report_submission/templates/report_submission/step-2.html
@@ -13,7 +13,7 @@
                     <legend class="usa-legend usa-legend--large">
                         Auditee information
                     </legend>
-                    {{ form.non_field_errors }}
+                    <span class="usa-error-message margin-top-2">{{ form.non_field_errors|striptags }}</span>
                     <p>
                         <abbr title="required" class="usa-hint usa-hint--required">*</abbr>Indicates a required field.
                     </p>
@@ -37,7 +37,7 @@
                             <li id="auditee_uei-not-null" hidden>Can&#39;t be null</li>
                             <li id="auditee_uei-length" hidden>UEI is twelve characters long</li>
                         </ul>
-                        {{ form.auditee_uei.errors }}
+                        <span class="usa-error-message margin-top-2">{{ form.auditee_uei.errors|striptags }}</span>
                         <div class="usa-search" role="search">
                             <label class="usa-sr-only" for="auditee_uei">Search</label>
                             <input class="usa-input"
@@ -91,6 +91,7 @@
                                     role="alert">
                                     <li id="auditee_fiscal_period_start-not-null" hidden>Can&#39;t be null</li>
                                 </ul>
+                                <span class="usa-error-message margin-top-2">{{ form.auditee_fiscal_period_start.errors|striptags }}</span>
                                 <input class="usa-input"
                                     id="auditee_fiscal_period_start"
                                     name="auditee_fiscal_period_start"
@@ -116,6 +117,7 @@
                                     role="alert">
                                     <li id="auditee_fiscal_period_end-not-null" hidden>Can&#39;t be null</li>
                                 </ul>
+                                <span class="usa-error-message margin-top-2">{{ form.auditee_fiscal_period_end.errors|striptags }}</span>
                                 <input class="usa-input"
                                     id="auditee_fiscal_period_end"
                                     name="auditee_fiscal_period_end"

--- a/backend/report_submission/test_views.py
+++ b/backend/report_submission/test_views.py
@@ -218,7 +218,7 @@ class TestPreliminaryViews(TestCase):
         """
         /report_submissions/auditeeinfo
         Check that the correct templates are loaded on GET.
-        Check that the POST succeeds with appropriate data.
+        Check that the POST fails with an empty data payload
         """
         user = baker.make(User)
         self.client.force_login(user)
@@ -234,8 +234,10 @@ class TestPreliminaryViews(TestCase):
         response = self.client.post(
             url, data=json.dumps(data), content_type="application/json"
         )
-        self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, "/report_submission/auditeeinfo/")
+        self.assertEqual(response.status_code, 200)
+        self.assertListEqual(response.context["form"].errors["auditee_uei"], ["This field is required."])
+        self.assertListEqual(response.context["form"].errors["auditee_fiscal_period_start"], ["This field is required."])
+        self.assertListEqual(response.context["form"].errors["auditee_fiscal_period_end"], ["This field is required."])
 
     def test_step_three_accessandsubmission_submission_fail(self):
         """

--- a/backend/report_submission/test_views.py
+++ b/backend/report_submission/test_views.py
@@ -235,9 +235,17 @@ class TestPreliminaryViews(TestCase):
             url, data=json.dumps(data), content_type="application/json"
         )
         self.assertEqual(response.status_code, 200)
-        self.assertListEqual(response.context["form"].errors["auditee_uei"], ["This field is required."])
-        self.assertListEqual(response.context["form"].errors["auditee_fiscal_period_start"], ["This field is required."])
-        self.assertListEqual(response.context["form"].errors["auditee_fiscal_period_end"], ["This field is required."])
+        self.assertListEqual(
+            response.context["form"].errors["auditee_uei"], ["This field is required."]
+        )
+        self.assertListEqual(
+            response.context["form"].errors["auditee_fiscal_period_start"],
+            ["This field is required."],
+        )
+        self.assertListEqual(
+            response.context["form"].errors["auditee_fiscal_period_end"],
+            ["This field is required."],
+        )
 
     def test_step_three_accessandsubmission_submission_fail(self):
         """

--- a/backend/report_submission/views.py
+++ b/backend/report_submission/views.py
@@ -61,7 +61,7 @@ class AuditeeInfoFormView(LoginRequiredMixin, View):
 
         formatted_post = {
             "csrfmiddlewaretoken": request.POST.get("csrfmiddlewaretoken"),
-            "auditee_uei": request.POST.get("auditee_uei"),
+            "auditee_uei": form.cleaned_data["auditee_uei"],
             "auditee_name": request.POST.get("auditee_name"),
             "auditee_address_line_1": request.POST.get("auditee_address_line_1"),
             "auditee_city": request.POST.get("auditee_city"),


### PR DESCRIPTION
Resolves #1816 

- Makes UEI, start, and end dates required fields on the server side
- Adds server side validation of UEI against SAM.gov
- Adds server side validation that start date is earlier than end date
- Updates related view tests, which previously were not submitting data in the correct format

https://github.com/GSA-TTS/FAC/assets/1425377/28007fc8-c85a-4033-9c74-87b37a0918e6
