### PR TITLE
Use fixture for IntakeToDissemination.load_general test.

### DIFF
--- a/backend/audit/test_intake_to_dissemination.py
+++ b/backend/audit/test_intake_to_dissemination.py
@@ -5,7 +5,10 @@ from django.test import TestCase
 from model_bakery import baker
 from faker import Faker
 
-from .models import SingleAuditChecklist, User
+from audit.models import SingleAuditChecklist, User
+from audit.intake_to_dissemination import IntakeToDissemination
+from audit.test_views import AUDIT_JSON_FIXTURES, _load_json
+from audit.utils import Util
 from dissemination.models import (
     General,
     FederalAward,
@@ -18,8 +21,6 @@ from dissemination.models import (
     AdditionalEin,
     AdditionalUei,
 )
-from audit.intake_to_dissemination import IntakeToDissemination
-from audit.utils import Util
 
 
 class IntakeToDisseminationTests(TestCase):
@@ -66,7 +67,10 @@ class IntakeToDisseminationTests(TestCase):
     @staticmethod
     def _fake_general():
         fake = Faker()
-        return {
+        geninfofile = "general-information--test0001test--simple-pass.json"
+        geninfo = _load_json(AUDIT_JSON_FIXTURES / geninfofile)
+
+        return geninfo | {
             "ein": fake.ssn().replace("-", ""),
             "audit_type": "single-audit",
             "auditee_uei": "ZQGGHJH74DW7",


### PR DESCRIPTION
Since we have fixtures
We should use them where we can:
Fewer truth sources.

-----

Bases the General Information data in the `IntakeToDissemination.load_general` test on the JSON test fixture; would have caught [this](https://github.com/GSA-TTS/FAC/pull/2177/files).

## PR checklist: reviewers

- [ ]   Test-only change. If the tests pass, this PR should be good to go.

