### PR TITLE
Manage issues around Access and missing certifier roles

### DIFF
--- a/backend/audit/views/manage_submission_access.py
+++ b/backend/audit/views/manage_submission_access.py
@@ -65,14 +65,12 @@ class ChangeOrAddRoleView(SingleAuditChecklistAccessRequiredMixin, generic.View)
             "errors": [],
         }
         if self.role != "editor":
-            access = SimpleNamespace(
-                fullname="UNASSIGNED ROLE", email="UNASSIGNED ROLE", role=self.role
-            )
-
             try:
                 access = Access.objects.get(sac=sac, role=self.role)
             except Access.DoesNotExist:
-                pass
+                access = SimpleNamespace(
+                    fullname="UNASSIGNED ROLE", email="UNASSIGNED ROLE", role=self.role
+                )
 
             context = context | {
                 "friendly_role": _get_friendly_role(access.role),

--- a/backend/audit/views/manage_submission_access.py
+++ b/backend/audit/views/manage_submission_access.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from django import forms
 from django.db import transaction
 from django.shortcuts import redirect, render, reverse
@@ -7,9 +8,18 @@ from audit.mixins import (
     SingleAuditChecklistAccessRequiredMixin,
 )
 from audit.models import (
+    ACCESS_ROLES,
     Access,
     SingleAuditChecklist,
 )
+
+
+def _get_friendly_role(role):
+    return dict(ACCESS_ROLES)[role]
+
+
+def _create_and_save_access(sac, role, fullname, email):
+    Access(sac=sac, role=role, fullname=fullname, email=email).save()
 
 
 class ChangeAccessForm(forms.Form):
@@ -36,6 +46,7 @@ class ChangeOrAddRoleView(SingleAuditChecklistAccessRequiredMixin, generic.View)
 
     role = "editor"
     other_role = ""
+    template = "audit/manage-submission-change-access.html"
 
     def get(self, request, *args, **kwargs):
         """
@@ -54,14 +65,22 @@ class ChangeOrAddRoleView(SingleAuditChecklistAccessRequiredMixin, generic.View)
             "errors": [],
         }
         if self.role != "editor":
-            access = Access.objects.get(sac=sac, role=self.role)
+            access = SimpleNamespace(
+                fullname="UNASSIGNED ROLE", email="UNASSIGNED ROLE", role=self.role
+            )
+
+            try:
+                access = Access.objects.get(sac=sac, role=self.role)
+            except Access.DoesNotExist:
+                pass
+
             context = context | {
-                "friendly_role": access.get_friendly_role(),
+                "friendly_role": _get_friendly_role(access.role),
                 "certifier_name": access.fullname,
                 "email": access.email,
             }
 
-        return render(request, "audit/manage-submission-change-access.html", context)
+        return render(request, self.template, context)
 
     def post(self, request, *args, **kwargs):
         """
@@ -73,22 +92,33 @@ class ChangeOrAddRoleView(SingleAuditChecklistAccessRequiredMixin, generic.View)
         form = ChangeAccessForm(request.POST)
         form.full_clean()
         url = reverse("audit:ManageSubmission", kwargs={"report_id": report_id})
+        fullname = form.cleaned_data["fullname"]
+        email = form.cleaned_data["email"]
 
+        # Only if we have self.other_role do we need further checks:
         if not self.other_role:
-            Access(
-                sac=sac,
-                role=self.role,
-                fullname=form.cleaned_data["fullname"],
-                email=form.cleaned_data["email"],
-            ).save()
+            _create_and_save_access(sac, self.role, fullname, email)
             return redirect(url)
 
-        access = Access.objects.get(sac=sac, role=self.role)
-        other_access = Access.objects.get(sac=sac, role=self.other_role)
-        if form.cleaned_data["email"] == other_access.email:
+        # We need the existing role assignment, if any, to delete it:
+        try:
+            access = Access.objects.get(sac=sac, role=self.role)
+        except Access.DoesNotExist:
+            access = SimpleNamespace(
+                fullname="UNASSIGNED ROLE", email="UNASSIGNED ROLE", role=self.role
+            )
+
+        # We need the other role assignment, if any, to compare email addresses:
+        try:
+            other_access = Access.objects.get(sac=sac, role=self.other_role)
+            other_access_email = other_access.email
+        except Access.DoesNotExist:
+            other_access_email = None
+
+        if email == other_access_email:
             context = {
                 "role": self.role,
-                "friendly_role": access.get_friendly_role(),
+                "friendly_role": _get_friendly_role(self.role),
                 "auditee_uei": sac.general_information["auditee_uei"],
                 "auditee_name": sac.general_information.get("auditee_name"),
                 "certifier_name": access.fullname,
@@ -98,22 +128,18 @@ class ChangeOrAddRoleView(SingleAuditChecklistAccessRequiredMixin, generic.View)
                     "Cannot use the same email address for both certifying officials."
                 ],
             }
