### PR TITLE
Remove lighthouse and pa11y from test workflows

### DIFF
--- a/.github/workflows/testing-from-build.yml
+++ b/.github/workflows/testing-from-build.yml
@@ -11,11 +11,11 @@ jobs:
     env:
       ENV: TESTING
       SAM_API_KEY: ${{ secrets.SAM_API_KEY }}
-      DJANGO_BASE_URL: 'http://localhost:8000'
+      DJANGO_BASE_URL: "http://localhost:8000"
       DJANGO_SECRET_LOGIN_KEY: ${{ secrets.DJANGO_SECRET_LOGIN_KEY }}
       LOGIN_CLIENT_ID: ${{ secrets.LOGIN_CLIENT_ID }}
       SECRET_KEY: ${{ secrets.SECRET_KEY }}
-      ALLOWED_HOSTS: '0.0.0.0 127.0.0.1 localhost'
+      ALLOWED_HOSTS: "0.0.0.0 127.0.0.1 localhost"
       DISABLE_AUTH: False
     steps:
       - name: Checkout
@@ -39,8 +39,7 @@ jobs:
 
       - name: Run Django test suite
         working-directory: ./backend
-        run:
-          docker compose -f docker-compose.yml run web bash -c 'coverage run --parallel-mode --concurrency=multiprocessing manage.py test --parallel && coverage combine && coverage report -m --fail-under=90 && coverage xml -o coverage.xml'
+        run: docker compose -f docker-compose.yml run web bash -c 'coverage run --parallel-mode --concurrency=multiprocessing manage.py test --parallel && coverage combine && coverage report -m --fail-under=90 && coverage xml -o coverage.xml'
 
       - name: Copy Coverage From Docker Container
         run: |
@@ -63,11 +62,11 @@ jobs:
     env:
       ENV: TESTING
       SAM_API_KEY: ${{ secrets.SAM_API_KEY }}
-      DJANGO_BASE_URL: 'http://localhost:8000'
+      DJANGO_BASE_URL: "http://localhost:8000"
       DJANGO_SECRET_LOGIN_KEY: ${{ secrets.DJANGO_SECRET_LOGIN_KEY }}
       LOGIN_CLIENT_ID: ${{ secrets.LOGIN_CLIENT_ID }}
       SECRET_KEY: ${{ secrets.SECRET_KEY }}
-      ALLOWED_HOSTS: '0.0.0.0 127.0.0.1 localhost'
+      ALLOWED_HOSTS: "0.0.0.0 127.0.0.1 localhost"
       DISABLE_AUTH: True
     steps:
       - uses: actions/checkout@v4
@@ -79,10 +78,10 @@ jobs:
         run: |
           touch .env
           docker compose -f docker-compose.yml up -d
-      
+
       - name: Run Lighthouse CI and pa11y
         working-directory: ./backend
         run: |
           sudo npm ci
-          npm run test:a11y:lighthouse
+          # npm run test:a11y:lighthouse
           npm run test:a11y:pa11y

--- a/.github/workflows/testing-from-build.yml
+++ b/.github/workflows/testing-from-build.yml
@@ -57,31 +57,31 @@ jobs:
           show_missing: true
           repo_token: ${{ secrets.GITHUB_TOKEN }}
 
-  a11y-testing:
-    runs-on: ubuntu-latest
-    env:
-      ENV: TESTING
-      SAM_API_KEY: ${{ secrets.SAM_API_KEY }}
-      DJANGO_BASE_URL: "http://localhost:8000"
-      DJANGO_SECRET_LOGIN_KEY: ${{ secrets.DJANGO_SECRET_LOGIN_KEY }}
-      LOGIN_CLIENT_ID: ${{ secrets.LOGIN_CLIENT_ID }}
-      SECRET_KEY: ${{ secrets.SECRET_KEY }}
-      ALLOWED_HOSTS: "0.0.0.0 127.0.0.1 localhost"
-      DISABLE_AUTH: True
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18
-      - name: Start services
-        working-directory: ./backend
-        run: |
-          touch .env
-          docker compose -f docker-compose.yml up -d
-
-      - name: Run Lighthouse CI and pa11y
-        working-directory: ./backend
-        run: |
-          sudo npm ci
-          # npm run test:a11y:lighthouse
-          npm run test:a11y:pa11y
+  # a11y-testing:
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     ENV: TESTING
+  #     SAM_API_KEY: ${{ secrets.SAM_API_KEY }}
+  #     DJANGO_BASE_URL: "http://localhost:8000"
+  #     DJANGO_SECRET_LOGIN_KEY: ${{ secrets.DJANGO_SECRET_LOGIN_KEY }}
+  #     LOGIN_CLIENT_ID: ${{ secrets.LOGIN_CLIENT_ID }}
+  #     SECRET_KEY: ${{ secrets.SECRET_KEY }}
+  #     ALLOWED_HOSTS: "0.0.0.0 127.0.0.1 localhost"
+  #     DISABLE_AUTH: True
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: actions/setup-node@v3
+  #       with:
+  #         node-version: 18
+  #     - name: Start services
+  #       working-directory: ./backend
+  #       run: |
+  #         touch .env
+  #         docker compose -f docker-compose.yml up -d
+  #
+  #     - name: Run Lighthouse CI and pa11y
+  #       working-directory: ./backend
+  #       run: |
+  #         sudo npm ci
+  #         npm run test:a11y:lighthouse
+  #         npm run test:a11y:pa11y

