### PR TITLE
Adds columns to FederalAwards, Findings in summary sheets

### DIFF
--- a/backend/dissemination/summary_reports.py
+++ b/backend/dissemination/summary_reports.py
@@ -296,31 +296,37 @@ def insert_dissem_coversheet(workbook):
     # sheet.cell(row=3, column=2).hyperlink = f"{settings.STATIC_SITE_URL}/developers/"
     set_column_widths(sheet)
 
+
 def _get_attribute_or_data(obj, field_name):
     if field_name.startswith("_"):
         if field_name == "_aln":
             if isinstance(obj, FederalAward):
-                return (getattr(obj, "federal_agency_prefix") 
-                        + "." 
-                        + getattr(obj, "federal_award_extension"))
+                return (
+                    getattr(obj, "federal_agency_prefix")
+                    + "."
+                    + getattr(obj, "federal_award_extension")
+                )
             elif isinstance(obj, Finding):
                 fa = FederalAward.objects.get(
-                        report_id=getattr(obj, "report_id"),
-                        award_reference=getattr(obj, "award_reference")
-                    )
-                return (getattr(fa, "federal_agency_prefix") 
-                        + "." 
-                        + getattr(fa, "federal_award_extension"))
+                    report_id=getattr(obj, "report_id"),
+                    award_reference=getattr(obj, "award_reference"),
+                )
+                return (
+                    getattr(fa, "federal_agency_prefix")
+                    + "."
+                    + getattr(fa, "federal_award_extension")
+                )
         else:
             field_name = field_name[1:]
             if isinstance(obj, Finding):
                 fa = FederalAward.objects.get(
-                        report_id=getattr(obj, "report_id"),
-                        award_reference=getattr(obj, "award_reference")
-                    )
+                    report_id=getattr(obj, "report_id"),
+                    award_reference=getattr(obj, "award_reference"),
+                )
                 return getattr(fa, field_name)
     else:
         return getattr(obj, field_name)
+
 
 def gather_report_data_dissemination(report_ids):
     """

--- a/backend/dissemination/summary_reports.py
+++ b/backend/dissemination/summary_reports.py
@@ -173,6 +173,7 @@ field_name_ordered = {
         "award_reference",
         "federal_agency_prefix",
         "federal_award_extension",
+        "_aln",
         "findings_count",
         "additional_award_identification",
         "federal_program_name",
@@ -192,6 +193,9 @@ field_name_ordered = {
     ],
     "finding": [
         "report_id",
+        "_federal_agency_prefix",
+        "_federal_award_extension",
+        "_aln",
         "award_reference",
         "reference_number",
         "type_requirement",
@@ -292,6 +296,31 @@ def insert_dissem_coversheet(workbook):
     # sheet.cell(row=3, column=2).hyperlink = f"{settings.STATIC_SITE_URL}/developers/"
     set_column_widths(sheet)
 
+def _get_attribute_or_data(obj, field_name):
+    if field_name.startswith("_"):
+        if field_name == "_aln":
+            if isinstance(obj, FederalAward):
+                return (getattr(obj, "federal_agency_prefix") 
+                        + "." 
+                        + getattr(obj, "federal_award_extension"))
+            elif isinstance(obj, Finding):
+                fa = FederalAward.objects.get(
+                        report_id=getattr(obj, "report_id"),
+                        award_reference=getattr(obj, "award_reference")
+                    )
+                return (getattr(fa, "federal_agency_prefix") 
+                        + "." 
+                        + getattr(fa, "federal_award_extension"))
+        else:
+            field_name = field_name[1:]
+            if isinstance(obj, Finding):
+                fa = FederalAward.objects.get(
+                        report_id=getattr(obj, "report_id"),
+                        award_reference=getattr(obj, "award_reference")
+                    )
+                return getattr(fa, field_name)
+    else:
+        return getattr(obj, field_name)
 
 def gather_report_data_dissemination(report_ids):
     """
