### PR TITLE
New Relic Service Instances

### DIFF
--- a/backend/.profile
+++ b/backend/.profile
@@ -32,15 +32,7 @@ export NEW_RELIC_LOG_LEVEL=info
 # https://docs.newrelic.com/docs/security/security-privacy/compliance/fedramp-compliant-endpoints/
 export NEW_RELIC_HOST="gov-collector.newrelic.com"
 # https://docs.newrelic.com/docs/apm/agents/python-agent/configuration/python-agent-configuration/#proxy
-#https_proxy_protocol="$(echo "$VCAP_SERVICES" | jq --raw-output --arg service_name "https-proxy-creds" ".[][] | select(.name == \$service_name) | .credentials.protocol")"
-#https_proxy_domain="$(echo "$VCAP_SERVICES" | jq --raw-output --arg service_name "https-proxy-creds" ".[][] | select(.name == \$service_name) | .credentials.domain")"
-#https_proxy_port="$(echo "$VCAP_SERVICES" | jq --raw-output --arg service_name "https-proxy-creds" ".[][] | select(.name == \$service_name) | .credentials.port")"
-
-#export NEW_RELIC_PROXY_SCHEME="$https_proxy_protocol"
 export NEW_RELIC_PROXY_HOST="$https_proxy"
-#export NEW_RELIC_PROXY_PORT="$https_proxy_port"
-#export NEW_RELIC_PROXY_USER="$(echo "$VCAP_SERVICES" | jq --raw-output --arg service_name "https-proxy-creds" ".[][] | select(.name == \$service_name) | .credentials.username")"
-#export NEW_RELIC_PROXY_PASS="$(echo "$VCAP_SERVICES" | jq --raw-output --arg service_name "https-proxy-creds" ".[][] | select(.name == \$service_name) | .credentials.password")"
 
 # We only want to run migrate and collecstatic for the first app instance, not
 # for additional app instances, so we gate all of this behind CF_INSTANCE_INDEX

--- a/backend/.profile
+++ b/backend/.profile
@@ -14,15 +14,11 @@ S3_PRIVATE_ENDPOINT_FOR_NO_PROXY="$(echo $VCAP_SERVICES | jq --raw-output --arg 
 S3_PRIVATE_FIPS_ENDPOINT_FOR_NO_PROXY="$(echo $VCAP_SERVICES | jq --raw-output --arg service_name "fac-private-s3" ".[][] | select(.name == \$service_name) | .credentials.fips_endpoint")"
 export no_proxy="${S3_ENDPOINT_FOR_NO_PROXY},${S3_FIPS_ENDPOINT_FOR_NO_PROXY},${S3_PRIVATE_ENDPOINT_FOR_NO_PROXY},${S3_PRIVATE_FIPS_ENDPOINT_FOR_NO_PROXY},apps.internal"
 
-
 # Grab the New Relic license key from the newrelic-creds user-provided service instance
 export NEW_RELIC_LICENSE_KEY="$(echo "$VCAP_SERVICES" | jq --raw-output --arg service_name "newrelic-creds" ".[][] | select(.name == \$service_name) | .credentials.NEW_RELIC_LICENSE_KEY")"
 
 # Set the application name for New Relic telemetry.
-# this did not work on preview, so, since gsa-fac-app works, keeping that there
-#export NEW_RELIC_APP_NAME="$(echo "$VCAP_APPLICATION" | jq -r .application_name)-$(echo "$VCAP_APPLICATION" | jq -r .space_name)"
-export NEW_RELIC_APP_NAME="$(echo "$VCAP_APPLICATION" | jq -r .application_name)-app"
-
+export NEW_RELIC_APP_NAME="$(echo "$VCAP_APPLICATION" | jq -r .application_name)-$(echo "$VCAP_APPLICATION" | jq -r .space_name)"
 
 # Set the environment name for New Relic telemetry.
 export NEW_RELIC_ENVIRONMENT="$(echo "$VCAP_APPLICATION" | jq -r .space_name)"

--- a/backend/.profile
+++ b/backend/.profile
@@ -37,7 +37,7 @@ export NEW_RELIC_HOST="gov-collector.newrelic.com"
 #https_proxy_port="$(echo "$VCAP_SERVICES" | jq --raw-output --arg service_name "https-proxy-creds" ".[][] | select(.name == \$service_name) | .credentials.port")"
 
 #export NEW_RELIC_PROXY_SCHEME="$https_proxy_protocol"
-#export NEW_RELIC_PROXY_HOST="$https_proxy_domain"
+export NEW_RELIC_PROXY_HOST="$https_proxy"
 #export NEW_RELIC_PROXY_PORT="$https_proxy_port"
 #export NEW_RELIC_PROXY_USER="$(echo "$VCAP_SERVICES" | jq --raw-output --arg service_name "https-proxy-creds" ".[][] | select(.name == \$service_name) | .credentials.username")"
 #export NEW_RELIC_PROXY_PASS="$(echo "$VCAP_SERVICES" | jq --raw-output --arg service_name "https-proxy-creds" ".[][] | select(.name == \$service_name) | .credentials.password")"

