### PR TITLE
Fixes autodeploy repo event

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -88,12 +88,12 @@ jobs:
     secrets: inherit
 
   repo-event:
-    if: ${{ github.base_ref == 'prod' }}
+    if: ${{ github.base_ref == 'prod' && always() }}
     name: Set Repository Event
     permissions:
       contents: write
     runs-on: ubuntu-latest
-    needs: [terraform-plan-staging, testing-from-ghcr]
+    needs: [terraform-plan-staging, testing-from-ghcr, testing-from-build]
     steps:
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v2


### PR DESCRIPTION
uses the always() conditional expression so that it always runs after testing-from-ghcr and testing-from-build terraform-plan-staging have completed, regardless of whether they were successful, so long as the base_ref is prod.

![image](https://github.com/GSA-TTS/FAC/assets/130377221/da25a2f1-1628-4be4-bb1f-015b7cf30002)

## PR checklist: submitters

- [ ]   Link to an issue if possible. If there’s no issue, describe what your branch does. Even if there is an issue, a brief description in the PR is still useful.
- [ ]   List any special steps reviewers have to follow to test the PR. For example, adding a local environment variable, creating a local test file, etc.
- [ ]   For extra credit, submit a screen recording like [this one](https://github.com/GSA-TTS/FAC/pull/1821).
- [X]   Make sure you’ve merged `main` into your branch shortly before creating the PR. (You should also be merging `main` into your branch regularly during development.)
- [ ]   Make sure that whatever feature you’re adding has tests that cover the feature. This includes test coverage to make sure that the previous workflow still works, if applicable.
- [X]   Do manual testing locally. Our tests are not good enough yet to allow us to skip this step.
- [ ]   If Git surgery is necessary at any point, repeat the testing after it’s finished.
- [ ]   Once a PR is merged, keep an eye on it until it’s deployed to dev, and do enough testing on dev to verify that it deployed successfully, the feature works as expected, and the happy path for the broad feature area (such as submission) still works.

## PR checklist: reviewers

- [ ]   Pull the branch to your local environment and run `make docker clean; make docker-first-run && docker compose up`; then run `docker compose exec web /bin/bash -c "python manage.py test"`
- [ ]   Manually test out the changes locally.
- [ ]   Check that the PR has appropriate tests. Look out for changes in HTML/JS/JSON Schema logic that may need to be captured in Python tests even though the logic isn’t in Python.
- [ ]   If Git surgery is necessary at any point (such as during a merge party), repeat the testing after it’s finished.
        
The larger the PR, the stricter we should be about these points.
