### PR TITLE
Swap to error mode

### DIFF
--- a/backend/.profile
+++ b/backend/.profile
@@ -28,7 +28,7 @@ export NEW_RELIC_ENVIRONMENT="$(echo "$VCAP_APPLICATION" | jq -r .space_name)"
 export NEW_RELIC_LOG=stdout
 
 # Logging level, (critical, error, warning, info and debug). Default to info
-export NEW_RELIC_LOG_LEVEL=debug
+export NEW_RELIC_LOG_LEVEL=error
 
 # https://docs.newrelic.com/docs/security/security-privacy/compliance/fedramp-compliant-endpoints/
 export NEW_RELIC_HOST="gov-collector.newrelic.com"


### PR DESCRIPTION
Leaving this for tomorrow (10/20) to do an early AM deploy with NR logging to error to see if there is any useful information regarding the 502 that is being thrown. 

Debug is not just debugging new relic (actually it may be) but if you ssh into the app and `source .profile` it dumps way more info than we need, and don't want to keep this on too long.

A subsequent PR will comment this out again, presuming we get it working, or leave it on error (if the logs aren't completely overwhelming)

For approval - Please approve, but do not merge, I will rebase and merge into main tomorrow