### PR TITLE
Fix version input for new relic deployments

### DIFF
--- a/.github/workflows/new-relic-deployment.yml
+++ b/.github/workflows/new-relic-deployment.yml
@@ -10,20 +10,17 @@ on:
 jobs:
   newrelic:
     runs-on: ubuntu-latest
-    name: New Relic Record Deployment
+    name: New Relic
     steps:
-      # This step builds a var with the sha value to use later
-      - name: Get Git Short Commit
-        id: git-short
-        run: |
-          echo "short_sha=$(git rev-parse --short ${{ github.sha }})" >> $GITHUB_OUTPUT
-
+      # This step builds a var with the release tag value to use later
+      - name: Set Release Version from Tag
+        run: echo "RELEASE_VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
       # This step creates a new Change Tracking Marker
-      - name: Add New Relic Application Deployment Marker
+      - name: New Relic Application Deployment Marker
         uses: newrelic/deployment-marker-action@v2.3.0
         with:
           apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
           guid: ${{ secrets.NEW_RELIC_DEPLOYMENT_ENTITY_GUID }}
-          version: "${{ steps.git-short.outputs.short_sha }}"
+          version: "${{ env.RELEASE_VERSION }}"
           user: "${{ github.actor }}"
 

--- a/.github/workflows/new-relic-deployment.yml
+++ b/.github/workflows/new-relic-deployment.yml
@@ -10,13 +10,13 @@ on:
 jobs:
   newrelic:
     runs-on: ubuntu-latest
-    name: New Relic
+    name: New Relic Record Deployment
     steps:
       # This step builds a var with the release tag value to use later
       - name: Set Release Version from Tag
         run: echo "RELEASE_VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
       # This step creates a new Change Tracking Marker
-      - name: New Relic Application Deployment Marker
+      - name: Add New Relic Application Deployment Marker
         uses: newrelic/deployment-marker-action@v2.3.0
         with:
           apiKey: ${{ secrets.NEW_RELIC_API_KEY }}


### PR DESCRIPTION
Short Sha was not accepted, so using the ref_name

```
The short ref name of the branch or tag that triggered the workflow run. This value matches the branch or tag name shown on GitHub. For example, feature-branch-1.
```