### PR TITLE
Resolve new User Accesses immediately, if possible

### DIFF
--- a/backend/audit/models/access.py
+++ b/backend/audit/models/access.py
@@ -30,7 +30,6 @@ class AccessManager(models.Manager):
         event_type = obj_data.pop("event_type", None)
 
         # try to pair this Access with an actual User object if we have one for this email address
-        print(obj_data)
         if obj_data["email"]:
             try:
                 acc_user = User.objects.get(email__iexact=obj_data["email"])

--- a/backend/audit/models/access.py
+++ b/backend/audit/models/access.py
@@ -30,9 +30,10 @@ class AccessManager(models.Manager):
         event_type = obj_data.pop("event_type", None)
 
         # try to pair this Access with an actual User object if we have one for this email address
+        print(obj_data)
         if obj_data["email"]:
             try:
-                acc_user = User.objects.get(email=obj_data["email"])
+                acc_user = User.objects.get(email__iexact=obj_data["email"])
             # if we don't have a User for this email, leave it as None (unclaimed Access)
             except User.DoesNotExist:
                 acc_user = None

--- a/backend/audit/views/manage_submission_access.py
+++ b/backend/audit/views/manage_submission_access.py
@@ -19,7 +19,7 @@ def _get_friendly_role(role):
 
 
 def _create_and_save_access(sac, role, fullname, email):
-    Access(sac=sac, role=role, fullname=fullname, email=email).save()
+    Access.objects.create(sac=sac, role=role, fullname=fullname, email=email)
 
 
 class ChangeAccessForm(forms.Form):


### PR DESCRIPTION
Resolves #3142 

Small update to user the `create` method rather than `save` when creating `Access` objects via the manage submission access page. Using `save` meant that we were not utilizing our overridden `create` method that attempts to immediately map the `Access` object to a `User` object, if one exists with a matching email address.

To test locally:
1. Create a new submission
2. Login to the FAC with a different email address in a private browser window
3. In the original window, go to Manage access, add the alternate email address as an editor
4. In the private window, refresh the My submissions page --> should see the new submission listed without having to logout/login

## PR checklist: submitters

- [x]   Link to an issue if possible. If there’s no issue, describe what your branch does. Even if there is an issue, a brief description in the PR is still useful.
- [x]   List any special steps reviewers have to follow to test the PR. For example, adding a local environment variable, creating a local test file, etc.
- [ ]   For extra credit, submit a screen recording like [this one](https://github.com/GSA-TTS/FAC/pull/1821).
- [x]   Make sure you’ve merged `main` into your branch shortly before creating the PR. (You should also be merging `main` into your branch regularly during development.)
- [x]   Make sure you’ve accounted for any migrations. When you’re about to create the PR, bring up the application locally and then run `git status | grep migrations`. If there are any results, you probably need to add them to the branch for the PR. Your PR should have only **one** new migration file for each of the component apps, except in rare circumstances; you may need to delete some and re-run `python manage.py makemigrations` to reduce the number to one. (Also, unless in exceptional circumstances, your PR should not delete any migration files.)
- [x]   Make sure that whatever feature you’re adding has tests that cover the feature. This includes test coverage to make sure that the previous workflow still works, if applicable.
- [ ]   Make sure the full-submission.cy.js [Cypress test](https://github.com/GSA-TTS/FAC/blob/main/docs/testing.md#end-to-end-testing) passes, if applicable.
- [x]   Do manual testing locally. Our tests are not good enough yet to allow us to skip this step. If that’s not applicable for some reason, check this box.
- [x]   Verify that no Git surgery was necessary, or, if it was necessary at any point, repeat the testing after it’s finished.
- [ ]   Once a PR is merged, keep an eye on it until it’s deployed to dev, and do enough testing on dev to verify that it deployed successfully, the feature works as expected, and the happy path for the broad feature area (such as submission) still works.

## PR checklist: reviewers

- [ ]   Pull the branch to your local environment and run `make docker-clean; make docker-first-run && docker compose up`; then run `docker compose exec web /bin/bash -c "python manage.py test"`
- [ ]   Manually test out the changes locally, or check this box to verify that it wasn’t applicable in this case.
- [ ]   Check that the PR has appropriate tests. Look out for changes in HTML/JS/JSON Schema logic that may need to be captured in Python tests even though the logic isn’t in Python.
- [ ]   Verify that no Git surgery is necessary at any point (such as during a merge party), or, if it was, repeat the testing after it’s finished.

The larger the PR, the stricter we should be about these points.
