### PR TITLE
Add New Relic Proxy Config

### DIFF
--- a/backend/.profile
+++ b/backend/.profile
@@ -32,6 +32,14 @@ export NEW_RELIC_LOG=stdout
 
 # https://docs.newrelic.com/docs/security/security-privacy/compliance/fedramp-compliant-endpoints/
 export NEW_RELIC_HOST="gov-collector.newrelic.com"
+# https://docs.newrelic.com/docs/apm/agents/python-agent/configuration/python-agent-configuration/#proxy
+https_proxy_protocol="$(echo "$VCAP_SERVICES" | jq --raw-output --arg service_name "https-proxy-creds" ".[][] | select(.name == \$service_name) | .credentials.protocol")"
+https_proxy_domain="$(echo "$VCAP_SERVICES" | jq --raw-output --arg service_name "https-proxy-creds" ".[][] | select(.name == \$service_name) | .credentials.domain")"
+https_proxy_port="$(echo "$VCAP_SERVICES" | jq --raw-output --arg service_name "https-proxy-creds" ".[][] | select(.name == \$service_name) | .credentials.port")"
+
+export NEW_RELIC_PROXY_HOST="$https_proxy_protocol://$https_proxy_domain:$https_proxy_port"
+export NEW_RELIC_PROXY_USER="$(echo "$VCAP_SERVICES" | jq --raw-output --arg service_name "https-proxy-creds" ".[][] | select(.name == \$service_name) | .credentials.username")"
+export NEW_RELIC_PROXY_PASS="$(echo "$VCAP_SERVICES" | jq --raw-output --arg service_name "https-proxy-creds" ".[][] | select(.name == \$service_name) | .credentials.password")"
 
 # We only want to run migrate and collecstatic for the first app instance, not
 # for additional app instances, so we gate all of this behind CF_INSTANCE_INDEX


### PR DESCRIPTION
This is following up on the guidance received from New Relic Support. Adding in the following values to .profile: `NEW_RELIC_PROXY_HOST` `NEW_RELIC_PROXY_USER` `NEW_RELIC_PROXY_PASS`

```
Hey Alex,

If you're using a Proxy you'll need to set the environment variables so the agent is able to route network data through your proxy server.

According to the log you included, there's no proxy host or port set up with the agent:

2023-10-06 17:19:27,085 (244/MainThread) newrelic.admin.validate_config DEBUG - Collector host is '[gov-collector.newrelic.com](http://gov-collector.newrelic.com/)'.
2023-10-06 17:19:27,085 (244/MainThread) newrelic.admin.validate_config DEBUG - Collector port is 0.
2023-10-06 17:19:27,085 (244/MainThread) newrelic.admin.validate_config DEBUG - Proxy scheme is None.
2023-10-06 17:19:27,085 (244/MainThread) newrelic.admin.validate_config DEBUG - Proxy host is None.
2023-10-06 17:19:27,085 (244/MainThread) newrelic.admin.validate_config DEBUG - Proxy port is 0.
2023-10-06 17:19:27,085 (244/MainThread) newrelic.admin.validate_config DEBUG - Proxy user is None.

That would look something like this:

NEW_RELIC_PROXY_HOST=https://hostname:port

Here's more information about specifying a proxy via environment variables with the agent:
https://docs.newrelic.com/docs/apm/agents/python-agent/configuration/python-agent-configuration/#proxy
```