### PR TITLE
Move cf-cli into TERRAFORM_PRE_RUN

### DIFF
--- a/.github/workflows/terraform-apply-env.yml
+++ b/.github/workflows/terraform-apply-env.yml
@@ -27,21 +27,18 @@ jobs:
       TERRAFORM_PRE_RUN: |
           apt-get update
           apt-get install -y zip python
+
+          sudo mkdir -p /etc/apt/keyrings/
+          wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/cf.gpg > /dev/null
+          echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
+          sudo apt-get update && DEBIAN_FRONTEND=noninteractive
+          sudo apt-get install --assume-yes cf8-cli
       TF_VAR_postgrest_image: 'ghcr.io/gsa-tts/fac/postgrest:latest'
       TF_VAR_clamav_image: 'ghcr.io/gsa-tts/fac/clamav:latest'
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Install CF CLI8
-        if: ${{ inputs.environment == 'meta' }}
-        run: |
-          sudo mkdir -p /etc/apt/keyrings/
-          wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/cf.gpg > /dev/null
-          echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
-          sudo apt-get update && DEBIAN_FRONTEND=noninteractive
-          sudo apt-get install --assume-yes cf8-cli
 
       - name: Apply ( ${{ inputs.environment }} )
         uses: dflook/terraform-apply@v1


### PR DESCRIPTION
Moves the code to obtain cf-cli8 into `TERRAFORM_PRE_RUN` as dflook's action runs containerized. That container needs to have cf cli, not the runner