### PR TITLE
Initial rework of cognizant/oversight agency assignment.

### DIFF
--- a/backend/audit/fixtures/json/federal-awards--test0001test--simple-pass.json
+++ b/backend/audit/fixtures/json/federal-awards--test0001test--simple-pass.json
@@ -12,8 +12,8 @@
           "is_major": "N",
           "audit_report_type": "",
           "number_of_audit_findings": 0,
-          "amount_expended": 500,
-          "federal_program_total": 500
+          "amount_expended": 5000000,
+          "federal_program_total": 5000000
         },
         "loan_or_loan_guarantee": {
           "is_guaranteed": "N",

--- a/backend/audit/intake_to_dissemination.py
+++ b/backend/audit/intake_to_dissemination.py
@@ -15,14 +15,13 @@ from dissemination.models import (
     AdditionalUei,
     AdditionalEin,
 )
-from audit.models import SingleAuditChecklist
 from audit.utils import Util
 
 logger = logging.getLogger(__name__)
 
 
 class IntakeToDissemination(object):
-    def __init__(self, sac: SingleAuditChecklist) -> None:
+    def __init__(self, sac) -> None:
         self.single_audit_checklist = sac
         self.report_id = sac.report_id
         audit_date = sac.general_information.get(

--- a/backend/audit/intake_to_dissemination.py
+++ b/backend/audit/intake_to_dissemination.py
@@ -20,6 +20,11 @@ from audit.utils import Util
 logger = logging.getLogger(__name__)
 
 
+def omit(remove, d) -> dict:
+    """omit(["a"], {"a":1, "b": 2}) => {"b": 2}"""
+    return {k: d[k] for k in d if k not in remove}
+
+
 class IntakeToDissemination(object):
     def __init__(self, sac) -> None:
         self.single_audit_checklist = sac
@@ -121,12 +126,6 @@ class IntakeToDissemination(object):
         self.loaded_objects["Findings"] = findings_objects
         return findings_objects
 
-    def conditional_lookup(self, dict, key, default):
-        if key in dict:
-            return dict[key]
-        else:
-            return default
-
     def load_federal_award(self):
         federal_awards = self.single_audit_checklist.federal_awards
         federal_awards_objects = []
@@ -189,7 +188,7 @@ class IntakeToDissemination(object):
         return cap_text_objects
 
     def load_notes(self):
-        sefa = self.single_audit_checklist.notes_to_sefa
+        sefa = self.single_audit_checklist.notes_to_sefa or {}
         n2sefa = sefa.get("NotesToSefa", {})
         sefa_objects = []
         if n2sefa:
@@ -251,115 +250,110 @@ class IntakeToDissemination(object):
 
     def load_general(self):
         general_information = self.single_audit_checklist.general_information
-        auditee_certification = self.single_audit_checklist.auditee_certification
-        audit_information = self.single_audit_checklist.audit_information
-        # auditor_certification = self.single_audit_checklist.auditor_certification
+        audit_information = self.single_audit_checklist.audit_information or {}
+        auditee_certification = self.single_audit_checklist.auditee_certification or {}
+        # auditor_certification = self.single_audit_checklist.auditor_certification or {}
+        cognizant_agency = self.single_audit_checklist.cognizant_agency or ""
+        oversight_agency = self.single_audit_checklist.oversight_agency or ""
 
         dates_by_status = self._get_dates_from_sac()
+        status = self.single_audit_checklist.STATUS
+        ready_for_certification_date = dates_by_status[status.READY_FOR_CERTIFICATION]
+        auditor_certified_date = dates_by_status[status.AUDITOR_CERTIFIED]
+        auditee_certified_date = dates_by_status[status.AUDITEE_CERTIFIED]
+        submitted_date = dates_by_status[status.SUBMITTED]
+        auditee_certify_name = auditee_certification.get("auditee_signature", {}).get(
+            "auditee_name", ""
+        )
+        auditee_certify_title = auditee_certification.get("auditee_signature", {}).get(
+            "auditee_title", ""
+        )
+
+        total_amount_expended = self.single_audit_checklist.federal_awards[
+            "FederalAwards"
+        ]["total_amount_expended"]
+
+        # Some keys in sac.general_information are different or absent in General
+        gen_key_exceptions = (
+            # Handled below:
+            "audit_period_other_months",
+            "auditee_fiscal_period_end",
+            "auditee_fiscal_period_start",
+            "auditor_international_address",
+            "ein",
+            "multiple_ueis_covered",
+            "user_provided_organization_type",
+            # Omitted:
+            "auditor_ein_not_an_ssn_attestation",
+            "ein_not_an_ssn_attestation",
+            "is_usa_based",
+            "met_spending_threshold",
+            "multiple_eins_covered",
+        )
+        general_data = omit(gen_key_exceptions, general_information)
+        general_data = general_data | {
+            "number_months": general_information.get("audit_period_other_months", ""),
+            "fy_end_date": general_information["auditee_fiscal_period_end"],
+            "fy_start_date": general_information["auditee_fiscal_period_start"],
+            "auditor_foreign_address": general_information.get(
+                "auditor_international_address", ""
+            ),
+            "auditee_ein": general_information["ein"],
+            "entity_type": general_information["user_provided_organization_type"],
+        }
+        if "multiple_ueis_covered" in general_information:
+            addl = Util.bool_to_yes_no(general_information["multiple_ueis_covered"])
+            general_data["is_additional_ueis"] = addl
+
+        # Various values in audit_information need special handling
+        audit_data = {
+            "agencies_with_prior_findings": Util.json_array_to_str(
+                audit_information["agencies"]
+            ),
+            "dollar_threshold": audit_information["dollar_threshold"],
+            "gaap_results": Util.json_array_to_str(audit_information["gaap_results"]),
+        }
+        audit_keys_arrtostr_opt = (
+            "sp_framework_basis",
+            "sp_framework_opinions",
+        )
+        audit_keys_yn = (
+            "is_going_concern_included",
+            "is_internal_control_deficiency_disclosed",
+            "is_internal_control_material_weakness_disclosed",
+            "is_material_noncompliance_disclosed",
+            "is_aicpa_audit_guide_included",
+            "is_low_risk_auditee",
+        )
+        audit_keys_opt_bool = ("is_sp_framework_required",)
+        for key in audit_keys_arrtostr_opt:
+            audit_data[key] = Util.json_array_to_str(audit_information.get(key))
+        for key in audit_keys_yn:
+            audit_data[key] = Util.bool_to_yes_no(audit_information[key])
+        for key in audit_keys_opt_bool:
+            audit_data[key] = Util.optional_bool(audit_information.get(key, None))
 
         general = General(
             report_id=self.report_id,
-            auditee_certify_name=auditee_certification["auditee_signature"][
-                "auditee_name"
-            ],
-            auditee_certify_title=auditee_certification["auditee_signature"][
-                "auditee_title"
-            ],
-            auditee_contact_name=general_information["auditee_contact_name"],
-            auditee_email=general_information["auditee_email"],
-            auditee_name=general_information["auditee_name"],
-            auditee_phone=general_information["auditee_phone"],
-            auditee_contact_title=general_information["auditee_contact_title"],
-            auditee_address_line_1=general_information["auditee_address_line_1"],
-            auditee_city=general_information["auditee_city"],
-            auditee_state=general_information["auditee_state"],
-            auditee_ein=general_information["ein"],
-            auditee_uei=general_information["auditee_uei"],
-            is_additional_ueis=Util.bool_to_yes_no(
-                general_information["multiple_ueis_covered"]
-            ),
-            auditee_zip=general_information["auditee_zip"],
-            auditor_phone=general_information["auditor_phone"],
-            auditor_state=general_information["auditor_state"],
-            auditor_city=general_information["auditor_city"],
-            auditor_contact_title=general_information["auditor_contact_title"],
-            auditor_address_line_1=general_information["auditor_address_line_1"],
-            auditor_zip=general_information["auditor_zip"],
-            auditor_country=general_information["auditor_country"],
-            auditor_contact_name=general_information["auditor_contact_name"],
-            auditor_email=general_information["auditor_email"],
-            auditor_firm_name=general_information["auditor_firm_name"],
-            auditor_foreign_address=general_information.get(
-                "auditor_international_address", ""
-            ),
-            auditor_ein=general_information["auditor_ein"],
-            cognizant_agency=self.single_audit_checklist.cognizant_agency
-            if self.single_audit_checklist.cognizant_agency
-            else "",
-            oversight_agency=self.single_audit_checklist.oversight_agency
-            if self.single_audit_checklist.oversight_agency
-            else "",
+            auditee_certify_name=auditee_certify_name,
+            auditee_certify_title=auditee_certify_title,
+            cognizant_agency=cognizant_agency,
+            oversight_agency=oversight_agency,
             date_created=self.single_audit_checklist.date_created,
-            ready_for_certification_date=dates_by_status[
-                self.single_audit_checklist.STATUS.READY_FOR_CERTIFICATION
-            ],
-            auditor_certified_date=dates_by_status[
-                self.single_audit_checklist.STATUS.AUDITOR_CERTIFIED
-            ],
-            auditee_certified_date=dates_by_status[
-                self.single_audit_checklist.STATUS.AUDITEE_CERTIFIED
-            ],
-            submitted_date=dates_by_status[
-                self.single_audit_checklist.STATUS.SUBMITTED
-            ],
+            ready_for_certification_date=ready_for_certification_date,
+            auditor_certified_date=auditor_certified_date,
+            auditee_certified_date=auditee_certified_date,
+            submitted_date=submitted_date,
             # auditor_signature_date=auditor_certification["auditor_signature"]["auditor_certification_date_signed"],
             # auditee_signature_date=auditee_certification["auditee_signature"]["auditee_certification_date_signed"],
-            fy_end_date=general_information["auditee_fiscal_period_end"],
-            fy_start_date=general_information["auditee_fiscal_period_start"],
             audit_year=str(self.audit_year),
-            audit_type=general_information["audit_type"],
-            gaap_results=Util.json_array_to_str(audit_information["gaap_results"]),
-            sp_framework_basis=Util.json_array_to_str(
-                audit_information.get("sp_framework_basis")
-            ),
-            is_sp_framework_required=Util.optional_bool(
-                audit_information.get("is_sp_framework_required", None)
-            ),
-            sp_framework_opinions=Util.json_array_to_str(
-                audit_information.get("sp_framework_opinions")
-            ),
-            is_going_concern_included=Util.bool_to_yes_no(
-                audit_information["is_going_concern_included"]
-            ),
-            is_internal_control_deficiency_disclosed=Util.bool_to_yes_no(
-                audit_information["is_internal_control_deficiency_disclosed"]
-            ),
-            is_internal_control_material_weakness_disclosed=Util.bool_to_yes_no(
-                audit_information["is_internal_control_material_weakness_disclosed"]
-            ),
-            is_material_noncompliance_disclosed=Util.bool_to_yes_no(
-                audit_information["is_material_noncompliance_disclosed"]
-            ),
             # is_duplicate_reports = Util.bool_to_yes_no(audit_information["is_aicpa_audit_guide_included"]), #FIXME This mapping does not seem correct
-            is_aicpa_audit_guide_included=Util.bool_to_yes_no(
-                audit_information["is_aicpa_audit_guide_included"]
-            ),
-            dollar_threshold=audit_information["dollar_threshold"],
-            is_low_risk_auditee=Util.bool_to_yes_no(
-                audit_information["is_low_risk_auditee"]
-            ),
-            agencies_with_prior_findings=Util.json_array_to_str(
-                audit_information["agencies"]
-            ),
-            entity_type=general_information["user_provided_organization_type"],
-            number_months=general_information.get("audit_period_other_months", ""),
-            audit_period_covered=general_information["audit_period_covered"],
-            total_amount_expended=self.single_audit_checklist.federal_awards[
-                "FederalAwards"
-            ]["total_amount_expended"],
+            total_amount_expended=total_amount_expended,
             type_audit_code="UG",
             is_public=self.single_audit_checklist.is_public,
             data_source=self.single_audit_checklist.data_source,
+            **general_data,
+            **audit_data,
         )
 
         self.loaded_objects["Generals"] = [general]

--- a/backend/audit/models.py
+++ b/backend/audit/models.py
@@ -167,14 +167,14 @@ class SingleAuditChecklist(models.Model, GeneralInformationMixin):  # type: igno
         Cognizant/Oversight agency assignment followed by dissemination
         ETL.
         """
-        try:
-            self.assign_cog_over()
-            intake_to_dissem = IntakeToDissemination(self)
-            intake_to_dissem.load_all()
-            intake_to_dissem.save_dissemination_objects()
-            return None
-        except Exception as err:
-            return {"error": err}
+        # try:
+        self.assign_cog_over()
+        intake_to_dissem = IntakeToDissemination(self)
+        intake_to_dissem.load_all()
+        intake_to_dissem.save_dissemination_objects()
+        # TODO: figure out what exceptions to catch here
+        # except Exception as err:
+        #     return {"error": err}
 
     def assign_cog_over(self):
         """

--- a/backend/audit/models.py
+++ b/backend/audit/models.py
@@ -469,11 +469,6 @@ class SingleAuditChecklist(models.Model, GeneralInformationMixin):  # type: igno
 
         self.transition_name.append(SingleAuditChecklist.STATUS.SUBMITTED)
         self.transition_date.append(datetime.now(timezone.utc))
-        if self.general_information:
-            intake_to_dissem = IntakeToDissemination(self)
-            intake_to_dissem.load_all()
-            # FIXME MSHD: Handle exceptions raised by the save methods
-            intake_to_dissem.save_dissemination_objects()
 
     @transition(
         field="submission_status",

--- a/backend/audit/models.py
+++ b/backend/audit/models.py
@@ -236,7 +236,7 @@ class SingleAuditChecklist(models.Model, GeneralInformationMixin):  # type: igno
         (STATUS.AUDITEE_CERTIFIED, "Auditee Certified"),
         (STATUS.CERTIFIED, "Certified"),
         (STATUS.SUBMITTED, "Submitted"),
-        (STATUS.DISSEMINATED, "Disseminated")
+        (STATUS.DISSEMINATED, "Disseminated"),
     )
 
     USER_PROVIDED_ORGANIZATION_TYPE_CODE = (
@@ -484,6 +484,7 @@ class SingleAuditChecklist(models.Model, GeneralInformationMixin):  # type: igno
         logger.info("Transitioning to DISSEMINATED")
         self.transition_name.append(SingleAuditChecklist.STATUS.DISSEMINATED)
         self.transition_date.append(datetime.now(timezone.utc))
+
     @transition(
         field="submission_status",
         source=[
@@ -494,7 +495,6 @@ class SingleAuditChecklist(models.Model, GeneralInformationMixin):  # type: igno
         ],
         target=STATUS.SUBMITTED,
     )
-
     def transition_to_in_progress(self):
         """
         Any edit to a submission in the following states should result in it

--- a/backend/audit/models.py
+++ b/backend/audit/models.py
@@ -167,10 +167,14 @@ class SingleAuditChecklist(models.Model, GeneralInformationMixin):  # type: igno
         Cognizant/Oversight agency assignment followed by dissemination
         ETL.
         """
-        self.assign_cog_over()
-        intake_to_dissem = IntakeToDissemination(self)
-        intake_to_dissem.load_all()
-        intake_to_dissem.save_dissemination_objects()
+        try:
+            self.assign_cog_over()
+            intake_to_dissem = IntakeToDissemination(self)
+            intake_to_dissem.load_all()
+            intake_to_dissem.save_dissemination_objects()
+            return None
+        except Exception as err:
+            return {"error": err}
 
     def assign_cog_over(self):
         """

--- a/backend/audit/models.py
+++ b/backend/audit/models.py
@@ -168,7 +168,8 @@ class SingleAuditChecklist(models.Model, GeneralInformationMixin):  # type: igno
         ETL.
         """
         # try:
-        self.assign_cog_over()
+        if not self.cognizant_agency and not self.oversight_agency:
+            self.assign_cog_over()
         intake_to_dissem = IntakeToDissemination(self)
         intake_to_dissem.load_all()
         intake_to_dissem.save_dissemination_objects()
@@ -194,6 +195,8 @@ class SingleAuditChecklist(models.Model, GeneralInformationMixin):  # type: igno
             self.save()
             return
         if cognizant_agency:
+            self.cognizant_agency = cognizant_agency
+            self.save()
             record_cog_assignment(self.report_id, self.submitted_by, cognizant_agency)
 
     def _reject_late_changes(self):

--- a/backend/audit/test_views.py
+++ b/backend/audit/test_views.py
@@ -13,7 +13,7 @@ from model_bakery import baker
 from openpyxl import load_workbook
 from openpyxl.cell import Cell
 
-from .fixtures.excel import (
+from audit.fixtures.excel import (
     ADDITIONAL_UEIS_TEMPLATE,
     ADDITIONAL_EINS_TEMPLATE,
     FEDERAL_AWARDS_TEMPLATE,
@@ -32,12 +32,18 @@ from .fixtures.excel import (
     NOTES_TO_SEFA_ENTRY_FIXTURES,
     FORM_SECTIONS,
 )
-from .fixtures.single_audit_checklist import (
+from audit.fixtures.single_audit_checklist import (
     fake_auditor_certification,
     fake_auditee_certification,
 )
-from .models import Access, SingleAuditChecklist, SingleAuditReportFile, SubmissionEvent
-from .views import MySubmissions
+from audit.models import (
+    Access,
+    SingleAuditChecklist,
+    SingleAuditReportFile,
+    SubmissionEvent,
+)
+from audit.cross_validation.naming import NC, SECTION_NAMES as SN
+from audit.views import MySubmissions
 
 User = get_user_model()
 
@@ -176,12 +182,42 @@ class SubmissionViewTests(TestCase):
         The status should be "submitted" after the post.
         The user should be redirected to the submissions table.
         """
+        filename = "general-information--test0001test--simple-pass.json"
+        info = _load_json(AUDIT_JSON_FIXTURES / filename)
+        awardsfile = "federal-awards--test0001test--simple-pass.json"
+        awards = _load_json(AUDIT_JSON_FIXTURES / awardsfile)
+        auditor_certification, auditor_signature = fake_auditor_certification()
+        auditee_certification, auditee_signature = fake_auditee_certification()
+
         user = baker.make(User)
         sac = baker.make(
             SingleAuditChecklist,
             submission_status=SingleAuditChecklist.STATUS.AUDITEE_CERTIFIED,
+            general_information=info,
+            audit_information={"stuff": "whatever"},
+            federal_awards=awards,
+            auditor_certification=auditor_certification | auditor_signature,
+            auditee_certification=auditee_certification | auditee_signature,
+            corrective_action_plan={
+                SN[NC.CORRECTIVE_ACTION_PLAN].camel_case: {
+                    "auditee_uei": "TEST0001TEST"
+                }
+            },
+            findings_text={
+                SN[NC.FINDINGS_TEXT].camel_case: {"auditee_uei": "TEST0001TEST"}
+            },
+            findings_uniform_guidance={
+                SN[NC.FINDINGS_UNIFORM_GUIDANCE].camel_case: {
+                    "auditee_uei": "TEST0001TEST"
+                }
+            },
+            notes_to_sefa={
+                SN[NC.NOTES_TO_SEFA].camel_case: {"auditee_uei": "TEST0001TEST"}
+            },
         )
+
         baker.make(Access, user=user, sac=sac, role="certifying_auditee_contact")
+
         response = _authed_post(
             Client(),
             user,
@@ -228,19 +264,29 @@ class SubmissionStatusTests(TestCase):
 
         filename = "general-information--test0001test--simple-pass.json"
         info = _load_json(AUDIT_JSON_FIXTURES / filename)
+        auditor_certification, auditor_signature = fake_auditor_certification()
+        auditee_certification, auditee_signature = fake_auditee_certification()
+
         # Update the SAC so that it will pass overall validation:
         sac = SingleAuditChecklist.objects.get(report_id=report_id)
         sac.general_information = info
         sac.audit_information = {"stuff": "whatever"}
-        sac.federal_awards = {"FederalAwards": {"federal_awards": []}}
+        awards = {SN[NC.FEDERAL_AWARDS].camel_case: {"federal_awards": []}}
+        sac.federal_awards = awards
+        sac.auditor_certification = auditor_certification | auditor_signature
+        sac.auditee_certification = auditee_certification | auditee_signature
         sac.corrective_action_plan = {
-            "CorrectiveActionPlan": {"auditee_uei": "TEST0001TEST"}
+            SN[NC.CORRECTIVE_ACTION_PLAN].camel_case: {"auditee_uei": "TEST0001TEST"}
         }
-        sac.findings_text = {"FindingsText": {"auditee_uei": "TEST0001TEST"}}
+        sac.findings_text = {
+            SN[NC.FINDINGS_TEXT].camel_case: {"auditee_uei": "TEST0001TEST"}
+        }
         sac.findings_uniform_guidance = {
-            "FindingsUniformGuidance": {"auditee_uei": "TEST0001TEST"}
+            SN[NC.FINDINGS_UNIFORM_GUIDANCE].camel_case: {"auditee_uei": "TEST0001TEST"}
         }
-        sac.notes_to_sefa = {"NotesToSefa": {"auditee_uei": "TEST0001TEST"}}
+        sac.notes_to_sefa = {
+            SN[NC.NOTES_TO_SEFA].camel_case: {"auditee_uei": "TEST0001TEST"}
+        }
         baker.make(SingleAuditReportFile, sac=sac)
         sac.save()
 
@@ -267,6 +313,18 @@ class SubmissionStatusTests(TestCase):
 
         user, sac = _make_user_and_sac(submission_status="ready_for_certification")
         baker.make(Access, sac=sac, user=user, role="certifying_auditor_contact")
+        sac.corrective_action_plan = {
+            SN[NC.CORRECTIVE_ACTION_PLAN].camel_case: {"auditee_uei": "TEST0001TEST"}
+        }
+        sac.findings_text = {
+            SN[NC.FINDINGS_TEXT].camel_case: {"auditee_uei": "TEST0001TEST"}
+        }
+        sac.findings_uniform_guidance = {
+            SN[NC.FINDINGS_UNIFORM_GUIDANCE].camel_case: {"auditee_uei": "TEST0001TEST"}
+        }
+        sac.notes_to_sefa = {
+            SN[NC.NOTES_TO_SEFA].camel_case: {"auditee_uei": "TEST0001TEST"}
+        }
 
         kwargs = {"report_id": sac.report_id}
         _authed_post(
@@ -306,6 +364,18 @@ class SubmissionStatusTests(TestCase):
 
         user, sac = _make_user_and_sac(submission_status="auditor_certified")
         baker.make(Access, sac=sac, user=user, role="certifying_auditee_contact")
+        sac.corrective_action_plan = {
+            SN[NC.CORRECTIVE_ACTION_PLAN].camel_case: {"auditee_uei": "TEST0001TEST"}
+        }
+        sac.findings_text = {
+            SN[NC.FINDINGS_TEXT].camel_case: {"auditee_uei": "TEST0001TEST"}
+        }
+        sac.findings_uniform_guidance = {
+            SN[NC.FINDINGS_UNIFORM_GUIDANCE].camel_case: {"auditee_uei": "TEST0001TEST"}
+        }
+        sac.notes_to_sefa = {
+            SN[NC.NOTES_TO_SEFA].camel_case: {"auditee_uei": "TEST0001TEST"}
+        }
 
         kwargs = {"report_id": sac.report_id}
         _authed_post(
@@ -341,7 +411,37 @@ class SubmissionStatusTests(TestCase):
         """
         Test that certifying auditee contacts can perform submission
         """
-        user, sac = _make_user_and_sac(submission_status="auditee_certified")
+
+        geninfofile = "general-information--test0001test--simple-pass.json"
+        geninfo = _load_json(AUDIT_JSON_FIXTURES / geninfofile)
+        awardsfile = "federal-awards--test0001test--simple-pass.json"
+        awards = _load_json(AUDIT_JSON_FIXTURES / awardsfile)
+        auditor_certification, auditor_signature = fake_auditor_certification()
+        auditee_certification, auditee_signature = fake_auditee_certification()
+        user, sac = _make_user_and_sac(
+            auditee_certification=auditee_certification | auditee_signature,
+            auditor_certification=auditor_certification | auditor_signature,
+            corrective_action_plan={
+                SN[NC.CORRECTIVE_ACTION_PLAN].camel_case: {
+                    "auditee_uei": "TEST0001TEST"
+                }
+            },
+            federal_awards=awards,
+            findings_text={
+                SN[NC.FINDINGS_TEXT].camel_case: {"auditee_uei": "TEST0001TEST"}
+            },
+            findings_uniform_guidance={
+                SN[NC.FINDINGS_UNIFORM_GUIDANCE].camel_case: {
+                    "auditee_uei": "TEST0001TEST"
+                }
+            },
+            general_information=geninfo,
+            notes_to_sefa={
+                SN[NC.NOTES_TO_SEFA].camel_case: {"auditee_uei": "TEST0001TEST"}
+            },
+            submission_status="auditee_certified",
+        )
+
         baker.make(Access, sac=sac, user=user, role="certifying_auditee_contact")
 
         kwargs = {"report_id": sac.report_id}

--- a/backend/audit/views.py
+++ b/backend/audit/views.py
@@ -718,6 +718,12 @@ class SubmissionView(CertifyingAuditeeRequiredMixin, generic.View):
             sac.save(
                 event_user=request.user, event_type=SubmissionEvent.EventType.SUBMITTED
             )
+            disseminated = sac.disseminate()
+            # FIXME: We should now provide a reasonable error to the user.
+            if disseminated:
+                sac.transition_to_disseminated()
+
+            logger.info(f"Dissemination result: {disseminated}")
 
             return redirect(reverse("audit:MySubmissions"))
 

--- a/backend/audit/views.py
+++ b/backend/audit/views.py
@@ -720,10 +720,12 @@ class SubmissionView(CertifyingAuditeeRequiredMixin, generic.View):
             )
             disseminated = sac.disseminate()
             # FIXME: We should now provide a reasonable error to the user.
-            if disseminated:
+            if disseminated is None:
                 sac.transition_to_disseminated()
 
-            logger.info(f"Dissemination result: {disseminated}")
+            logger.info(
+                "Dissemination errors: %s, report_id: %s", disseminated, report_id
+            )
 
             return redirect(reverse("audit:MySubmissions"))
 

--- a/backend/support/admin.py
+++ b/backend/support/admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 
+from audit.models import SingleAuditChecklist
 from .models import CognizantBaseline, CognizantAssignment, AssignmentTypeCode
 
 
@@ -70,10 +71,12 @@ class CognizantAssignmentAdmin(SupportAdmin):
     ]
 
     def uei(self, obj):
-        return obj.sac.auditee_uei
+        return SingleAuditChecklist.objects.get(report_id=obj.report_id).auditee_uei
 
     def current_cog(self, obj):
-        return obj.sac.cognizant_agency
+        return SingleAuditChecklist.objects.get(
+            report_id=obj.report_id
+        ).cognizant_agency
 
     def last_assigned_by(self, obj):
         return obj.assignor_email
@@ -89,9 +92,7 @@ class CognizantAssignmentAdmin(SupportAdmin):
         extra_context[
             "show_save_and_add_another"
         ] = False  # this not works if has_add_permision is True
-        return super(CognizantAssignmentAdmin, self).change_view(
-            request, object_id, extra_context=extra_context
-        )
+        return super().change_view(request, object_id, extra_context=extra_context)
 
     def save_model(self, request, obj, form, change):
         obj.assignor_email = request.user.email

--- a/backend/support/cog_over.py
+++ b/backend/support/cog_over.py
@@ -220,4 +220,4 @@ def assign_cog_over(sac):
         sac.save()
         return
     if conizantg_agency:
-        record_cog_assignment(sac.report_id, sac.submitted_by.email, conizantg_agency)
+        record_cog_assignment(sac.report_id, sac.submitted_by, conizantg_agency)

--- a/backend/support/cog_over.py
+++ b/backend/support/cog_over.py
@@ -211,13 +211,13 @@ def assign_cog_over(sac):
     """
     Function that the FAC app uses when a submission is completed and cog_over needs to be assigned.
     """
-    # (conizantg_agency, oversight_agency) = compute_cog_over(sac)
-    conizantg_agency, oversight_agency = compute_cog_over(
+    # (cognizant_agency, oversight_agency) = compute_cog_over(sac)
+    cognizant_agency, oversight_agency = compute_cog_over(
         sac.federal_awards, sac.submission_status, sac.ein, sac.auditee_uei
     )
     if oversight_agency:
         sac.oversight_agency = oversight_agency
         sac.save()
         return
-    if conizantg_agency:
-        record_cog_assignment(sac.report_id, sac.submitted_by, conizantg_agency)
+    if cognizant_agency:
+        record_cog_assignment(sac.report_id, sac.submitted_by, cognizant_agency)

--- a/backend/support/management/commands/run_2022.py
+++ b/backend/support/management/commands/run_2022.py
@@ -26,6 +26,7 @@ class Command(BaseCommand):
             sac = self.make_sac(gen)
             sac.submission_status = sac.STATUS.SUBMITTED
             sac.save()
+            sac.disseminate()
             processed += 1
             if gen.cogagency != sac.cognizant_agency:
                 cog_mismatches += 1

--- a/backend/support/models.py
+++ b/backend/support/models.py
@@ -1,7 +1,5 @@
 from django.db import models
 
-from audit.models import SingleAuditChecklist
-
 
 class CognizantBaseline(models.Model):
     dbkey = models.CharField(
@@ -76,7 +74,3 @@ class CognizantAssignment(models.Model):
         default=AssignmentTypeCode.COMPUTED,
         verbose_name="Type",
     )
-
-    @property
-    def sac(self):
-        return SingleAuditChecklist.objects.get(report_id=self.report_id)

--- a/backend/support/signals.py
+++ b/backend/support/signals.py
@@ -13,17 +13,13 @@ def post_cog_assignment(sender, instance, created, **kwargs):
     If a CognizantAssignment instance is saved, handle the effects this should
     have on other tables.
     """
-    # instance = kwargs["instance"]
-    # import pdb
-    #
-    # pdb.set_trace()
     if created:
         sac = SingleAuditChecklist.objects.get(report_id=instance.report_id)
         cognizant_agency = instance.cognizant_agency
         sac.cognizant_agency = cognizant_agency
         sac.save()
 
-        (ein, uei) = (sac.auditee_uei, sac.ein)
+        ein, uei = sac.auditee_uei, sac.ein
         baselines = CognizantBaseline.objects.filter(Q(ein=ein) | Q(uei=uei))
         for baseline in baselines:
             baseline.is_active = False
@@ -36,13 +32,3 @@ def post_cog_assignment(sender, instance, created, **kwargs):
             gen.save()
         except General.DoesNotExist:
             pass  # etl may not have been run yet
-
-
-# @receiver(post_save, sender=SingleAuditChecklist)
-# def fac_post_process(sender, instance, _created, **kwargs):
-#     sac: SingleAuditChecklist = instance
-#     if sac.submission_status != SingleAuditChecklist.STATUS.SUBMITTED:
-#         return
-#     if sac.cognizant_agency or sac.oversight_agency:
-#         return
-#     assign_cog_over(sac)

--- a/backend/support/signals.py
+++ b/backend/support/signals.py
@@ -1,22 +1,48 @@
 from django.db.models.signals import post_save
+from django.db.models import Q
 from django.dispatch import receiver
 
-from .models import CognizantAssignment
 from audit.models import SingleAuditChecklist
-from .cog_over import propogate_cog_update, assign_cog_over
+from dissemination.models import General
+from support.models import CognizantAssignment, CognizantBaseline
 
 
 @receiver(post_save, sender=CognizantAssignment)
 def post_cog_assignment(sender, instance, created, **kwargs):
+    """
+    If a CognizantAssignment instance is saved, handle the effects this should
+    have on other tables.
+    """
+    # instance = kwargs["instance"]
+    # import pdb
+    #
+    # pdb.set_trace()
     if created:
-        propogate_cog_update(cog_assignment=instance)
+        sac = SingleAuditChecklist.objects.get(report_id=instance.report_id)
+        cognizant_agency = instance.cognizant_agency
+        sac.cognizant_agency = cognizant_agency
+        sac.save()
+
+        (ein, uei) = (sac.auditee_uei, sac.ein)
+        baselines = CognizantBaseline.objects.filter(Q(ein=ein) | Q(uei=uei))
+        for baseline in baselines:
+            baseline.is_active = False
+            baseline.save()
+        CognizantBaseline(ein=ein, uei=uei, cognizant_agency=cognizant_agency).save()
+
+        try:
+            gen = General.objects.get(report_id=sac.report_id)
+            gen.cognizant_agency = cognizant_agency
+            gen.save()
+        except General.DoesNotExist:
+            pass  # etl may not have been run yet
 
 
-@receiver(post_save, sender=SingleAuditChecklist)
-def fac_post_process(sender, instance, created, **kwargs):
-    sac: SingleAuditChecklist = instance
-    if sac.submission_status != SingleAuditChecklist.STATUS.SUBMITTED:
-        return
-    if sac.cognizant_agency or sac.oversight_agency:
-        return
-    assign_cog_over(sac)
+# @receiver(post_save, sender=SingleAuditChecklist)
+# def fac_post_process(sender, instance, _created, **kwargs):
+#     sac: SingleAuditChecklist = instance
+#     if sac.submission_status != SingleAuditChecklist.STATUS.SUBMITTED:
+#         return
+#     if sac.cognizant_agency or sac.oversight_agency:
+#         return
+#     assign_cog_over(sac)

--- a/backend/support/signals.py
+++ b/backend/support/signals.py
@@ -15,9 +15,7 @@ def post_cog_assignment(sender, instance, created, **kwargs):
     """
     if created:
         sac = SingleAuditChecklist.objects.get(report_id=instance.report_id)
-        cognizant_agency = instance.cognizant_agency
-        sac.cognizant_agency = cognizant_agency
-        sac.save()
+        cognizant_agency = sac.cognizant_agency
 
         ein, uei = sac.auditee_uei, sac.ein
         baselines = CognizantBaseline.objects.filter(Q(ein=ein) | Q(uei=uei))

--- a/backend/support/test_cog_over.py
+++ b/backend/support/test_cog_over.py
@@ -359,7 +359,6 @@ class CogOverTests(TestCase):
             uei=UEI_WITH_BASELINE,
             cognizant_agency="17",
         )
-        # assign_cog_over(sac)
         sac.assign_cog_over()
         cas = CognizantAssignment.objects.all()
         self.assertEquals(1, len(cas))

--- a/backend/support/test_cog_over.py
+++ b/backend/support/test_cog_over.py
@@ -256,7 +256,9 @@ class CogOverTests(TestCase):
         """
         sac = self._fake_sac()
         sac.general_information["ein"] = UNIQUE_EIN_WITHOUT_DBKEY
-        cog_agency, over_agency = compute_cog_over(sac)
+        cog_agency, over_agency = compute_cog_over(
+            sac.federal_awards, sac.submission_status, sac.ein, sac.auditee_uei
+        )
         self.assertEqual(cog_agency, "84")
         self.assertEqual(over_agency, None)
 
@@ -267,7 +269,9 @@ class CogOverTests(TestCase):
         """
         sac = self._fake_sac()
         sac.general_information["ein"] = EIN_2023_ONLY
-        cog_agency, over_agency = compute_cog_over(sac)
+        cog_agency, over_agency = compute_cog_over(
+            sac.federal_awards, sac.submission_status, sac.ein, sac.auditee_uei
+        )
         self.assertEqual(cog_agency, "10")
         self.assertEqual(over_agency, None)
 
@@ -279,7 +283,9 @@ class CogOverTests(TestCase):
 
         sac = self._fake_sac()
         sac.general_information["ein"] = DUP_EIN_WITHOUT_RESOLVER
-        cog_agency, over_agency = compute_cog_over(sac)
+        cog_agency, over_agency = compute_cog_over(
+            sac.federal_awards, sac.submission_status, sac.ein, sac.auditee_uei
+        )
         self.assertEqual(cog_agency, "10")
         self.assertEqual(over_agency, None)
 
@@ -293,7 +299,9 @@ class CogOverTests(TestCase):
 
         sac.general_information["ein"] = RESOLVABLE_EIN_WITHOUT_BASELINE
         sac.general_information["auditee_uei"] = RESOLVABLE_UEI_WITHOUT_BASELINE
-        cog_agency, over_agency = compute_cog_over(sac)
+        cog_agency, over_agency = compute_cog_over(
+            sac.federal_awards, sac.submission_status, sac.ein, sac.auditee_uei
+        )
         self.assertEqual(cog_agency, "22")
         self.assertEqual(over_agency, None)
 
@@ -306,7 +314,9 @@ class CogOverTests(TestCase):
             general_information=self._fake_general(),
             federal_awards=self._fake_federal_awards_lt_cog_limit(),
         )
-        cog_agency, over_agency = compute_cog_over(sac)
+        cog_agency, over_agency = compute_cog_over(
+            sac.federal_awards, sac.submission_status, sac.ein, sac.auditee_uei
+        )
         self.assertEqual(cog_agency, None)
         self.assertEqual(over_agency, "15")
 
@@ -321,7 +331,9 @@ class CogOverTests(TestCase):
             federal_awards=self._fake_federal_awards_lt_cog_limit(),
         )
         sac.general_information["ein"] = UNIQUE_EIN_WITHOUT_DBKEY
-        cog_agency, over_agency = compute_cog_over(sac)
+        cog_agency, over_agency = compute_cog_over(
+            sac.federal_awards, sac.submission_status, sac.ein, sac.auditee_uei
+        )
         self.assertEqual(cog_agency, None)
         self.assertEqual(over_agency, "15")
 
@@ -333,7 +345,9 @@ class CogOverTests(TestCase):
             uei=UEI_WITH_BASELINE,
             cognizant_agency="17",
         )
-        cog_agency, over_agency = compute_cog_over(sac)
+        cog_agency, over_agency = compute_cog_over(
+            sac.federal_awards, sac.submission_status, sac.ein, sac.auditee_uei
+        )
         self.assertEqual(cog_agency, "17")
         self.assertEqual(over_agency, None)
 
@@ -345,6 +359,7 @@ class CogOverTests(TestCase):
             uei=UEI_WITH_BASELINE,
             cognizant_agency="17",
         )
-        assign_cog_over(sac)
+        # assign_cog_over(sac)
+        sac.assign_cog_over()
         cas = CognizantAssignment.objects.all()
         self.assertEquals(1, len(cas))

--- a/backend/support/test_cog_over.py
+++ b/backend/support/test_cog_over.py
@@ -9,7 +9,7 @@ from django.db import connection
 from audit.models import SingleAuditChecklist
 from .models import CognizantBaseline, CognizantAssignment
 
-from .cog_over import compute_cog_over, assign_cog_over
+from .cog_over import compute_cog_over
 
 # Note:  Fake data is generated for SingleAuditChecklist, CognizantBaseline.
 #        Using only the data fields that apply to cog / over assignment.


### PR DESCRIPTION
Dissemination
Requires a lot of info.
Do we have it all?

-----

## Overview

The standard checklist isn’t really applicable here (but will be for the PR to `main`).

When we were reviewing #2065, we discovered that not all of the data was making it to dissemination. This works stems from trying to fix that and then to get the tests to pass.

I opted to move the dissemination step into a `SingleAuditChecklist` method, rather than having it be a signal that handles the `post_save` event on `SingleAuditChecklist`. It’s now necessary to call `sac.disseminate()` after `sac.save()`. In the application, this happens in `audit/views.py`, in the submission step view.

After that change and some others, submission tests failed, because if we initiated the dissemination code from our tests (which exercise the submission step view), that code would look for things that weren’t present in the test data. A number of changes address that.

Avoiding circular imports was an issue here, requiring moving code around.

I wasn’t testing the `run_2022` management command when I did the initial refactor, and I’m not sure I have the setup steps for it fully correct; right now, when I run it locally on this branch it seems to report many more cog assignment mismatches than it apparently should.

In addition, it had a number of errors around not being able to find fields when translating from `SingleAuditChecklist.general_information` to `General`; I don’t know why these only showed up after the changes I made, since I don’t see how my changes would alter the data arriving at that point. I made a few changes to that, primarily making a number of fields optional (or populating them with empty strings if they were absent); that’s probably the part of this that needs the most attention.
While making those changes I also refactored `audit.intake_to_dissemination.IntakeToDissemination.load_general`, but kept the same per-field approaches to getting data out of `SingleAuditChecklist.general_information` and `SingleAuditChecklist.audit_information`.

-----

## File by file

### `audit/fixtures/json/federal-awards--test0001test--simple-pass.json`

I increased these just in case tests would fail for having too small a number in either or both of them.

### `audit/intake_to_dissemination.py`

Remove references to `SingleAuditChecklist` to prevent circular-import problems.

Previously-mandatory fields that are now optional:

#### `load_notes`

*   `notes_to_sefa`—will be an empty dict if missing in `load_notes()`.

#### `load_general`

*   `audit_information`—will be an empty dict if missing.
*   `auditee_certification`—will be an empty dict if missing.
*   `auditee_certify_name` and `auditee_certify_title`—will now fail one level deeper if `auditee_certification` is missing.
*   `cognizant_agency` and `oversight_agency`—will now be empty strings if missing.

### `audit/models.py`

*   Add `disseminate` and `assign_cog_over` methods to `SingleAuditChecklist`, moving that logic out of `support`.
*   Add `DISSEMINATED` status.
*   Add `transition_to_disseminated` method.

### `audit/test_views.py`

Various changes to provide sufficient data so that `sac.disseminate` doesn’t break tests when invoked.

### `audit/models.py`

Add explicit invocation of `sac.disseminate` after `sac.save` in submission step.

### `support/admin.py`

I removed the `sac` property from `CognizantAssignment`, so now things that previously relied upon that need to look up the SAC by `report_id`, as done here.o

### `support/cog_over.py`

*   Correct import order.
*   Alter `compute_cog_over` to take as arguments the fields from a `SingleAuditChecklist` that it needs, rather than the entire object.
*   Remove `propogate_cog_update`; this logic is now in-line in `support/signals.py`, primarily for circular import reasons.
*   Alter `record_cog_assignment` to take as arguments the fields from a `SingleAuditChecklist` that it needs, rather than the entire object.

### `support/management/commands/run_2022.py`

Add `sac.disseminate()` after `sac.save()`.

### `support/models.py`

Remove `sac` property of `CognizantAssignment`, primarily for circular import reasons.

### `support/signals.py`

*   Move what was `propogate_cog_update` into `post_cog_assignment`.
*   Remove `fac_post_process` now that we’re using explicit `sac.disseminate()` calls.

### `support/test_cog_over.py`

Alter tests to support all of the other changes.