### PR TITLE
Bug - 500 on Precertification Summary Report

### DIFF
--- a/backend/audit/intake_to_dissemination.py
+++ b/backend/audit/intake_to_dissemination.py
@@ -89,8 +89,8 @@ class IntakeToDissemination(object):
                     finding_text=entry["text_of_finding"],
                 )
                 findings_text_objects.append(finding_text_)
-            self.loaded_objects["FindingTexts"] = findings_text_objects
-
+        
+        self.loaded_objects["FindingTexts"] = findings_text_objects
         return findings_text_objects
 
     def load_findings(self):

--- a/backend/audit/intake_to_dissemination.py
+++ b/backend/audit/intake_to_dissemination.py
@@ -89,7 +89,7 @@ class IntakeToDissemination(object):
                     finding_text=entry["text_of_finding"],
                 )
                 findings_text_objects.append(finding_text_)
-        
+
         self.loaded_objects["FindingTexts"] = findings_text_objects
         return findings_text_objects
 

--- a/backend/dissemination/summary_reports.py
+++ b/backend/dissemination/summary_reports.py
@@ -360,7 +360,7 @@ def gather_report_data_pre_certification(i2d_data):
     # Move the IntakeToDissemination data to dissemination_data, under the proper naming scheme.
     dissemination_data = {}
     for name_i2d, model in i2d_to_dissemination.items():
-        dissemination_data[model.__name__.lower()] = i2d_data.get(name_i2d)
+        dissemination_data[model.__name__.lower()] = i2d_data.get(name_i2d, [])
 
     data = {}
 


### PR DESCRIPTION
# Bug - 500 on Precertification Summary Report

ZD: https://fac-gov.zendesk.com/agent/tickets/1538

## Problem:
Users were seeing 500 errors when attempting to view their pre-certification summary report. 

The given error, pulled from production by Tadhg:
```
/home/vcap/app/dissemination/summary_reports.py\", line 469, in generate_presubmission_report
data = gather_report_data_pre_certification(i2d_data)
File \"/home/vcap/app/dissemination/summary_reports.py\", line 381, in gather_report_data_pre_certification
for obj in dissemination_data[model_name]:\nTypeError: 'NoneType' object is not iterable"
```

To generate the summary report, we:
1. Run the data we already have through IntakeToDissemination, so that it is formatted in the way that we will eventually present it to the public.
2. Run this new IntakeToDissemination data through a few loops, reformatting it and placing it into a spreadsheet.
3. Store the generated spreadsheet in S3.
4. Redirect the user to this new file for download.

The problem is in step one and two.
1. Running the data through IntakeToDissemination's `load_all` should place an empty array if no data exists. So, if someone has no findings, `self.loaded_objects["Findings"]` will be an empty array. This was not happening to the FindingTexts field, due to a whitespace issue. Then, the later step tries to loop through this data and gets mad.
2. When we loop through the IntakeToDissemination data, we assume each field will have a value. If it doesn't, we get a `None`, which we then try to iterate through. 

## Changes:
1. Ensure `self.loaded_objects["FindingTexts"]` will be an empty array if FindingTexts don't exist. 
2. Don't rely on IntakeToDissemination's `load_all` to always place data, and set a default value when using the `.get()` methods. 

## PR checklist: submitters

- [ ]   Link to an issue if possible. If there’s no issue, describe what your branch does. Even if there is an issue, a brief description in the PR is still useful.
- [ ]   List any special steps reviewers have to follow to test the PR. For example, adding a local environment variable, creating a local test file, etc.
- [ ]   For extra credit, submit a screen recording like [this one](https://github.com/GSA-TTS/FAC/pull/1821).
- [ ]   Make sure you’ve merged `main` into your branch shortly before creating the PR. (You should also be merging `main` into your branch regularly during development.)
- [ ]   Make sure you’ve accounted for any migrations. When you’re about to create the PR, bring up the application locally and then run `git status | grep migrations`. If there are any results, you probably need to add them to the branch for the PR. Your PR should have only **one** new migration file for each of the component apps, except in rare circumstances; you may need to delete some and re-run `python manage.py makemigrations` to reduce the number to one. (Also, unless in exceptional circumstances, your PR should not delete any migration files.)
- [ ]   Make sure that whatever feature you’re adding has tests that cover the feature. This includes test coverage to make sure that the previous workflow still works, if applicable.
- [ ]   Make sure the full-submission.cy.js [Cypress test](https://github.com/GSA-TTS/FAC/blob/main/docs/testing.md#end-to-end-testing) passes, if applicable.
- [ ]   Do manual testing locally. Our tests are not good enough yet to allow us to skip this step. If that’s not applicable for some reason, check this box.
- [ ]   Verify that no Git surgery was necessary, or, if it was necessary at any point, repeat the testing after it’s finished.
- [ ]   Once a PR is merged, keep an eye on it until it’s deployed to dev, and do enough testing on dev to verify that it deployed successfully, the feature works as expected, and the happy path for the broad feature area (such as submission) still works.

## PR checklist: reviewers

- [ ]   Pull the branch to your local environment and run `make docker-clean; make docker-first-run && docker compose up`; then run `docker compose exec web /bin/bash -c "python manage.py test"`
- [ ]   Manually test out the changes locally, or check this box to verify that it wasn’t applicable in this case.
- [ ]   Check that the PR has appropriate tests. Look out for changes in HTML/JS/JSON Schema logic that may need to be captured in Python tests even though the logic isn’t in Python.
- [ ]   Verify that no Git surgery is necessary at any point (such as during a merge party), or, if it was, repeat the testing after it’s finished.

The larger the PR, the stricter we should be about these points.
