### PR TITLE
Don't create ever-expanding results in create_views 

### DIFF
--- a/backend/dissemination/api/api_v1_0_3/create_views.sql
+++ b/backend/dissemination/api/api_v1_0_3/create_views.sql
@@ -16,10 +16,11 @@ create view api_v1_0_3.findings_text as
         dissemination_findingtext ft,
         dissemination_general gen
     where
-        (ft.report_id = gen.report_id
+        ft.report_id = gen.report_id
          and
-         gen.is_public = true)
-        or (gen.is_public = false and api_v1_0_3_functions.has_tribal_data_access())
+        (gen.is_public = true
+         or 
+        (gen.is_public = false and api_v1_0_3_functions.has_tribal_data_access()))
     order by ft.id
 ;
 
@@ -37,10 +38,11 @@ create view api_v1_0_3.additional_ueis as
         dissemination_general gen,
         dissemination_additionaluei uei
     where
-        (gen.report_id = uei.report_id
+        gen.report_id = uei.report_id
          and
-         gen.is_public = true)
-        or (gen.is_public = false and api_v1_0_3_functions.has_tribal_data_access())
+        (gen.is_public = true
+         or 
+        (gen.is_public = false and api_v1_0_3_functions.has_tribal_data_access()))
     order by uei.id
 ;
 
@@ -67,10 +69,11 @@ create view api_v1_0_3.findings as
         dissemination_finding finding,
         dissemination_general gen
     where
-        (finding.report_id = gen.report_id
+        finding.report_id = gen.report_id
          and
-         gen.is_public = true)
-        or (gen.is_public = false and api_v1_0_3_functions.has_tribal_data_access())
+        (gen.is_public = true
+         or 
+        (gen.is_public = false and api_v1_0_3_functions.has_tribal_data_access()))
     order by finding.id
 ;
 
@@ -79,9 +82,9 @@ create view api_v1_0_3.findings as
 ---------------------------------------
 create view api_v1_0_3.federal_awards as
     select
-        gen.report_id,
-        gen.auditee_uei,
-        gen.audit_year,
+        award.report_id,
+        -- gen.auditee_uei,
+        -- gen.audit_year,
         ---
         award.award_reference,
         award.federal_agency_prefix,
@@ -106,10 +109,11 @@ create view api_v1_0_3.federal_awards as
         dissemination_federalaward award,
         dissemination_general gen
     where
-        (award.report_id = gen.report_id
+        award.report_id = gen.report_id
          and
-         gen.is_public = true)
-        or (gen.is_public = false and api_v1_0_3_functions.has_tribal_data_access())
+        (gen.is_public = true
+         or 
+        (gen.is_public = false and api_v1_0_3_functions.has_tribal_data_access()))
     order by award.id
 ;
 
@@ -130,10 +134,11 @@ create view api_v1_0_3.corrective_action_plans as
         dissemination_CAPText ct,
         dissemination_General gen
     where
-        (ct.report_id = gen.report_id
+        ct.report_id = gen.report_id
          and
-         gen.is_public = true)
-        or (gen.is_public = false and api_v1_0_3_functions.has_tribal_data_access())
+        (gen.is_public = true
+         or 
+        (gen.is_public = false and api_v1_0_3_functions.has_tribal_data_access()))
     order by ct.id
 ;
 
@@ -156,10 +161,11 @@ create view api_v1_0_3.notes_to_sefa as
         dissemination_general gen,
         dissemination_note note
     where
-        (note.report_id = gen.report_id
+        note.report_id = gen.report_id
          and
-         gen.is_public = true)
-        or (gen.is_public = false and api_v1_0_3_functions.has_tribal_data_access())
+        (gen.is_public = true
+         or 
+        (gen.is_public = false and api_v1_0_3_functions.has_tribal_data_access()))
     order by note.id
 ;
 
@@ -179,10 +185,11 @@ create view api_v1_0_3.passthrough as
         dissemination_general as gen,
         dissemination_passthrough as pass
     where