--- a/.github/workflows/testing-from-ghcr.yml
+++ b/.github/workflows/testing-from-ghcr.yml
@@ -11,11 +11,11 @@ jobs:
     env:
       ENV: TESTING
       SAM_API_KEY: ${{ secrets.SAM_API_KEY }}
-      DJANGO_BASE_URL: 'http://localhost:8000'
+      DJANGO_BASE_URL: "http://localhost:8000"
       DJANGO_SECRET_LOGIN_KEY: ${{ secrets.DJANGO_SECRET_LOGIN_KEY }}
       LOGIN_CLIENT_ID: ${{ secrets.LOGIN_CLIENT_ID }}
       SECRET_KEY: ${{ secrets.SECRET_KEY }}
-      ALLOWED_HOSTS: '0.0.0.0 127.0.0.1 localhost'
+      ALLOWED_HOSTS: "0.0.0.0 127.0.0.1 localhost"
       DISABLE_AUTH: False
       PGRST_JWT_SECRET: ${{ secrets.PGRST_JWT_SECRET }}
     steps:
@@ -64,11 +64,11 @@ jobs:
     env:
       ENV: TESTING
       SAM_API_KEY: ${{ secrets.SAM_API_KEY }}
-      DJANGO_BASE_URL: 'http://localhost:8000'
+      DJANGO_BASE_URL: "http://localhost:8000"
       DJANGO_SECRET_LOGIN_KEY: ${{ secrets.DJANGO_SECRET_LOGIN_KEY }}
       LOGIN_CLIENT_ID: ${{ secrets.LOGIN_CLIENT_ID }}
       SECRET_KEY: ${{ secrets.SECRET_KEY }}
-      ALLOWED_HOSTS: '0.0.0.0 127.0.0.1 localhost'
+      ALLOWED_HOSTS: "0.0.0.0 127.0.0.1 localhost"
       DISABLE_AUTH: True
     steps:
       - uses: actions/checkout@v4
@@ -84,5 +84,5 @@ jobs:
         working-directory: ./backend
         run: |
           sudo npm ci
-          npm run test:a11y:lighthouse
+          # npm run test:a11y:lighthouse
           npm run test:a11y:pa11y

--- a/.github/workflows/testing-from-ghcr.yml
+++ b/.github/workflows/testing-from-ghcr.yml
@@ -59,30 +59,30 @@ jobs:
           show_missing: true
           repo_token: ${{ secrets.GITHUB_TOKEN }}
 
-  a11y-testing:
-    runs-on: ubuntu-latest
-    env:
-      ENV: TESTING
-      SAM_API_KEY: ${{ secrets.SAM_API_KEY }}
-      DJANGO_BASE_URL: "http://localhost:8000"
-      DJANGO_SECRET_LOGIN_KEY: ${{ secrets.DJANGO_SECRET_LOGIN_KEY }}
-      LOGIN_CLIENT_ID: ${{ secrets.LOGIN_CLIENT_ID }}
-      SECRET_KEY: ${{ secrets.SECRET_KEY }}
-      ALLOWED_HOSTS: "0.0.0.0 127.0.0.1 localhost"
-      DISABLE_AUTH: True
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
-      - name: Start services
-        working-directory: ./backend
-        run: |
-          touch .env
-          docker compose -f docker-compose.yml up -d
-      - name: Run Lighthouse CI and pa11y
-        working-directory: ./backend
-        run: |
-          sudo npm ci
-          # npm run test:a11y:lighthouse
-          npm run test:a11y:pa11y
+  # a11y-testing:
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     ENV: TESTING
+  #     SAM_API_KEY: ${{ secrets.SAM_API_KEY }}
+  #     DJANGO_BASE_URL: "http://localhost:8000"
+  #     DJANGO_SECRET_LOGIN_KEY: ${{ secrets.DJANGO_SECRET_LOGIN_KEY }}
+  #     LOGIN_CLIENT_ID: ${{ secrets.LOGIN_CLIENT_ID }}
+  #     SECRET_KEY: ${{ secrets.SECRET_KEY }}
+  #     ALLOWED_HOSTS: "0.0.0.0 127.0.0.1 localhost"
+  #     DISABLE_AUTH: True
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: actions/setup-node@v3
+  #       with:
+  #         node-version: 16
+  #     - name: Start services
+  #       working-directory: ./backend
+  #       run: |
+  #         touch .env
+  #         docker compose -f docker-compose.yml up -d
+  #     - name: Run Lighthouse CI and pa11y
+  #       working-directory: ./backend
+  #       run: |
+  #         sudo npm ci
+  #         npm run test:a11y:lighthouse
+  #         npm run test:a11y:pa11y


### PR DESCRIPTION
Warnings are useful
But constant failures less so.
Scratch Lighthouse for now.

-----

The Lighthouse and pa11y failures due to upstream problems are getting in the way, so disable Lighthouse and pa11y for now.

-----

This does nothing but remove the a11y test step, other checks should be unnecessary for this PR.
