### PR TITLE
New Relic Deployment Blips

### DIFF
--- a/.github/workflows/new-relic-deployment.yml
+++ b/.github/workflows/new-relic-deployment.yml
@@ -1,0 +1,29 @@
+name: Record Deployment And Add New Relic Monitor
+on:
+  push:
+    branches:
+      - main
+      - prod
+    tags:
+      - v1.*
+
+jobs:
+  newrelic:
+    runs-on: ubuntu-latest
+    name: New Relic Record Deployment
+    steps:
+      # This step builds a var with the sha value to use later
+      - name: Get Git Short Commit
+        id: git-short
+        run: |
+          echo "short_sha=$(git rev-parse --short ${{ github.sha }})" >> $GITHUB_OUTPUT
+
+      # This step creates a new Change Tracking Marker
+      - name: Add New Relic Application Deployment Marker
+        uses: newrelic/deployment-marker-action@v2.3.0
+        with:
+          apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
+          guid: ${{ secrets.NEW_RELIC_DEPLOYMENT_ENTITY_GUID }}
+          version: "${{ steps.git-short.outputs.short_sha }}"
+          user: "${{ github.actor }}"
+

--- a/backend/.profile
+++ b/backend/.profile
@@ -19,8 +19,10 @@ export no_proxy="${S3_ENDPOINT_FOR_NO_PROXY},${S3_FIPS_ENDPOINT_FOR_NO_PROXY},${
 export NEW_RELIC_LICENSE_KEY="$(echo "$VCAP_SERVICES" | jq --raw-output --arg service_name "newrelic-creds" ".[][] | select(.name == \$service_name) | .credentials.NEW_RELIC_LICENSE_KEY")"
 
 # Set the application name for New Relic telemetry.
-# This will give 4 services (gsa-fac-dev, gsa-fac-staging, gsa-fac-production, gsa-fac-preview)
-export NEW_RELIC_APP_NAME="$(echo "$VCAP_APPLICATION" | jq -r .application_name)-$(echo "$VCAP_APPLICATION" | jq -r .space_name)"
+# this did not work on preview, so, since gsa-fac-app works, keeping that there
+#export NEW_RELIC_APP_NAME="$(echo "$VCAP_APPLICATION" | jq -r .application_name)-$(echo "$VCAP_APPLICATION" | jq -r .space_name)"
+export NEW_RELIC_APP_NAME="$(echo "$VCAP_APPLICATION" | jq -r .application_name)-app"
+
 
 # Set the environment name for New Relic telemetry.
 export NEW_RELIC_ENVIRONMENT="$(echo "$VCAP_APPLICATION" | jq -r .space_name)"

--- a/backend/.profile
+++ b/backend/.profile
@@ -19,8 +19,8 @@ export no_proxy="${S3_ENDPOINT_FOR_NO_PROXY},${S3_FIPS_ENDPOINT_FOR_NO_PROXY},${
 export NEW_RELIC_LICENSE_KEY="$(echo "$VCAP_SERVICES" | jq --raw-output --arg service_name "newrelic-creds" ".[][] | select(.name == \$service_name) | .credentials.NEW_RELIC_LICENSE_KEY")"
 
 # Set the application name for New Relic telemetry.
-#export NEW_RELIC_APP_NAME="$(echo "$VCAP_APPLICATION" | jq -r .application_name)"
-export NEW_RELIC_APP_NAME="$(echo "$VCAP_APPLICATION" | jq -r .application_name)-app"
+# This will give 4 services (gsa-fac-dev, gsa-fac-staging, gsa-fac-production, gsa-fac-preview)
+export NEW_RELIC_APP_NAME="$(echo "$VCAP_APPLICATION" | jq -r .application_name)-$(echo "$VCAP_APPLICATION" | jq -r .space_name)"
 
 # Set the environment name for New Relic telemetry.
 export NEW_RELIC_ENVIRONMENT="$(echo "$VCAP_APPLICATION" | jq -r .space_name)"


### PR DESCRIPTION
Adds a workflow to tell new relic when a deployment is happening. This will allow us to see (via NR) that our deploys are going through, and when downtime occurs, and will help finish the new relic service setup