-        (gen.report_id = pass.report_id
+        gen.report_id = pass.report_id
         and
-        gen.is_public = true)
-        or (gen.is_public = false and api_v1_0_3_functions.has_tribal_data_access())
+        (gen.is_public = true
+        or 
+        (gen.is_public = false and api_v1_0_3_functions.has_tribal_data_access()))
     order by pass.id
 ;
 
@@ -267,10 +274,11 @@ create view api_v1_0_3.general as
         dissemination_General gen,
         audit_singleauditchecklist aud
     where
-        (aud.report_id = gen.report_id
+        aud.report_id = gen.report_id
         and 
-        gen.is_public = true)
-        or (gen.is_public = false and api_v1_0_3_functions.has_tribal_data_access())
+        (gen.is_public = true
+         or 
+        (gen.is_public = false and api_v1_0_3_functions.has_tribal_data_access()))
     order by gen.id
 ;
 
@@ -297,10 +305,11 @@ create view api_v1_0_3.secondary_auditors as
         dissemination_General gen,
         dissemination_SecondaryAuditor sa
     where
-        (sa.report_id = gen.report_id
+        sa.report_id = gen.report_id
          and
-         gen.is_public=True)
-        or (gen.is_public=false and api_v1_0_3_functions.has_tribal_data_access())
+        (gen.is_public=True
+         or 
+        (gen.is_public=false and api_v1_0_3_functions.has_tribal_data_access()))
     order by sa.id
 ;
 
@@ -315,13 +324,13 @@ create view api_v1_0_3.additional_eins as
         dissemination_general gen,
         dissemination_additionalein ein
     where
-        (gen.report_id = ein.report_id
+        gen.report_id = ein.report_id
          and
-         gen.is_public = true)
-        or (gen.is_public = false and api_v1_0_3_functions.has_tribal_data_access())
+        (gen.is_public = true
+         or 
+        (gen.is_public = false and api_v1_0_3_functions.has_tribal_data_access()))
     order by ein.id
 ;
-
 
 commit;
 

--- a/backend/dissemination/api/api_v1_0_3/create_views.sql
+++ b/backend/dissemination/api/api_v1_0_3/create_views.sql
@@ -83,8 +83,8 @@ create view api_v1_0_3.findings as
 create view api_v1_0_3.federal_awards as
     select
         award.report_id,
-        -- gen.auditee_uei,
-        -- gen.audit_year,
+        gen.auditee_uei,
+        gen.audit_year,
         ---
         award.award_reference,
         award.federal_agency_prefix,

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -111,6 +111,8 @@ services:
       # See https://postgrest.org/en/stable/references/api/schemas.html#multiple-schemas for multiple schemas
       PGRST_DB_SCHEMAS: "api_v1_0_3, admin_api_v1_0_0"
       PGRST_JWT_SECRET: ${PGRST_JWT_SECRET:-32_chars_fallback_secret_testing} # Fallback value for testing environments
+      # Enable this to inspect the DB plans for queries via EXPLAIN
+      PGRST_DB_PLAN_ENABLED: ${PGRST_DB_PLAN_ENABLED:-false}
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
This does not have a ticket.

Users have been reporting increasingly poor performance in the API. It was unclear what or why it was behaving badly.

Recently, a query to just return one record, offset 60K records into `federal_awards`, was reported as timing out by a Federal partner. Further investigation, with a full database, revealed that we had, in every view, something that looked like this:

```
    where
        (award.report_id = gen.report_id
         and
         gen.is_public = true)
        or (gen.is_public = false and api_v1_0_3_functions.has_tribal_data_access())
```

The second half of the `OR` clause is a huge problem.

It means the `SELECT` comes back for every condition under which the `OR` is `TRUE`. As a result, we are getting records back:

1. everywhere that the `report_id` is equal in both `federal_awards` AND
2. everywhere that `is_public` is `FALSE` and we are granted tribal access.

