### PR TITLE
Cypress - Wait on both Requests

### DIFF
--- a/backend/cypress/support/workbook-uploads.js
+++ b/backend/cypress/support/workbook-uploads.js
@@ -1,20 +1,35 @@
-// re-usable code for workbook uploads
-
-// testWorkbookUpload('/audit/excel/federal-awards-expended/*', '#file-input-federal-awards-xlsx', 'federal-awards-expended-UPDATE.xlsx')
-// assumes you are on the appropriate upload page already
+/**
+ * Tests an upload page. Assumes Cypress is on the appropriate upload page already.
+ * 1. Define the requests to watch (intercepts)
+ *   "uploadSuccess" - The file upload endpoint. On success, returns a 302 redirect to the homepage.
+ *   "uploadRedirect" - The post-upload 302 redirects to the homepage '/', which then directs to '/audit/'.
+ *   The first intercept cannot follow the redirect, so we watch for both requests. See https://github.com/cypress-io/cypress/issues/24700
+ * 2. Attach a file to upload.
+ * 3. Wait for the upload to complete by waiting for the requests to recieve proper responses.
+ * 4. Ensure the information box updated correctly.
+ * 5. Navigate through to the submission checklist.
+ *
+ * @param {string} interceptUrl The url for the file upload endpoint.
+ * @param {string} uploadSelector The name of the fle upload input element.
+ * @param {string} filename The path and name of the test file to upload.
+ * @param {boolean} will_intercept Whether or not the function will mock the upload.
+ * @return {null} No return value.
+ */
 function testWorkbookUpload(interceptUrl, uploadSelector, filename, will_intercept = true) {
-    cy.intercept(interceptUrl + '*', (req) => {
-      if (will_intercept) {
-        // return a success fixture
-        req.reply({ fixture: 'success-res.json' });
-      } else {
-        // with no intercept, don't intervene
-        req.continue();
-      }
-    }).as('uploadSuccess');
+  cy.intercept(interceptUrl + '*', (req) => {
+    if (will_intercept) {
+      req.reply({ fixture: 'success-res.json' });
+    } else {
+      req.continue();
+    }
+  }).as('uploadSuccess');
+  cy.intercept('/audit/').as('uploadRedirect');
+
   cy.get(uploadSelector).attachFile(filename);
-  // Upload url (POST /audit/excel/workbookname) returns a redirect to "/" on successful upload. So, 302.
-  cy.wait('@uploadSuccess').its('response.statusCode').should('eq', 302);  
+
+  cy.wait('@uploadSuccess').its('response.statusCode').should('eq', 302);
+  cy.wait('@uploadRedirect').its('response.statusCode').should('eq', 200);
+  
   cy.get('#info_box')
     .should(
       'have.text',
@@ -25,6 +40,12 @@ function testWorkbookUpload(interceptUrl, uploadSelector, filename, will_interce
   cy.url().should('match', /\/audit\/submission-progress\/[0-9]{4}-[0-9]{2}-GSAFAC-[0-9]{10}/);
 }
 
+/**
+ * Calls testWorkbookUpload with the appropriate static names - upload URL, file input element name, and sample workbook. 
+ * 
+ * @param {boolean} will_intercept Whether or not testWorkbookUpload function will mock the upload. Defaults to true.
+ * @return {null} No return value.
+ */
 export function testWorkbookFederalAwards(will_intercept = true) {
   testWorkbookUpload(
     '/audit/excel/federal-awards-expended/*',


### PR DESCRIPTION
# Cypress - Wait on both Requests

## The problem:
Cypress tests are failing when run through GHA, but not locally.

Here's what should happen:
1. Cypress uploads a file and awaits the response before continuing.
2. After the response, the frontend updates an info box to inform the user that their upload went through correctly. 
3. Cypress checks the box to see that it updated. 

The problem is in step two. After the upload response, Cypress moves on to check the info box immediately. But, since it's a 302 response, the frontend doesn't update the box until it sees the 200 response from the homepage redirect. There's a small gap of time where Cypress and the frontend are moving at the same time. If Cypress wins the race, it throws an error because the info box wasn't updated in accordance with our expectations. 

![image](https://github.com/GSA-TTS/FAC/assets/91098850/f2bdb3aa-3e5e-45a2-893a-2d5e8c7e0605)

Locally, response times are fast enough to not see this problem. In GHA, with slower response times and a headless (faster) Cypress, we see the problem frequently. 

## Change:
We need Cypress to wait for the frontend to be done changing things before it checks the info box. We can't naturally follow the 302 response through to its conclusion. So, this PR has it wait for **both** the 302 from the upload and the subsequent 200 from the homepage. 

![image](https://github.com/GSA-TTS/FAC/assets/91098850/9835243d-10a7-4b86-a216-26a5a0c78391)

## PR checklist: submitters

- [ ]   Link to an issue if possible. If there’s no issue, describe what your branch does. Even if there is an issue, a brief description in the PR is still useful.
- [ ]   List any special steps reviewers have to follow to test the PR. For example, adding a local environment variable, creating a local test file, etc.
- [ ]   For extra credit, submit a screen recording like [this one](https://github.com/GSA-TTS/FAC/pull/1821).
- [ ]   Make sure you’ve merged `main` into your branch shortly before creating the PR. (You should also be merging `main` into your branch regularly during development.)
- [ ]   Make sure you’ve accounted for any migrations. When you’re about to create the PR, bring up the application locally and then run `git status | grep migrations`. If there are any results, you probably need to add them to the branch for the PR. Your PR should have only **one** new migration file for each of the component apps, except in rare circumstances; you may need to delete some and re-run `python manage.py makemigrations` to reduce the number to one. (Also, unless in exceptional circumstances, your PR should not delete any migration files.)
- [ ]   Make sure that whatever feature you’re adding has tests that cover the feature. This includes test coverage to make sure that the previous workflow still works, if applicable.
- [ ]   Make sure the full-submission.cy.js [Cypress test](https://github.com/GSA-TTS/FAC/blob/main/docs/testing.md#end-to-end-testing) passes, if applicable.
- [ ]   Do manual testing locally. Our tests are not good enough yet to allow us to skip this step. If that’s not applicable for some reason, check this box.
- [ ]   Verify that no Git surgery was necessary, or, if it was necessary at any point, repeat the testing after it’s finished.
- [ ]   Once a PR is merged, keep an eye on it until it’s deployed to dev, and do enough testing on dev to verify that it deployed successfully, the feature works as expected, and the happy path for the broad feature area (such as submission) still works.

## PR checklist: reviewers

- [ ]   Pull the branch to your local environment and run `make docker-clean; make docker-first-run && docker compose up`; then run `docker compose exec web /bin/bash -c "python manage.py test"`
- [ ]   Manually test out the changes locally, or check this box to verify that it wasn’t applicable in this case.
- [ ]   Check that the PR has appropriate tests. Look out for changes in HTML/JS/JSON Schema logic that may need to be captured in Python tests even though the logic isn’t in Python.
- [ ]   Verify that no Git surgery is necessary at any point (such as during a merge party), or, if it was, repeat the testing after it’s finished.

The larger the PR, the stricter we should be about these points.