-            return render(
-                request,
-                "audit/manage-submission-change-access.html",
-                context,
-                status=400,
-            )
+            return render(request, self.template, context, status=400)
 
-        with transaction.atomic():
-            access.delete(removing_user=request.user, removal_event="access-change")
-
-            Access(
-                sac=sac,
-                role=self.role,
-                fullname=form.cleaned_data["fullname"],
-                email=form.cleaned_data["email"],
-            ).save()
+        # Only Access, and not SimpleNamespace, has .delete:
+        if hasattr(access, "delete"):
+            with transaction.atomic():
+                access.delete(removing_user=request.user, removal_event="access-change")
+                _create_and_save_access(sac, self.role, fullname, email)
+        # We know that submissions can get into a bad state where no
+        # certifying role(s) exist, so we should support cases where this
+        # happens:
+        else:
+            _create_and_save_access(sac, self.role, fullname, email)
 
         return redirect(url)
 


### PR DESCRIPTION
If you cannot change  
Something not already there  
Bugs may ensnare you.  

-----

The duplicate-email issues addressed by [Allow Access creation for non-unique emails](https://github.com/GSA-TTS/FAC/pull/3068) suggest that more users than previously thought may end up with submissions where mandatory `Access` roles are absent. This PR allows for the absence of those roles in the access management flow.

In the rare cases where there are missing roles, the manage access page will look something like this:

![image](https://github.com/GSA-TTS/FAC/assets/2626258/b9298f0d-199d-4a26-81d7-6e76b1dd6ccf)

We may want to clean this up later, but I’m bringing it in now because at the moment without this feature, the only way for users to get past this problem is to start a new submission from scratch.

I think this should be fine if the tests pass. To test locally, you should create a new submission as normal, then delete one or both of the certifier roles and check that this behaves as expected.

-----

## PR checklist: submitters

- [x]   Link to an issue if possible. If there’s no issue, describe what your branch does. Even if there is an issue, a brief description in the PR is still useful.
- [x]   List any special steps reviewers have to follow to test the PR. For example, adding a local environment variable, creating a local test file, etc.
- [ ]   For extra credit, submit a screen recording like [this one](https://github.com/GSA-TTS/FAC/pull/1821).
- [x]   Make sure you’ve merged `main` into your branch shortly before creating the PR. (You should also be merging `main` into your branch regularly during development.)
- [x]   Make sure you’ve accounted for any migrations. When you’re about to create the PR, bring up the application locally and then run `git status | grep migrations`. If there are any results, you probably need to add them to the branch for the PR. Your PR should have only **one** new migration file for each of the component apps, except in rare circumstances; you may need to delete some and re-run `python manage.py makemigrations` to reduce the number to one. (Also, unless in exceptional circumstances, your PR should not delete any migration files.)
- [x]   Make sure that whatever feature you’re adding has tests that cover the feature. This includes test coverage to make sure that the previous workflow still works, if applicable.
- [ ]   Make sure the full-submission.cy.js [Cypress test](https://github.com/GSA-TTS/FAC/blob/main/docs/testing.md#end-to-end-testing) passes, if applicable.
- [x]   Do manual testing locally. Our tests are not good enough yet to allow us to skip this step. If that’s not applicable for some reason, check this box.
- [x]   Verify that no Git surgery was necessary, or, if it was necessary at any point, repeat the testing after it’s finished.
- [x]   Once a PR is merged, keep an eye on it until it’s deployed to dev, and do enough testing on dev to verify that it deployed successfully, the feature works as expected, and the happy path for the broad feature area (such as submission) still works.

## PR checklist: reviewers

- [ ]   Pull the branch to your local environment and run `make docker-clean; make docker-first-run && docker compose up`; then run `docker compose exec web /bin/bash -c "python manage.py test"`
- [ ]   Manually test out the changes locally, or check this box to verify that it wasn’t applicable in this case.
- [ ]   Check that the PR has appropriate tests. Look out for changes in HTML/JS/JSON Schema logic that may need to be captured in Python tests even though the logic isn’t in Python.
- [ ]   Verify that no Git surgery is necessary at any point (such as during a merge party), or, if it was, repeat the testing after it’s finished.

The larger the PR, the stricter we should be about these points.
