### PR TITLE
Remove stray print statements

### DIFF
--- a/backend/audit/intakelib/checks/runners.py
+++ b/backend/audit/intakelib/checks/runners.py
@@ -98,7 +98,6 @@ def run_all_checks(ir, list_of_checks, section_name=None):
             errors.append(res)
     for fun in list_of_checks:
         res = fun(ir)
-        print(fun)
         if isinstance(res, list) and all(map(lambda v: isinstance(v, tuple), res)):
             errors = errors + res
         elif isinstance(res, tuple):

--- a/backend/audit/intakelib/mapping_notes_to_sefa.py
+++ b/backend/audit/intakelib/mapping_notes_to_sefa.py
@@ -43,7 +43,6 @@ def extract_notes_to_sefa(file):
 
     ir = extract_workbook_as_ir(file)
     run_all_general_checks(ir, FORM_SECTIONS.NOTES_TO_SEFA)
-    print("Done running all general checks")
     new_ir = run_all_notes_to_sefa_transforms(ir)
     run_all_notes_to_sefa_checks(new_ir)
     result = _extract_generic_data(new_ir, params)


### PR DESCRIPTION
Debugging is hard
And `print` is necessary
But not when we’re live.

-----

Remove some stray `print` statements.
