### PR TITLE
Set the name back to gsa-fac for testing

### DIFF
--- a/backend/.profile
+++ b/backend/.profile
@@ -19,8 +19,8 @@ export no_proxy="${S3_ENDPOINT_FOR_NO_PROXY},${S3_FIPS_ENDPOINT_FOR_NO_PROXY},${
 export NEW_RELIC_LICENSE_KEY="$(echo "$VCAP_SERVICES" | jq --raw-output --arg service_name "newrelic-creds" ".[][] | select(.name == \$service_name) | .credentials.NEW_RELIC_LICENSE_KEY")"
 
 # Set the application name for New Relic telemetry.
-#export NEW_RELIC_APP_NAME="$(echo "$VCAP_APPLICATION" | jq -r .application_name)"
-export NEW_RELIC_APP_NAME="$(echo "$VCAP_APPLICATION" | jq -r .application_name)-app"
+export NEW_RELIC_APP_NAME="$(echo "$VCAP_APPLICATION" | jq -r .application_name)"
+#export NEW_RELIC_APP_NAME="$(echo "$VCAP_APPLICATION" | jq -r .application_name)-app"
 
 # Set the environment name for New Relic telemetry.
 export NEW_RELIC_ENVIRONMENT="$(echo "$VCAP_APPLICATION" | jq -r .space_name)"


### PR DESCRIPTION
If this fails, we will send it back to NR support. This is a test for mogul, to see if our "gsa-fac" service is borked, and if this fails to send telemetry, then we can send it over. 

If this fails, a subsequent PR will change it back to gsa-fac-app (or a new name) and then add a deployment workflow to record them in new relic