@@ -329,7 +358,7 @@ def gather_report_data_dissemination(report_ids):
         objects = model.objects.all().filter(report_id__in=report_ids)
         for obj in objects:
             data[model_name]["entries"].append(
-                [getattr(obj, field_name) for field_name in field_names]
+                [_get_attribute_or_data(obj, field_name) for field_name in field_names]
             )
     return data
 


### PR DESCRIPTION
Resolves https://github.com/GSA-TTS/FAC/issues/3295

In conversation with NSF, it became clear that finding audits that need to be resolved involves 

1. Pulling the summary sheet
2. Finding awards relevant to the agency
3. Seeing if there are findings
4. Flipping between `federalaward` and `findings` tabs, because you need `award_reference` from `federalaward` to look up `reference_number` on `findings`

By adding the agency number, program number, and ALNs to the `findings` tab, the resolution official can "just" work from one tab if desired.

This replaces a direct call to `getattr` with a function that does some conditional work to make this possible. It might not scale to many columns, but it might not have to. For now, this seemed like a direct way to do it. Improvement suggestions welcome.

## To test

In an environment with some data, find some audits, and generate some workbooks. Confirm that the values in the ALN column are the same as the agency number/program number concat'd, and that the appropriate columns are now on the appropriate sheets.

## Summary

* Adds "_aln" to FederalAward
* Adds "_federal_agency_prefix", "_federal_award_extension" and "_aln" to Finding.


## PR checklist: submitters

- [x]   Link to an issue if possible. If there’s no issue, describe what your branch does. Even if there is an issue, a brief description in the PR is still useful.
- [x]   List any special steps reviewers have to follow to test the PR. For example, adding a local environment variable, creating a local test file, etc.
- [ ]   For extra credit, submit a screen recording like [this one](https://github.com/GSA-TTS/FAC/pull/1821).
- [x]   Make sure you’ve merged `main` into your branch shortly before creating the PR. (You should also be merging `main` into your branch regularly during development.)
- [ ]   Make sure you’ve accounted for any migrations. When you’re about to create the PR, bring up the application locally and then run `git status | grep migrations`. If there are any results, you probably need to add them to the branch for the PR. Your PR should have only **one** new migration file for each of the component apps, except in rare circumstances; you may need to delete some and re-run `python manage.py makemigrations` to reduce the number to one. (Also, unless in exceptional circumstances, your PR should not delete any migration files.)
- [ ]   Make sure that whatever feature you’re adding has tests that cover the feature. This includes test coverage to make sure that the previous workflow still works, if applicable.
- [ ]   Make sure the full-submission.cy.js [Cypress test](https://github.com/GSA-TTS/FAC/blob/main/docs/testing.md#end-to-end-testing) passes, if applicable.
- [x]   Do manual testing locally. Our tests are not good enough yet to allow us to skip this step. If that’s not applicable for some reason, check this box.
- [x]   Verify that no Git surgery was necessary, or, if it was necessary at any point, repeat the testing after it’s finished.
- [ ]   Once a PR is merged, keep an eye on it until it’s deployed to dev, and do enough testing on dev to verify that it deployed successfully, the feature works as expected, and the happy path for the broad feature area (such as submission) still works.

## PR checklist: reviewers

- [ ]   Pull the branch to your local environment and run `make docker-clean; make docker-first-run && docker compose up`; then run `docker compose exec web /bin/bash -c "python manage.py test"`
- [ ]   Manually test out the changes locally, or check this box to verify that it wasn’t applicable in this case.
- [ ]   Check that the PR has appropriate tests. Look out for changes in HTML/JS/JSON Schema logic that may need to be captured in Python tests even though the logic isn’t in Python.
- [ ]   Verify that no Git surgery is necessary at any point (such as during a merge party), or, if it was, repeat the testing after it’s finished.

The larger the PR, the stricter we should be about these points.
