### PR TITLE
Rollback Trivy to v0.13.1

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -39,7 +39,7 @@ jobs:
         run: docker build -t ${{ env.DOCKER_NAME }}:${{ steps.date.outputs.date }} .
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.16.0
+        uses: aquasecurity/trivy-action@0.13.1
         with:
           image-ref: '${{ env.DOCKER_NAME }}:${{ steps.date.outputs.date }}'
           scan-type: 'image'
@@ -74,7 +74,7 @@ jobs:
         run: docker pull ${{ matrix.image.name }}
 
       - name: Run Trivy vulnerability scanner on Third Party Images
-        uses: aquasecurity/trivy-action@0.16.0
+        uses: aquasecurity/trivy-action@0.13.1
         with:
           image-ref: '${{ matrix.image.name }}'
           scan-type: 'image'


### PR DESCRIPTION
![image](https://github.com/GSA-TTS/FAC/assets/130377221/e3c3dd43-5bcd-4902-8c34-1f933ad72363)

Based on [AquaSec Trivy Action](https://github.com/aquasecurity/trivy-action/actions), it seems all of the recent builds have failed. 

Rolling this back to the previous known working version to get our scans working again