### PR TITLE
Conditionally run share-service on meta only

### DIFF
--- a/.github/workflows/terraform-apply-env.yml
+++ b/.github/workflows/terraform-apply-env.yml
@@ -53,6 +53,7 @@ jobs:
             key=${{ env.KEY }},
 
       - name: Share backups s3 bucket to staging space
+        if: ${{ inputs.environment == 'meta' }}
         uses: cloud-gov/cg-cli-tools@main
         with:
           cf_username: ${{ secrets.CF_USERNAME }}


### PR DESCRIPTION
This should be there as we don't want it to do this unless it is in the meta space