### PR TITLE
Context for 500s, Resolve Pre-cert Report 500s

### DIFF
--- a/backend/config/error_handlers.py
+++ b/backend/config/error_handlers.py
@@ -1,0 +1,8 @@
+from django.shortcuts import render
+
+
+def handler500(request, template_name="500.html"):
+    """
+    Custom handler for 500s. Ensures the 500 template loads with proper context (environment, login info, OMB values).
+    """
+    return render(request, template_name, {})

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -18,6 +18,8 @@ schema_view = get_schema_view(
     renderer_classes=[JSONOpenAPIRenderer],
 )
 
+handler500 = "config.error_handlers.handler500"
+
 urlpatterns = [
     path("api/schema.json", schema_view),
     path(

--- a/backend/dissemination/summary_reports.py
+++ b/backend/dissemination/summary_reports.py
@@ -424,11 +424,12 @@ def gather_report_data_pre_certification(i2d_data):
         for obj in dissemination_data[model_name]:
             row = []
             for field_name in field_names:
-                value = getattr(obj, field_name)
-                # Wipe tzinfo
-                if isinstance(value, datetime):
-                    value = value.replace(tzinfo=None)
-                row.append(value)
+                if not field_name.startswith("_"):
+                    value = getattr(obj, field_name)
+                    # Wipe tzinfo
+                    if isinstance(value, datetime):
+                        value = value.replace(tzinfo=None)
+                    row.append(value)
             data[model_name]["entries"].append(row)
 
     return data


### PR DESCRIPTION
# Context for 500s, Resolve Pre-cert Report 500s

## Background:
Users have indicated via the help desk that pre certification SF-SAC downloads send them to a 500 error page. The page in question also displays the test site banner, despite the interaction occurring in production. 

Issues:
1. The test site banner appears on all 500 error pages. There are other things wrong too, because Django 500s default to containing no context at all. See [here](https://docs.djangoproject.com/en/5.0/ref/views/#the-500-server-error-view). 
2. The SF-SAC downloads are failing. Upon generation, it attempts to add data to a row from all columns in a given list. Some of these columns don't exist pre-certification, and are generated from disseminated data. So, the SF-SAC generator tries to fill in data that doesn't exist and breaks. 

## Changes:
1. Include a custom error handler for 500s that does very little. It exists to ensure that certain context processors run. This will mean that 500 errors pages properly include login info, the OMB values, and the test site banner. 
3. Update `gather_report_data_pre_certification()` to ensure it does not try to access/generate underscored fields. Underscored fields exist to add additional columns to workbooks for the benefit of certain users post-submission. Therefore, they're not necessary here.

## How to test:
First, verify that the issues are present in the first place.
1. Make sure the Django `settings.py` DEBUG variable is set to False. We want to see the error page. 
2. Run on main normally, and navigate to a pre-certification SF-SAC download. Try to download it. 
4. Verify that download fails and sends you to the 500 page.
5. Verify that the 500 page has the test banner, has no OMB values, and displays as though you are not signed in.

Second, switch to this branch and run normally.
1. Make sure the Django `settings.py` DEBUG variable is still set to False. We want to see any error pages. 
2. Run on this branch normally, try the download again. Verify that it works. 
3. To verify that the 500 page changes are working, we want to force a 500 to happen locally. You can do this by:
    a. Undoing the last commit to `dissemination/summary_reports.py`, essentially undoing the fix in this branch.
    b. Quickly implementing a test view that raises a 500. See [here](https://stackoverflow.com/a/24660486). 
    c. Modifying an existing view to raise a 500. 

## Screenshot:
500 error page, now:
![image](https://github.com/GSA-TTS/FAC/assets/91098850/e7a7737e-f86a-42d9-a6bc-2ec2be905058)

## PR checklist: submitters

- [ ]   Link to an issue if possible. If there’s no issue, describe what your branch does. Even if there is an issue, a brief description in the PR is still useful.
- [ ]   List any special steps reviewers have to follow to test the PR. For example, adding a local environment variable, creating a local test file, etc.
- [ ]   For extra credit, submit a screen recording like [this one](https://github.com/GSA-TTS/FAC/pull/1821).
- [ ]   Make sure you’ve merged `main` into your branch shortly before creating the PR. (You should also be merging `main` into your branch regularly during development.)
- [ ]   Make sure you’ve accounted for any migrations. When you’re about to create the PR, bring up the application locally and then run `git status | grep migrations`. If there are any results, you probably need to add them to the branch for the PR. Your PR should have only **one** new migration file for each of the component apps, except in rare circumstances; you may need to delete some and re-run `python manage.py makemigrations` to reduce the number to one. (Also, unless in exceptional circumstances, your PR should not delete any migration files.)
- [ ]   Make sure that whatever feature you’re adding has tests that cover the feature. This includes test coverage to make sure that the previous workflow still works, if applicable.
- [ ]   Make sure the full-submission.cy.js [Cypress test](https://github.com/GSA-TTS/FAC/blob/main/docs/testing.md#end-to-end-testing) passes, if applicable.
- [ ]   Do manual testing locally. Our tests are not good enough yet to allow us to skip this step. If that’s not applicable for some reason, check this box.
- [ ]   Verify that no Git surgery was necessary, or, if it was necessary at any point, repeat the testing after it’s finished.
- [ ]   Once a PR is merged, keep an eye on it until it’s deployed to dev, and do enough testing on dev to verify that it deployed successfully, the feature works as expected, and the happy path for the broad feature area (such as submission) still works.

## PR checklist: reviewers

- [ ]   Pull the branch to your local environment and run `make docker-clean; make docker-first-run && docker compose up`; then run `docker compose exec web /bin/bash -c "python manage.py test"`
- [ ]   Manually test out the changes locally, or check this box to verify that it wasn’t applicable in this case.
- [ ]   Check that the PR has appropriate tests. Look out for changes in HTML/JS/JSON Schema logic that may need to be captured in Python tests even though the logic isn’t in Python.
- [ ]   Verify that no Git surgery is necessary at any point (such as during a merge party), or, if it was, repeat the testing after it’s finished.

The larger the PR, the stricter we should be about these points.
