### PR TITLE
Set head_ref to an env var

### DIFF
--- a/.github/workflows/add-bpmn-renders.yml
+++ b/.github/workflows/add-bpmn-renders.yml
@@ -1,75 +1,78 @@
 ---
-name: Lint BPMN
-# Whenever a PR contains changes to BPMN files, render (or remove) the
-# corresponding PNG and SVG output, then raise a new pull-request to add/remove
-# those files onto the branch. (Note that this will count as a "failing test", so
-# the base branch won't be merge-able until the PR with the images is merged
-# into it!)
-#
-# Cribs heavily from this example:
-# https://github.com/peter-evans/create-pull-request/blob/main/docs/examples.md#use-case-create-a-pull-request-to-modifyfix-pull-requests
+  name: Lint BPMN
+  # Whenever a PR contains changes to BPMN files, render (or remove) the
+  # corresponding PNG and SVG output, then raise a new pull-request to add/remove
+  # those files onto the branch. (Note that this will count as a "failing test", so
+  # the base branch won't be merge-able until the PR with the images is merged
+  # into it!)
+  #
+  # Cribs heavily from this example:
+  # https://github.com/peter-evans/create-pull-request/blob/main/docs/examples.md#use-case-create-a-pull-request-to-modifyfix-pull-requests
 
-on:
-  workflow_call:
+  on:
+    workflow_call:
 
-jobs:
-  diagrams-up-to-date:
-    # Check that the PR is not raised by this workflow (avoiding recursion) and
-    # is not from a fork
-    if: startsWith(github.event.pull_request.head.ref, 'auto/bpmn-patches') == false && github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+  env:
+    BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
+  jobs:
+    diagrams-up-to-date:
+      # Check that the PR is not raised by this workflow (avoiding recursion) and
+      # is not from a fork
+      if: startsWith(github.event.pull_request.head.ref, 'auto/bpmn-patches') == false && github.event.pull_request.head.repo.full_name == github.repository
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
 
-      - name: Install bpmn-to-image
-        run: npm install -g bpmn-to-image
+        - name: Setup Node
+          uses: actions/setup-node@v4
 
-      - name: Remove existing PNGs
-        run: rm docs/bpmn-workflow-models/*.bpmn.png
+        - name: Install bpmn-to-image
+          run: npm install -g bpmn-to-image
 
-      - name: Generate a PNG for each BPMN file
-        run: |
-          for file in docs/bpmn-workflow-models/*.bpmn ; do
-            bpmn-to-image ${file}:${file}.png
-          done
+        - name: Remove existing PNGs
+          run: rm docs/bpmn-workflow-models/*.bpmn.png
 
-      - name: Check For Changes
-        id: vars
-        run: |
-          branchname="bpmn-patches/${{ github.event.pull_request.head.ref }}"
-          echo "branchname=${branchname}" >> $GITHUB_OUTPUT
-          imagesupdated=$(git status --porcelain | cut -d ' ' -f 2 | wc -l)
-          echo "imagesupdated=${imagesupdated}" >> $GITHUB_OUTPUT
+        - name: Generate a PNG for each BPMN file
+          run: |
+            for file in docs/bpmn-workflow-models/*.bpmn ; do
+              bpmn-to-image ${file}:${file}.png
+            done
 
-      - name: Create Pull Request with Changes
-        if: steps.vars.outputs.imagesupdated != 0
-        uses: peter-evans/create-pull-request@v5
-        with:
-          commit-message: Update BPMN images for ${{ github.event.pull_request.head.ref }}
-          title: Update BPMN images for ${{ github.event.pull_request.head.ref }}
-          body: This is an auto-generated PR to sync BPMN images with their source on ${{ github.event.pull_request.head.ref }}.
-          labels: bpmn-to-image, automated pr
-          branch: ${{ steps.vars.outputs.branchname }}
-          base: ${{ github.event.pull_request.head.ref }}
+        - name: Check For Changes
+          id: vars
+          run: |
+            branchname="bpmn-patches/${{ env.BRANCH_NAME }}"
+            echo "branchname=${branchname}" >> $GITHUB_OUTPUT
+            imagesupdated=$(git status --porcelain | cut -d ' ' -f 2 | wc -l)
+            echo "imagesupdated=${imagesupdated}" >> $GITHUB_OUTPUT
 
-      - name: Update Changes
-        if: steps.vars.outputs.imagesupdated != 0
-        uses: peter-evans/create-or-update-comment@v3
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            Source and image drift!
-            A PR stops confusion...
-            I got ya partner.
+        - name: Create Pull Request with Changes
+          if: steps.vars.outputs.imagesupdated != 0
+          uses: peter-evans/create-pull-request@v5
+          with:
+            commit-message: Update BPMN images for ${{ env.BRANCH_NAME }}
+            title: Update BPMN images for ${{ env.BRANCH_NAME }}
+            body: This is an auto-generated PR to sync BPMN images with their source on ${{ env.BRANCH_NAME }}.
+            labels: bpmn-to-image, automated pr
+            branch: ${{ steps.vars.outputs.branchname }}
+            base: ${{ env.BRANCH_NAME }}
 
-            (...merge PR #${{ env.PULL_REQUEST_NUMBER }}...)
+        - name: Update Changes
+          if: steps.vars.outputs.imagesupdated != 0
+          uses: peter-evans/create-or-update-comment@v3
+          with:
+            issue-number: ${{ github.event.pull_request.number }}
+            body: |
+              Source and image drift!
+              A PR stops confusion...
+              I got ya partner.
 
-      - name: Fail if images are not in sync with source
-        if: steps.vars.outputs.imagesupdated != 0
-        run: |
-          echo "BPMN images are out of sync with their source. Merge PR #${PULL_REQUEST_NUMBER}"
-          exit 1
+              (...merge PR #${{ github.event.pull_request.number }}...)
+
+        - name: Fail if images are not in sync with source
+          if: steps.vars.outputs.imagesupdated != 0
+          run: |
+            echo "BPMN images are out of sync with their source. Merge PR #${PULL_REQUEST_NUMBER}"
+            exit 1


### PR DESCRIPTION
Based on the following [example](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable)

I believe that this will work. Github suggests using the event payload in an env var, instead of directly referencing it. This _should_ patch the allstart issue. _I think_