Somehow... and, to be honest, I'm still not fully clear on the combinatorics of this query... we were getting back 40M rows on a 2.5M row table. (A full count would time out; an estimated count, from the planner, would throw up a number in the range of 40M.)

The change was to shift all conditionals on the views to this:

```
    where
        gen.report_id = ein.report_id
         and
        (gen.is_public = true
         or 
        (gen.is_public = false and api_v1_0_3_functions.has_tribal_data_access()))
```

which now says 

"I would like the report ID to match, and I want the general table to either say the data is public, or I want to have permission to view it when the data is not public."

We will revise that further with Tribal API keys, but still... this is a critical change.

**This is likely part of our live DB performance issue**... we're crushing the DB engine every time someone hits the API. This may be part of where our overall DB/app performance penalties are coming from---every hit on the DB is competing with API queries in the worst possible way.

Note that this would _not_ be a load/performance hit on PostgREST, because the API server is able to quickly turn the URL into a query, and it sits and waits for the DB to come back. The DB, however, takes a lifetime trying to build up a result against tens of millions of (virtual?) rows.

Experimentation with indexing demonstrates that we can get at least a factor of 2 speedup, and there may be more work we can do with caching function results (but we have to be careful how we do that). However, once this fix is in place (and it needs more tests---I want this to leverage work that was done by PP and TB in that regard), the performance goes from "the query takes minutes to resolve" to queries likely taking a fraction of a second to complete.


## PR checklist: submitters

- [ ]   Link to an issue if possible. If there’s no issue, describe what your branch does. Even if there is an issue, a brief description in the PR is still useful.
- [ ]   List any special steps reviewers have to follow to test the PR. For example, adding a local environment variable, creating a local test file, etc.
- [ ]   For extra credit, submit a screen recording like [this one](https://github.com/GSA-TTS/FAC/pull/1821).
- [ ]   Make sure you’ve merged `main` into your branch shortly before creating the PR. (You should also be merging `main` into your branch regularly during development.)
- [ ]   Make sure you’ve accounted for any migrations. When you’re about to create the PR, bring up the application locally and then run `git status | grep migrations`. If there are any results, you probably need to add them to the branch for the PR. Your PR should have only **one** new migration file for each of the component apps, except in rare circumstances; you may need to delete some and re-run `python manage.py makemigrations` to reduce the number to one. (Also, unless in exceptional circumstances, your PR should not delete any migration files.)
- [ ]   Make sure that whatever feature you’re adding has tests that cover the feature. This includes test coverage to make sure that the previous workflow still works, if applicable.
- [ ]   Make sure the full-submission.cy.js [Cypress test](https://github.com/GSA-TTS/FAC/blob/main/docs/testing.md#end-to-end-testing) passes, if applicable.
- [ ]   Do manual testing locally. Our tests are not good enough yet to allow us to skip this step. If that’s not applicable for some reason, check this box.
- [ ]   Verify that no Git surgery was necessary, or, if it was necessary at any point, repeat the testing after it’s finished.
- [ ]   Once a PR is merged, keep an eye on it until it’s deployed to dev, and do enough testing on dev to verify that it deployed successfully, the feature works as expected, and the happy path for the broad feature area (such as submission) still works.

## PR checklist: reviewers

- [ ]   Pull the branch to your local environment and run `make docker-clean; make docker-first-run && docker compose up`; then run `docker compose exec web /bin/bash -c "python manage.py test"`
- [ ]   Manually test out the changes locally, or check this box to verify that it wasn’t applicable in this case.
- [ ]   Check that the PR has appropriate tests. Look out for changes in HTML/JS/JSON Schema logic that may need to be captured in Python tests even though the logic isn’t in Python.
- [ ]   Verify that no Git surgery is necessary at any point (such as during a merge party), or, if it was, repeat the testing after it’s finished.

The larger the PR, the stricter we should be about these points.
