### PR TITLE
Add v0 to deprecated table list

### DIFF
--- a/backend/dissemination/api/api_v1_0_0/drop.sql
+++ b/backend/dissemination/api/api_v1_0_0/drop.sql
@@ -1,0 +1,11 @@
+
+begin;
+
+DROP SCHEMA IF EXISTS api_v1_0_0 CASCADE; 
+-- DROP ROLE IF EXISTS authenticator;
+-- DROP ROLE IF EXISTS api_fac_gov;
+
+commit;
+
+notify pgrst,
+       'reload schema';

--- a/backend/dissemination/api/api_v1_0_1/drop.sql
+++ b/backend/dissemination/api/api_v1_0_1/drop.sql
@@ -1,0 +1,11 @@
+
+begin;
+
+DROP SCHEMA IF EXISTS api_v1_0_1 CASCADE;
+-- DROP ROLE IF EXISTS authenticator;
+-- DROP ROLE IF EXISTS api_fac_gov;
+
+commit;
+
+notify pgrst,
+       'reload schema';

--- a/backend/dissemination/api_versions.py
+++ b/backend/dissemination/api_versions.py
@@ -1,17 +1,19 @@
 from psycopg2._psycopg import connection
 from config import settings
-from typing import List
 
 # These are API versions we want live.
-live = [
+live = (
     # These are API versions we have in flight.
     "api_v1_0_1",
-]
+)
 
 # These are API versions we have deprecated.
 # They will be removed. It should be safe to leave them
 # here for repeated runs.
-deprecated: List[str] = ["api"]
+deprecated = (
+    "api",
+    "api_v1_0_0",
+)
 
 
 def get_conn_string():


### PR DESCRIPTION
Lil Johnny Tables
Can be useful to invoke.
Exercise caution.

-----

If I understand this correctly we need to add `api_v1_0_0` to the list of tables to drop.

## PR checklist: submitters

- [ ]   Link to an issue if possible. If there’s no issue, describe what your branch does. Even if there is an issue, a brief description in the PR is still useful.
- [ ]   List any special steps reviewers have to follow to test the PR. For example, adding a local environment variable, creating a local test file, etc.
- [ ]   For extra credit, submit a screen recording like [this one](https://github.com/GSA-TTS/FAC/pull/1821).
- [ ]   Make sure you’ve merged `main` into your branch shortly before creating the PR. (You should also be merging `main` into your branch regularly during development.)
- [ ]   Make sure that whatever feature you’re adding has tests that cover the feature. This includes test coverage to make sure that the previous workflow still works, if applicable.
- [ ]   Do manual testing locally. Our tests are not good enough yet to allow us to skip this step. If that’s not applicable for some reason, check this box.
- [ ]   Verify that no Git surgery was necessary, or, if it was necessary at any point, repeat the testing after it’s finished.
- [ ]   Once a PR is merged, keep an eye on it until it’s deployed to dev, and do enough testing on dev to verify that it deployed successfully, the feature works as expected, and the happy path for the broad feature area (such as submission) still works.

## PR checklist: reviewers

- [ ]   Pull the branch to your local environment and run `make docker-clean; make docker-first-run && docker compose up`; then run `docker compose exec web /bin/bash -c "python manage.py test"`
- [ ]   Manually test out the changes locally, or check this box to verify that it wasn’t applicable in this case.
- [ ]   Check that the PR has appropriate tests. Look out for changes in HTML/JS/JSON Schema logic that may need to be captured in Python tests even though the logic isn’t in Python.
- [ ]   Verify that no Git surgery is necessary at any point (such as during a merge party), or, if it was, repeat the testing after it’s finished.
        
The larger the PR, the stricter we should be about these points.
