### PR TITLE
Bug: Encrypted PDF does not report back to user

### DIFF
--- a/backend/audit/templates/audit/upload-report.html
+++ b/backend/audit/templates/audit/upload-report.html
@@ -9,6 +9,9 @@
                 <p>
                     All components of the audit report package must be merged into a single PDF file and meet the uniform guidelines below. For more information on PDF formatting, please review our PDF guidelines.
                 </p>
+                {% if form.errors %}
+                    <span class="usa-error-message" role="alert">There were errors when attempting to submit the form. Scroll down for more details.</span>
+                {% endif %}
             </div>
             <ol class="usa-process-list">
                 <form id="upload-report__form"
@@ -61,7 +64,7 @@
                                                {% if x.required %}required{% endif %}
                                                type="number"
                                                value="{{ form.cleaned_data | get_attr:x.id }}" />
-                                        <span class="usa-error-message tablet:grid-col-12">{{ form.errors | get_attr:x.id }}</span>
+                                        <span class="usa-error-message tablet:grid-col-12">{{ form.errors | get_attr:x.id | striptags }}</span>
                                     </div>
                                 {% endfor %}
                             </div>
@@ -79,7 +82,7 @@
                                    aria-describedby="file_input_upload_report"
                                    required
                                    type="file" />
-                            <span class="usa-error-message tablet:grid-col-12">{{ form.errors.upload_report }}</span>
+                            <span class="usa-error-message tablet:grid-col-12 margin-top-1">{{ form.errors.upload_report | striptags }}</span>
                         </li>
                     </fieldset>
                 {% if already_submitted %}
@@ -87,7 +90,7 @@
                         A file has already been uploaded for this section. A successful reupload will overwrite your previous submission.
                     </p>
                 {% endif %}
-                <button class="usa-button margin-bottom-8 margin-top-4" id="continue">{% if already_submitted %}Re-upload{% else %}Upload{% endif %} Single Audit Package</button>
+                <button class="usa-button margin-bottom-8 margin-top-5" id="continue">{% if already_submitted %}Re-upload{% else %}Upload{% endif %} Single Audit Package</button>
                 <a class="usa-button usa-button--unstyled margin-left-2" href="{% url 'audit:SubmissionProgress' report_id %}"
                     aria-controls="upload-cancel">Cancel</a>
                 </form>


### PR DESCRIPTION
# Bug: Encrypted PDF does not report back to user

Issue: https://github.com/GSA-TTS/FAC/issues/2377

## Changes:
The ValidationErrors from saving the PDF now show to the user. 

1. The view:
    * Wraps the `full_clean` and `save` methods in a try/catch. If it catches validation issues, it adds the errors to the form and re-renders it to the user.
    * A new function, `reformat_form_data`, that takes a validated form data and reformats it for saving. Pretty much just exists to help de-complicate the view post. 
2. HTML - There's a blanket error statement at the top, asking users to scroll down and see what went wrong.

## How to test:
Switch to this branch and run normally. Create or edit an audit. Navigate to the upload report form. Attempt to upload a bad PDF, like [this encrypted one](https://drive.google.com/file/d/1gn5hthG9fgfT4ziM9zdLHt-8iYEj-nSC/view?usp=sharing). Verify that an error displays on the form, rather than a blanket BadRequest screen.

## Screenshots:
![image](https://github.com/GSA-TTS/FAC/assets/91098850/88e77bf0-8940-4670-8e0f-99b6990203ab)


## PR checklist: submitters

- [x]   Link to an issue if possible. If there’s no issue, describe what your branch does. Even if there is an issue, a brief description in the PR is still useful.
- [x]   List any special steps reviewers have to follow to test the PR. For example, adding a local environment variable, creating a local test file, etc.
- [ ]   For extra credit, submit a screen recording like [this one](https://github.com/GSA-TTS/FAC/pull/1821).
- [x]   Make sure you’ve merged `main` into your branch shortly before creating the PR. (You should also be merging `main` into your branch regularly during development.)
- [ ]   Make sure that whatever feature you’re adding has tests that cover the feature. This includes test coverage to make sure that the previous workflow still works, if applicable.
- [x]   Do manual testing locally. Our tests are not good enough yet to allow us to skip this step. If that’s not applicable for some reason, check this box.
- [x]   Verify that no Git surgery was necessary, or, if it was necessary at any point, repeat the testing after it’s finished.
- [ ]   Once a PR is merged, keep an eye on it until it’s deployed to dev, and do enough testing on dev to verify that it deployed successfully, the feature works as expected, and the happy path for the broad feature area (such as submission) still works.

## PR checklist: reviewers

- [ ]   Pull the branch to your local environment and run `make docker-clean; make docker-first-run && docker compose up`; then run `docker compose exec web /bin/bash -c "python manage.py test"`
- [ ]   Manually test out the changes locally, or check this box to verify that it wasn’t applicable in this case.
- [ ]   Check that the PR has appropriate tests. Look out for changes in HTML/JS/JSON Schema logic that may need to be captured in Python tests even though the logic isn’t in Python.
- [ ]   Verify that no Git surgery is necessary at any point (such as during a merge party), or, if it was, repeat the testing after it’s finished.
        
The larger the PR, the stricter we should be about these points.
