### PR TITLE
Make event targets consistent across event types

### DIFF
--- a/backend/static/js/check-access.js
+++ b/backend/static/js/check-access.js
@@ -21,14 +21,14 @@ function performValidations(nodes) {
 }
 
 function insertInc(elements, attr, splitter, inc) {
-  elements.forEach(function(el) {
+  elements.forEach(function (el) {
     let newVal = el[attr].replace(splitter, '');
     newVal = newVal + '_' + inc + splitter;
     el.setAttribute(attr, newVal);
   });
 }
 function appendInc(elements, attr, inc) {
-  elements.forEach(function(el) {
+  elements.forEach(function (el) {
     const newVal = el.getAttribute(attr) + '_' + inc;
     el.setAttribute(attr, newVal);
   });

--- a/backend/static/js/check-access.js
+++ b/backend/static/js/check-access.js
@@ -21,20 +21,20 @@ function performValidations(nodes) {
 }
 
 function insertInc(elements, attr, splitter, inc) {
-  elements.forEach(function (el) {
+  elements.forEach(function(el) {
     let newVal = el[attr].replace(splitter, '');
     newVal = newVal + '_' + inc + splitter;
     el.setAttribute(attr, newVal);
   });
 }
 function appendInc(elements, attr, inc) {
-  elements.forEach(function (el) {
+  elements.forEach(function(el) {
     const newVal = el.getAttribute(attr) + '_' + inc;
     el.setAttribute(attr, newVal);
   });
 }
 function appendContactField(btnEl) {
-  const inputContainer = btnEl.parentElement.parentElement;
+  const inputContainer = btnEl.parentElement;
   const template = inputContainer.querySelector('template');
   const newRow = template.content.cloneNode(true);
 
@@ -73,21 +73,13 @@ function appendContactField(btnEl) {
   deleteBtns.forEach((btn) => {
     btn.addEventListener('click', (e) => {
       e.preventDefault();
-      deleteContactField(e.target);
+      deleteContactField(btn);
     });
   });
 }
 
 function deleteContactField(el) {
-  const nodeName = el.nodeName;
-  const inputContainer =
-    nodeName == 'use'
-      ? el.parentElement.parentElement.parentElement
-      : nodeName == 'svg'
-      ? el.parentElement.parentElement.parentElement.parentElement
-      : el.parentElement.parentElement.parentElement.parentElement;
-
-  inputContainer.remove();
+  el.parentElement.parentElement.parentElement.remove();
 }
 
 function attachFocusoutMulti(elements) {
@@ -123,7 +115,7 @@ function attachEventHandlers() {
   addContactButtons.forEach((btn) => {
     btn.addEventListener('click', (e) => {
       e.preventDefault();
-      appendContactField(e.target);
+      appendContactField(btn);
     });
   });
   const contactsCollections = Array.from(


### PR DESCRIPTION
Fixes #1994 

This PR removes some bugginess around adding and removing contact fields from the Audit Access form. #1994 describes an issue where sometimes using the <kbd>Enter</kbd> key to hit a button would delete the entire `fieldset` from the page. That issue attributes the bug to the number of contacts added, but I was able to add more than the number suggested in the issue with no problems. What did cause things to break was hitting <kbd>Enter</kbd> instead of clicking the buttons with a pointer device. In that case, the button to add a contact wouldn't work, and the button to delete a contact would just delete the entire fieldset. This PR fixes that.

The DOM manipulation code was fragile and complicated because it was trying (and failing) to account for the node that was the event target and then traverse back up. Just making the element with the event listener on it be the one we base the DOM traversal on makes it all simpler and less fragile (I hope?).

This screen recording shows the buttons working correctly with both pointer and keyboard events (with keypresses shown on screen to illustrate the difference).

https://github.com/GSA-TTS/FAC/assets/6290/5af0c46c-dda0-4928-bc55-94c5c5ce64ec

## PR checklist: submitters

- [x]   Link to an issue if possible. If there’s no issue, describe what your branch does. Even if there is an issue, a brief description in the PR is still useful.
- [x]   List any special steps reviewers have to follow to test the PR. For example, adding a local environment variable, creating a local test file, etc.
- [x]   For extra credit, submit a screen recording like [this one](https://github.com/GSA-TTS/FAC/pull/1821).
- [x]   Make sure you’ve merged `main` into your branch shortly before creating the PR. (You should also be merging `main` into your branch regularly during development.)
- [ ]   Make sure that whatever feature you’re adding has tests that cover the feature. This includes test coverage to make sure that the previous workflow still works, if applicable.
- [x]   Do manual testing locally. Our tests are not good enough yet to allow us to skip this step. If that’s not applicable for some reason, check this box.
- [x]   Verify that no Git surgery was necessary, or, if it was necessary at any point, repeat the testing after it’s finished.
- [ ]   Once a PR is merged, keep an eye on it until it’s deployed to dev, and do enough testing on dev to verify that it deployed successfully, the feature works as expected, and the happy path for the broad feature area (such as submission) still works.

## PR checklist: reviewers

- [ ]   Pull the branch to your local environment and run `make docker clean; make docker-first-run && docker compose up`; then run `docker compose exec web /bin/bash -c "python manage.py test"`
- [ ]   Manually test out the changes locally, or check this box to verify that it wasn’t applicable in this case.
- [ ]   Check that the PR has appropriate tests. Look out for changes in HTML/JS/JSON Schema logic that may need to be captured in Python tests even though the logic isn’t in Python.
- [ ]   Verify that no Git surgery is necessary at any point (such as during a merge party), or, if it was, repeat the testing after it’s finished.
        
The larger the PR, the stricter we should be about these points.
