### PR TITLE
Fix for gpg error when getting cf-cli8

### DIFF
--- a/.github/workflows/terraform-apply-env.yml
+++ b/.github/workflows/terraform-apply-env.yml
@@ -38,7 +38,7 @@ jobs:
         if: ${{ inputs.environment == 'meta' }}
         run: |
           sudo mkdir -p /etc/apt/keyrings/
-          wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | gpg --dearmor | sudo tee /etc/apt/keyrings/cli.cloudfoundry.org.key > /dev/null
+          wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/cf.gpg > /dev/null
           echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
           sudo apt-get update && DEBIAN_FRONTEND=noninteractive
           sudo apt-get install --assume-yes cf8-cli


### PR DESCRIPTION
this should fix the keyring to allow us to install cf cli on the runner, so terraform can use cf commands 

Tested on gsa-fac localstack container

```bash
# wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | gpg --dearmor | tee /etc/apt/trusted.gpg.d/cf.gpg > /dev/null

# echo "deb https://packages.cloudfoundry.org/debian stable main" | tee /etc/apt/sources.list.d/cloudfoundry-cli.list
deb https://packages.cloudfoundry.org/debian stable main

# apt-get update && DEBIAN_FRONTEND=noninteractive
Hit:1 http://deb.debian.org/debian bookworm InRelease
Hit:2 http://deb.debian.org/debian bookworm-updates InRelease                                              
Hit:3 https://deb.nodesource.com/node_14.x bookworm InRelease       
Hit:4 http://deb.debian.org/debian-security bookworm-security InRelease
Get:5 https://cf-cli-debian-repo.s3.amazonaws.com stable InRelease [4368 B]
Get:6 https://cf-cli-debian-repo.s3.amazonaws.com stable/main amd64 Packages [13.2 kB]
Fetched 17.6 kB in 1s (14.4 kB/s)    
Reading package lists... Done

# apt-get install --assume-yes cf8-cli
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following NEW packages will be installed:
  cf8-cli
0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
Need to get 6402 kB of archives.
After this operation, 25.3 MB of additional disk space will be used.
Get:1 https://packages.cloudfoundry.org/debian stable/main amd64 cf8-cli amd64 8.7.3 [6402 kB]
Fetched 6402 kB in 2s (3838 kB/s)  
debconf: delaying package configuration, since apt-utils is not installed
Selecting previously unselected package cf8-cli.
(Reading database ... 54744 files and directories currently installed.)
Preparing to unpack .../cf8-cli_8.7.3_amd64.deb ...
Unpacking cf8-cli (8.7.3) ...
Setting up cf8-cli (8.7.3) ...

# cf
cf version 8.7.3+efd1d03.2023-09-12, Cloud Foundry command line tool
Usage: cf [global options] command [arguments...] [command options]

Before getting started:
  config    login,l      target,t
  help,h    logout,lo    

Application lifecycle:
  apps,a        run-task,rt    events
  push,p        logs           set-env,se
  start,st      ssh            create-app-manifest
  stop,sp       app            delete,d
  restart,rs    env,e          apply-manifest
  restage,rg    scale          revisions
```