### PR TITLE
Unshares the backups bucket so share happens cleanly every time

### DIFF
--- a/.github/workflows/terraform-apply-env.yml
+++ b/.github/workflows/terraform-apply-env.yml
@@ -52,6 +52,17 @@ jobs:
             region=${{ secrets.terraform_REGION }},
             key=${{ env.KEY }},
 
+
+      - name: Unshare backups s3 bucket to staging space
+        if: ${{ inputs.environment == 'meta' }}
+        uses: cloud-gov/cg-cli-tools@main
+        with:
+          cf_username: ${{ secrets.CF_USERNAME }}
+          cf_password: ${{ secrets.CF_PASSWORD }}
+          cf_org: gsa-tts-oros-fac
+          cf_space: production
+          command: cf unshare-service backups -s staging
+
       - name: Share backups s3 bucket to staging space
         if: ${{ inputs.environment == 'meta' }}
         uses: cloud-gov/cg-cli-tools@main

--- a/.github/workflows/terraform-apply-env.yml
+++ b/.github/workflows/terraform-apply-env.yml
@@ -61,7 +61,7 @@ jobs:
           cf_password: ${{ secrets.CF_PASSWORD }}
           cf_org: gsa-tts-oros-fac
           cf_space: production
-          command: cf unshare-service backups -s staging
+          command: cf unshare-service backups -s staging -f
 
       - name: Share backups s3 bucket to staging space
         if: ${{ inputs.environment == 'meta' }}


### PR DESCRIPTION
Last PR on this.. promise... _maybe..._

TLDR: `cf share-service` cannot share a service that is already shared. `cf share-service` also does not have have `-f`