### PR TITLE
Erroring on "GSA_MIGRATION" in emails when not migrating

### DIFF
--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -50,7 +50,7 @@ class EligibilitySerializer(serializers.Serializer):
 
     def validate(self, data):
         try:
-            validate_general_information_json(data)
+            validate_general_information_json(data, False)
             return data
         except ValidationError as err:
             raise serializers.ValidationError(_(err.message)) from err
@@ -172,7 +172,7 @@ class AuditeeInfoSerializer(serializers.Serializer):
 
     def validate(self, data):
         try:
-            validate_general_information_json(data)
+            validate_general_information_json(data, False)
             return data
         except ValidationError as err:
             raise serializers.ValidationError(_(err.message)) from err

--- a/backend/audit/test_validators.py
+++ b/backend/audit/test_validators.py
@@ -939,7 +939,7 @@ class TribalAccessTests(SimpleTestCase):
                 validate_tribal_data_consent_json(case_copy)
 
 
-class GeneralInformationTests(SimpleTestCase):
+class GeneralInformationCompleteTests(SimpleTestCase):
     def test_no_error_standard_case(self):
         """No error should be raised when is_gsa_migration is not supplied and no emails contain GSA_MIGRATION"""
         gen_info = json.loads(SIMPLE_CASES_TEST_FILE.read_text(encoding="utf-8"))[

--- a/backend/audit/test_validators.py
+++ b/backend/audit/test_validators.py
@@ -9,7 +9,6 @@ from django.core.files.uploadedfile import TemporaryUploadedFile
 from random import choice, randrange
 from openpyxl import Workbook
 from tempfile import NamedTemporaryFile
-from django.conf import settings
 
 import copy
 import requests

--- a/backend/audit/test_validators.py
+++ b/backend/audit/test_validators.py
@@ -958,7 +958,7 @@ class GeneralInformationCompleteTests(SimpleTestCase):
         with self.assertRaises(ValidationError):
             validate_general_information_complete_json(gen_info)
 
-    def test_no_error_is_gsa_migration(self):
+    def test_no_error_is_gsa_migration_auditee_email(self):
         """No error should be raised when is_gsa_migration is True and auditee_email contains GSA_MIGRATION"""
         gen_info = json.loads(SIMPLE_CASES_TEST_FILE.read_text(encoding="utf-8"))[
             "GeneralInformationCase"
@@ -967,7 +967,7 @@ class GeneralInformationCompleteTests(SimpleTestCase):
 
         validate_general_information_complete_json(gen_info, True)
 
-    def test_no_error_is_gsa_migration(self):
+    def test_no_error_is_gsa_migration_auditor_email(self):
         """No error should be raised when is_gsa_migration is True and auditor_email contains GSA_MIGRATION"""
         gen_info = json.loads(SIMPLE_CASES_TEST_FILE.read_text(encoding="utf-8"))[
             "GeneralInformationCase"
@@ -976,7 +976,7 @@ class GeneralInformationCompleteTests(SimpleTestCase):
 
         validate_general_information_complete_json(gen_info, True)
 
-    def test_error_is_not_gsa_migration(self):
+    def test_error_is_not_gsa_migration_auditee_email(self):
         """An error should be raised when is_gsa_migration is False and auditee_email contains GSA_MIGRATION"""
         gen_info = json.loads(SIMPLE_CASES_TEST_FILE.read_text(encoding="utf-8"))[
             "GeneralInformationCase"
@@ -986,7 +986,7 @@ class GeneralInformationCompleteTests(SimpleTestCase):
         with self.assertRaises(ValidationError):
             validate_general_information_complete_json(gen_info, False)
 
-    def test_error_is_not_gsa_migration(self):
+    def test_error_is_not_gsa_migration_auditor_email(self):
         """An error should be raised when is_gsa_migration is False and auditor_email contains GSA_MIGRATION"""
         gen_info = json.loads(SIMPLE_CASES_TEST_FILE.read_text(encoding="utf-8"))[
             "GeneralInformationCase"

--- a/backend/audit/test_validators.py
+++ b/backend/audit/test_validators.py
@@ -50,7 +50,7 @@ from .validators import (
     validate_component_page_numbers,
     validate_audit_information_json,
     validate_tribal_data_consent_json,
-    validate_general_information_complete_json,
+    validate_general_information_json,
 )
 
 # Simplest way to create a new copy of simple case rather than getting
@@ -939,24 +939,24 @@ class TribalAccessTests(SimpleTestCase):
                 validate_tribal_data_consent_json(case_copy)
 
 
-class GeneralInformationCompleteTests(SimpleTestCase):
+class GeneralInformationTests(SimpleTestCase):
     def test_no_error_standard_case(self):
         """No error should be raised when is_gsa_migration is not supplied and no emails contain GSA_MIGRATION"""
         gen_info = json.loads(SIMPLE_CASES_TEST_FILE.read_text(encoding="utf-8"))[
             "GeneralInformationCase"
         ]
 
-        validate_general_information_complete_json(gen_info)
+        validate_general_information_json(gen_info)
 
     def test_error_default_is_gsa_migration(self):
-        """An error should be raised when is_gsa_migration is not supplied and an email contains GSA_MIGRATION"""
+        """An error should be raised when is_gsa_migration is False and an email contains GSA_MIGRATION"""
         gen_info = json.loads(SIMPLE_CASES_TEST_FILE.read_text(encoding="utf-8"))[
             "GeneralInformationCase"
         ]
         gen_info["auditee_email"] = settings.GSA_MIGRATION
 
         with self.assertRaises(ValidationError):
-            validate_general_information_complete_json(gen_info)
+            validate_general_information_json(gen_info, False)
 
     def test_no_error_is_gsa_migration_auditee_email(self):
         """No error should be raised when is_gsa_migration is True and auditee_email contains GSA_MIGRATION"""
@@ -965,7 +965,7 @@ class GeneralInformationCompleteTests(SimpleTestCase):
         ]
         gen_info["auditee_email"] = settings.GSA_MIGRATION
 
-        validate_general_information_complete_json(gen_info, True)
+        validate_general_information_json(gen_info, True)
 
     def test_no_error_is_gsa_migration_auditor_email(self):
         """No error should be raised when is_gsa_migration is True and auditor_email contains GSA_MIGRATION"""
@@ -974,7 +974,7 @@ class GeneralInformationCompleteTests(SimpleTestCase):
         ]
         gen_info["auditor_email"] = settings.GSA_MIGRATION
 
-        validate_general_information_complete_json(gen_info, True)
+        validate_general_information_json(gen_info, True)
 
     def test_error_is_not_gsa_migration_auditee_email(self):
         """An error should be raised when is_gsa_migration is False and auditee_email contains GSA_MIGRATION"""
@@ -984,7 +984,7 @@ class GeneralInformationCompleteTests(SimpleTestCase):
         gen_info["auditee_email"] = settings.GSA_MIGRATION
 
         with self.assertRaises(ValidationError):
-            validate_general_information_complete_json(gen_info, False)
+            validate_general_information_json(gen_info, False)
 
     def test_error_is_not_gsa_migration_auditor_email(self):
         """An error should be raised when is_gsa_migration is False and auditor_email contains GSA_MIGRATION"""
@@ -994,4 +994,4 @@ class GeneralInformationCompleteTests(SimpleTestCase):
         gen_info["auditor_email"] = settings.GSA_MIGRATION
 
         with self.assertRaises(ValidationError):
-            validate_general_information_complete_json(gen_info, False)
+            validate_general_information_json(gen_info, False)

--- a/backend/audit/validators.py
+++ b/backend/audit/validators.py
@@ -219,7 +219,6 @@ def validate_general_information_json(value, is_data_migration=True):
     """
     Apply JSON Schema for general information and report errors.
     """
-    print("validate_general_information_json")
     schema_path = settings.SECTION_SCHEMA_DIR / "GeneralInformation.schema.json"
     schema = json.loads(schema_path.read_text(encoding="utf-8"))
 

--- a/backend/audit/validators.py
+++ b/backend/audit/validators.py
@@ -215,27 +215,12 @@ def validate_federal_award_json(value):
         raise ValidationError(message=_federal_awards_json_error(errors))
 
 
-def validate_general_information_json(value):
+def validate_general_information_json(value, is_data_migration=True):
     """
     Apply JSON Schema for general information and report errors.
     """
+    print("validate_general_information_json")
     schema_path = settings.SECTION_SCHEMA_DIR / "GeneralInformation.schema.json"
-    schema = json.loads(schema_path.read_text(encoding="utf-8"))
-
-    try:
-        validate(value, schema, format_checker=FormatChecker())
-    except JSONSchemaValidationError as err:
-        raise ValidationError(
-            _(err.message),
-        ) from err
-    return value
-
-
-def validate_general_information_complete_json(value, is_data_migration=False):
-    """
-    Apply JSON Schema for general information completeness and report errors.
-    """
-    schema_path = settings.SECTION_SCHEMA_DIR / "GeneralInformationComplete.schema.json"
     schema = json.loads(schema_path.read_text(encoding="utf-8"))
 
     try:
@@ -246,6 +231,22 @@ def validate_general_information_complete_json(value, is_data_migration=False):
             raise JSONSchemaValidationError(
                 f"{settings.GSA_MIGRATION} not permitted outside of migrations"
             )
+        validate(value, schema, format_checker=FormatChecker())
+    except JSONSchemaValidationError as err:
+        raise ValidationError(
+            _(err.message),
+        ) from err
+    return value
+
+
+def validate_general_information_complete_json(value):
+    """
+    Apply JSON Schema for general information completeness and report errors.
+    """
+    schema_path = settings.SECTION_SCHEMA_DIR / "GeneralInformationComplete.schema.json"
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+
+    try:
         validate(value, schema, format_checker=FormatChecker())
     except JSONSchemaValidationError as err:
         raise ValidationError(

--- a/backend/audit/validators.py
+++ b/backend/audit/validators.py
@@ -224,8 +224,8 @@ def validate_general_information_json(value, is_data_migration=True):
 
     try:
         if not is_data_migration and settings.GSA_MIGRATION in [
-            value["auditee_email"],
-            value["auditor_email"],
+            getattr(value, "auditee_email", ""),
+            getattr(value, "auditor_email", ""),
         ]:
             raise JSONSchemaValidationError(
                 f"{settings.GSA_MIGRATION} not permitted outside of migrations"

--- a/backend/audit/validators.py
+++ b/backend/audit/validators.py
@@ -224,8 +224,8 @@ def validate_general_information_json(value, is_data_migration=True):
 
     try:
         if not is_data_migration and settings.GSA_MIGRATION in [
-            getattr(value, "auditee_email", ""),
-            getattr(value, "auditor_email", ""),
+            value.get("auditee_email", ""),
+            value.get("auditor_email", ""),
         ]:
             raise JSONSchemaValidationError(
                 f"{settings.GSA_MIGRATION} not permitted outside of migrations"

--- a/backend/audit/validators.py
+++ b/backend/audit/validators.py
@@ -231,7 +231,7 @@ def validate_general_information_json(value):
     return value
 
 
-def validate_general_information_complete_json(value):
+def validate_general_information_complete_json(value, is_data_migration=False):
     """
     Apply JSON Schema for general information completeness and report errors.
     """
@@ -239,6 +239,13 @@ def validate_general_information_complete_json(value):
     schema = json.loads(schema_path.read_text(encoding="utf-8"))
 
     try:
+        if not is_data_migration and settings.GSA_MIGRATION in [
+            value["auditee_email"],
+            value["auditor_email"],
+        ]:
+            raise JSONSchemaValidationError(
+                f"{settings.GSA_MIGRATION} not permitted outside of migrations"
+            )
         validate(value, schema, format_checker=FormatChecker())
     except JSONSchemaValidationError as err:
         raise ValidationError(

--- a/backend/census_historical_migration/sac_general_lib/general_information.py
+++ b/backend/census_historical_migration/sac_general_lib/general_information.py
@@ -360,7 +360,7 @@ def general_information(audit_header):
             general_information = transform(general_information)
 
     audit.validators.validate_general_information_complete_json(
-        general_information, True
+        general_information, True,
     )
 
     return general_information

--- a/backend/census_historical_migration/sac_general_lib/general_information.py
+++ b/backend/census_historical_migration/sac_general_lib/general_information.py
@@ -359,8 +359,6 @@ def general_information(audit_header):
         else:
             general_information = transform(general_information)
 
-    audit.validators.validate_general_information_complete_json(
-        general_information, True,
-    )
+    audit.validators.validate_general_information_complete_json(general_information)
 
     return general_information

--- a/backend/census_historical_migration/sac_general_lib/general_information.py
+++ b/backend/census_historical_migration/sac_general_lib/general_information.py
@@ -359,6 +359,8 @@ def general_information(audit_header):
         else:
             general_information = transform(general_information)
 
-    audit.validators.validate_general_information_complete_json(general_information)
+    audit.validators.validate_general_information_complete_json(
+        general_information, True
+    )
 
     return general_information

--- a/backend/report_submission/test_views.py
+++ b/backend/report_submission/test_views.py
@@ -682,14 +682,14 @@ class GeneralInformationFormViewTests(TestCase):
             "auditee_contact_name": "Updated Designated Representative",
             "auditee_contact_title": "Lord of Windows",
             "auditee_phone": "5558675310",
-            "auditee_email": settings.GSA_MIGRATION, # Not allowed
+            "auditee_email": settings.GSA_MIGRATION,  # Not allowed
             "auditor_firm_name": "Penny Audit Store",
             "auditor_ein": "123456780",
             "auditor_ein_not_an_ssn_attestation": True,
             "auditor_contact_name": "Qualified Robot Accountant",
             "auditor_contact_title": "Just an extraordinary person",
             "auditor_phone": "9876543210",
-            "auditor_email": settings.GSA_MIGRATION, # Not allowed
+            "auditor_email": settings.GSA_MIGRATION,  # Not allowed
         }
 
         response = self.client.post(url, data=data)

--- a/backend/report_submission/views.py
+++ b/backend/report_submission/views.py
@@ -201,7 +201,7 @@ class GeneralInformationFormView(LoginRequiredMixin, View):
             form.cleaned_data = self._dates_to_hyphens(form.cleaned_data)
             general_information = sac.general_information
             general_information.update(form.cleaned_data)
-            validated = validate_general_information_json(general_information)
+            validated = validate_general_information_json(general_information, False)
             sac.general_information = validated
             if general_information.get("audit_type"):
                 sac.audit_type = general_information["audit_type"]

--- a/backend/report_submission/views.py
+++ b/backend/report_submission/views.py
@@ -201,7 +201,7 @@ class GeneralInformationFormView(LoginRequiredMixin, View):
             form.cleaned_data = self._dates_to_hyphens(form.cleaned_data)
             general_information = sac.general_information
             general_information.update(form.cleaned_data)
-            validated = validate_general_information_json(general_information, False)
+            validated = validate_general_information_json(general_information)
             sac.general_information = validated
             if general_information.get("audit_type"):
                 sac.audit_type = general_information["audit_type"]


### PR DESCRIPTION
In this PR:
- Currently the General Info Complete schema validation always allows for the "GSA_MIGRATION" string for emails. Instead, we don't want to permit these unless it's via migration. This change will raise an exception if the string is used and a new `is_gsa_migration` param is False.
- Unit tests

Testing
- A standard audit should still migrate as normal
- Modify `AUDITEEEMAIL` and/or `CPAEMAIL` to be invalid (empty string) and the migration should still pass
- Unit tests pass

## PR checklist: submitters

- [ ]   Link to an issue if possible. If there’s no issue, describe what your branch does. Even if there is an issue, a brief description in the PR is still useful.
- [ ]   List any special steps reviewers have to follow to test the PR. For example, adding a local environment variable, creating a local test file, etc.
- [ ]   For extra credit, submit a screen recording like [this one](https://github.com/GSA-TTS/FAC/pull/1821).
- [ ]   Make sure you’ve merged `main` into your branch shortly before creating the PR. (You should also be merging `main` into your branch regularly during development.)
- [ ]   Make sure you’ve accounted for any migrations. When you’re about to create the PR, bring up the application locally and then run `git status | grep migrations`. If there are any results, you probably need to add them to the branch for the PR. Your PR should have only **one** new migration file for each of the component apps, except in rare circumstances; you may need to delete some and re-run `python manage.py makemigrations` to reduce the number to one. (Also, unless in exceptional circumstances, your PR should not delete any migration files.)
- [ ]   Make sure that whatever feature you’re adding has tests that cover the feature. This includes test coverage to make sure that the previous workflow still works, if applicable.
- [ ]   Make sure the full-submission.cy.js [Cypress test](https://github.com/GSA-TTS/FAC/blob/main/docs/testing.md#end-to-end-testing) passes, if applicable.
- [ ]   Do manual testing locally. Our tests are not good enough yet to allow us to skip this step. If that’s not applicable for some reason, check this box.
- [ ]   Verify that no Git surgery was necessary, or, if it was necessary at any point, repeat the testing after it’s finished.
- [ ]   Once a PR is merged, keep an eye on it until it’s deployed to dev, and do enough testing on dev to verify that it deployed successfully, the feature works as expected, and the happy path for the broad feature area (such as submission) still works.

## PR checklist: reviewers

- [ ]   Pull the branch to your local environment and run `make docker-clean; make docker-first-run && docker compose up`; then run `docker compose exec web /bin/bash -c "python manage.py test"`
- [ ]   Manually test out the changes locally, or check this box to verify that it wasn’t applicable in this case.
- [ ]   Check that the PR has appropriate tests. Look out for changes in HTML/JS/JSON Schema logic that may need to be captured in Python tests even though the logic isn’t in Python.
- [ ]   Verify that no Git surgery is necessary at any point (such as during a merge party), or, if it was, repeat the testing after it’s finished.

The larger the PR, the stricter we should be about these points.
