### PR TITLE
Bump Trivy to v0.17.0

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -39,14 +39,14 @@ jobs:
         run: docker build -t ${{ env.DOCKER_NAME }}:${{ steps.date.outputs.date }} .
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.13.1
+        uses: aquasecurity/trivy-action@0.17.0
         with:
           image-ref: '${{ env.DOCKER_NAME }}:${{ steps.date.outputs.date }}'
           scan-type: 'image'
           hide-progress: false
           format: 'sarif'
           output: 'trivy-results.sarif'
-          exit-code: '1'
+          exit-code: 0 # Setting the exit-code to 1 will fail the action, without publishing to Github Security Tab (> aquasecurity/trivy-action@0.13.1)
           severity: 'CRITICAL,HIGH'
           timeout: 15m0s
           ignore-unfixed: true
@@ -74,14 +74,14 @@ jobs:
         run: docker pull ${{ matrix.image.name }}
 
       - name: Run Trivy vulnerability scanner on Third Party Images
-        uses: aquasecurity/trivy-action@0.13.1
+        uses: aquasecurity/trivy-action@0.17.0
         with:
           image-ref: '${{ matrix.image.name }}'
           scan-type: 'image'
           hide-progress: false
           format: 'sarif'
           output: 'trivy-results.sarif'
-          exit-code: '1'
+          exit-code: 0 # Setting the exit-code to 1 will fail the action, without publishing to Github Security Tab (> aquasecurity/trivy-action@0.13.1)
           severity: 'CRITICAL,HIGH'
           timeout: 15m0s
           ignore-unfixed: true


### PR DESCRIPTION
Successful Run: [here](https://github.com/GSA-TTS/FAC/actions/runs/7920994387)

This brings Trivy action up to date. In v0.13.1, which we were formerly using, the `exit-code: 1` allowed the run to pass. It appears, however, that this was updated at or around v0.14.0-1. When I raised an issue on the trivy github, an option would be to use `limit-severities-for-sarif: true` with `exit-code: 1`, however, based on the [docs](https://github.com/marketplace/actions/aqua-security-trivy) `limit-severities-for-sarif` option description states, "By default SARIF format enforces output of all vulnerabilities regardless of configured severities. To override this behavior set this parameter to true". Our configuration, is all `HIGH,CRITICAL` and, this shouldn't be a problem. 

A subsequent PR may modify this further, but, for the current configuration, the successful completion of the Trivy Scan + Upload to Github Security Tab, is what we need. This was fixed by setting the `exit-code: 0`. This is the default configuration if not specified, but for clarity, I decided to leave it in place.

This is _likely_ something we need to watch. If for whatever reason, the security tab, after updating to v0.17.0 is not consuming the sarif report and adding vulnerabilities as we expect over the coming week, I will need to investigate this. As of the moment, I do not see any issues arising, now that the scan completes with the `exit-code` change.

## PR checklist: submitters

- [ ]   Link to an issue if possible. If there’s no issue, describe what your branch does. Even if there is an issue, a brief description in the PR is still useful.
- [ ]   List any special steps reviewers have to follow to test the PR. For example, adding a local environment variable, creating a local test file, etc.
- [ ]   For extra credit, submit a screen recording like [this one](https://github.com/GSA-TTS/FAC/pull/1821).
- [ ]   Make sure you’ve merged `main` into your branch shortly before creating the PR. (You should also be merging `main` into your branch regularly during development.)
- [ ]   Make sure you’ve accounted for any migrations. When you’re about to create the PR, bring up the application locally and then run `git status | grep migrations`. If there are any results, you probably need to add them to the branch for the PR. Your PR should have only **one** new migration file for each of the component apps, except in rare circumstances; you may need to delete some and re-run `python manage.py makemigrations` to reduce the number to one. (Also, unless in exceptional circumstances, your PR should not delete any migration files.)
- [ ]   Make sure that whatever feature you’re adding has tests that cover the feature. This includes test coverage to make sure that the previous workflow still works, if applicable.
- [ ]   Make sure the full-submission.cy.js [Cypress test](https://github.com/GSA-TTS/FAC/blob/main/docs/testing.md#end-to-end-testing) passes, if applicable.
- [ ]   Do manual testing locally. Our tests are not good enough yet to allow us to skip this step. If that’s not applicable for some reason, check this box.
- [ ]   Verify that no Git surgery was necessary, or, if it was necessary at any point, repeat the testing after it’s finished.
- [ ]   Once a PR is merged, keep an eye on it until it’s deployed to dev, and do enough testing on dev to verify that it deployed successfully, the feature works as expected, and the happy path for the broad feature area (such as submission) still works.

## PR checklist: reviewers

- [ ]   Pull the branch to your local environment and run `make docker-clean; make docker-first-run && docker compose up`; then run `docker compose exec web /bin/bash -c "python manage.py test"`
- [ ]   Manually test out the changes locally, or check this box to verify that it wasn’t applicable in this case.
- [ ]   Check that the PR has appropriate tests. Look out for changes in HTML/JS/JSON Schema logic that may need to be captured in Python tests even though the logic isn’t in Python.
- [ ]   Verify that no Git surgery is necessary at any point (such as during a merge party), or, if it was, repeat the testing after it’s finished.

The larger the PR, the stricter we should be about these points.