--- a/terraform/shared/modules/env/https-proxy.tf
+++ b/terraform/shared/modules/env/https-proxy.tf
@@ -23,12 +23,11 @@ module "https-proxy" {
       # We put in an upstream issue about this: https://github.com/caddyserver/forwardproxy/issues/102
       "*.newrelic.com:443",
 
-      # This is thanks to Ryan Ahearn at 18F for pointing us in this direction. We originally used New Relic without
-      # any proxy configuration, but it was determined that our security group in the dev environment allowed that
-      # to work. Our other spaces do not have this, and it was determined that NR wants to proxy a connection to a proxy
-      # This does need the NEW_RELIC_PROXY_HOST="$https_proxy" set, in conjunction with this. We believe this to be a
-      # potential bug with the new relic agent, and will be reporting this to New Relic in the hopes of being able to
-      # remove the proxy from our allow list.
+      # It was determined that NR wants to proxy a connection to a proxy. This does need the NEW_RELIC_PROXY_HOST="$https_proxy" set,
+      # in conjunction with this. We believe this to be a potential bug with the new relic agent,
+      #and will be reporting this to New Relic in the hopes of being able to remove the proxy from our allow list.
+      # This is thanks to Ryan Ahearn at 18F for pointing us in this direction
+      # https://gsa-tts.slack.com/archives/C09CR1Q9Z/p1699394487090859
       "${var.cf_org_name}-${var.cf_space_name}-https-proxy.apps.internal",
 
       # Login.gov sandbox

--- a/terraform/shared/modules/env/https-proxy.tf
+++ b/terraform/shared/modules/env/https-proxy.tf
@@ -23,6 +23,14 @@ module "https-proxy" {
       # We put in an upstream issue about this: https://github.com/caddyserver/forwardproxy/issues/102
       "*.newrelic.com:443",
 
+      # This is thanks to Ryan Ahearn at 18F for pointing us in this direction. We originally used New Relic without
+      # any proxy configuration, but it was determined that our security group in the dev environment allowed that
+      # to work. Our other spaces do not have this, and it was determined that NR wants to proxy a connection to a proxy
+      # This does need the NEW_RELIC_PROXY_HOST="$https_proxy" set, in conjunction with this. We believe this to be a
+      # potential bug with the new relic agent, and will be reporting this to New Relic in the hopes of being able to
+      # remove the proxy from our allow list.
+      "${var.cf_org_name}-${var.cf_space_name}-https-proxy.apps.internal",
+
       # Login.gov sandbox
       "idp.int.identitysandbox.gov:443",
 

--- a/terraform/shared/modules/env/https-proxy.tf
+++ b/terraform/shared/modules/env/https-proxy.tf
@@ -28,7 +28,7 @@ module "https-proxy" {
       #and will be reporting this to New Relic in the hopes of being able to remove the proxy from our allow list.
       # This is thanks to Ryan Ahearn at 18F for pointing us in this direction
       # https://gsa-tts.slack.com/archives/C09CR1Q9Z/p1699394487090859
-      "${var.cf_org_name}-${var.cf_space_name}-https-proxy.apps.internal",
+      "${var.cf_org_name}-${var.cf_space_name}-egress-https-proxy.apps.internal",
 
       # Login.gov sandbox
       "idp.int.identitysandbox.gov:443",

--- a/terraform/shared/modules/env/https-proxy.tf
+++ b/terraform/shared/modules/env/https-proxy.tf
@@ -25,7 +25,7 @@ module "https-proxy" {
 
       # It was determined that NR wants to proxy a connection to a proxy. This does need the NEW_RELIC_PROXY_HOST="$https_proxy" set,
       # in conjunction with this. We believe this to be a potential bug with the new relic agent,
-      #and will be reporting this to New Relic in the hopes of being able to remove the proxy from our allow list.
+      # and will be reporting this to New Relic in the hopes of being able to remove the proxy from our allow list.
       # This is thanks to Ryan Ahearn at 18F for pointing us in this direction
       # https://gsa-tts.slack.com/archives/C09CR1Q9Z/p1699394487090859
       "${var.cf_org_name}-${var.cf_space_name}-egress-https-proxy.apps.internal",


### PR DESCRIPTION
The most recent deployment to preview registered the service with New Relic.

![image](https://github.com/GSA-TTS/FAC/assets/130377221/c84f49a1-9eb2-4cc0-8a00-133700d12ac5)

This will give us 4 unique services. Each service will share alerts (soon) and this will allow me to work on the poams.
```bash
gsa-fac-dev
gsa-fac-preview
gsa-fac-staging
gsa-fac-production
```

A subsequent PR, after this goes to prod will address [NR Deployment Logging](https://github.com/GSA-TTS/FAC/blob/main/.github/workflows/new-relic-deployment.yml) so that each deploy workflow calls this, with a ${env} input, and does the deployment marker on an env-by-env basis. 8 new secrets will need to be added to github secrets

Adding @mogul as a reviewer for awareness, since we need to fix the security group in `dev`