### PR TITLE
Fix docker-clean command in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,7 @@
 
 ## PR checklist: reviewers
 
-- [ ]   Pull the branch to your local environment and run `make docker clean; make docker-first-run && docker compose up`; then run `docker compose exec web /bin/bash -c "python manage.py test"`
+- [ ]   Pull the branch to your local environment and run `make docker-clean; make docker-first-run && docker compose up`; then run `docker compose exec web /bin/bash -c "python manage.py test"`
 - [ ]   Manually test out the changes locally, or check this box to verify that it wasn’t applicable in this case.
 - [ ]   Check that the PR has appropriate tests. Look out for changes in HTML/JS/JSON Schema logic that may need to be captured in Python tests even though the logic isn’t in Python.
 - [ ]   Verify that no Git surgery is necessary at any point (such as during a merge party), or, if it was, repeat the testing after it’s finished.


### PR DESCRIPTION
Tiny tweak to the PR template guidance to make sure folks are getting clean docker instances when they copy and paste commands from the reviewer guidance.

h/t @phildominguez-gsa 

This only affects the PR template. No manual testing steps required. 
