### PR TITLE
Logshipper patch for deterministic zip files v2

### DIFF
--- a/terraform/shared/modules/cg-logshipper/cg-logshipper.tf
+++ b/terraform/shared/modules/cg-logshipper/cg-logshipper.tf
@@ -71,11 +71,11 @@ data "external" "logshipperzip" {
 }
 
 resource "cloudfoundry_app" "cg_logshipper_app" {
-  name       = var.name
-  space      = data.cloudfoundry_space.apps.id
-  buildpacks = ["https://github.com/cloudfoundry/apt-buildpack", "nginx_buildpack"]
-  path       = "${path.module}/${data.external.logshipperzip.result.path}"
-  # source_code_hash  = filesha256("${path.module}/${data.external.logshipperzip.result.path}")
+  name              = var.name
+  space             = data.cloudfoundry_space.apps.id
+  buildpacks        = ["https://github.com/cloudfoundry/apt-buildpack", "nginx_buildpack"]
+  path              = "${path.module}/${data.external.logshipperzip.result.path}"
+  source_code_hash  = filesha256("${path.module}/${data.external.logshipperzip.result.path}")
   timeout           = 180
   disk_quota        = var.disk_quota
   memory            = var.logshipper_memory

--- a/terraform/shared/modules/cg-logshipper/prepare-logshipper.sh
+++ b/terraform/shared/modules/cg-logshipper/prepare-logshipper.sh
@@ -34,7 +34,7 @@ $(git config --global --add safe.directory /github/workspace && \
   git config --global --unset safe.directory /github/workspace
 )
 
-cd "${tmpdir}/cg-logshipper-main" && zip -r -o "${popdir}/logshipper.zip" ./ > /dev/null
+cd "${tmpdir}/cg-logshipper-main" && zip -r -o -X "${popdir}/logshipper.zip" ./ > /dev/null
 
 # Tell Terraform where to find it
 cat << EOF


### PR DESCRIPTION
### Problem:
When we were zipping the contents of the file, we found that the sha256sum was different on, what appeared to be the same contents.

### Resolution
Based on [the following blog](https://zerostride.medium.com/building-deterministic-zip-files-with-built-in-commands-741275116a19)
`By default, zip will include “extra information” in the zip file. This depends on OS and such, but can include owner, creation time, access time etc`


So, adding -X to our zip command, seems to have resolved this issue, on both Windows and WSL2 Ubuntu

```bash
# Windows
Alex Steel@DESKTOP-NL4DO24 MINGW64 ~/Code/FAC/terraform/shared/modules/cg-logshipper (logshipper-patch)
$ ./prepare-logshipper.sh 
{ "path": "logshipper.zip" }

Alex Steel@DESKTOP-NL4DO24 MINGW64 ~/Code/FAC/terraform/shared/modules/cg-logshipper (logshipper-patch)
$ sha256sum.exe logshipper.zip 
53fd8eddce10a7f3302aa20de9242163afabbbf3be09518a3fb545320df51ee1 *logshipper.zip

Alex Steel@DESKTOP-NL4DO24 MINGW64 ~/Code/FAC/terraform/shared/modules/cg-logshipper (logshipper-patch)
$ rm logshipper.zip 

Alex Steel@DESKTOP-NL4DO24 MINGW64 ~/Code/FAC/terraform/shared/modules/cg-logshipper (logshipper-patch)
$ ./prepare-logshipper.sh
{ "path": "logshipper.zip" }

Alex Steel@DESKTOP-NL4DO24 MINGW64 ~/Code/FAC/terraform/shared/modules/cg-logshipper (logshipper-patch)
$ sha256sum.exe logshipper.zip
53fd8eddce10a7f3302aa20de9242163afabbbf3be09518a3fb545320df51ee1 *logshipper.zip
```

```bash
# WSL2 Ubuntu
asteel@DESKTOP-NL4DO24:~/FAC/terraform/shared/modules/cg-logshipper$ sha256sum logshipper.zip 
0d3768dc4f30085afc9fe6e93c0a9d7de737ab38f511a0b8291ff600498429b6  logshipper.zip

asteel@DESKTOP-NL4DO24:~/FAC/terraform/shared/modules/cg-logshipper$ rm logshipper.zip 

asteel@DESKTOP-NL4DO24:~/FAC/terraform/shared/modules/cg-logshipper$ ./prepare-logshipper.sh 
{ "path": "logshipper.zip" }

asteel@DESKTOP-NL4DO24:~/FAC/terraform/shared/modules/cg-logshipper$ sha256sum logshipper.zip 
0d3768dc4f30085afc9fe6e93c0a9d7de737ab38f511a0b8291ff600498429b6  logshipper.zip
```