### PR TITLE
Terraform updates for march

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -23,19 +23,19 @@ jobs:
         autoapprove: true
     secrets: inherit
 
-  deploy-preview:
-    name: Deploy application
-    needs:
-      - deploy-infrastructure-preview
-    uses: ./.github/workflows/deploy-application.yml
-    with:
-        environment: "preview"
-    secrets: inherit
+  # deploy-preview:
+  #   name: Deploy application
+  #   needs:
+  #     - deploy-infrastructure-preview
+  #   uses: ./.github/workflows/deploy-application.yml
+  #   with:
+  #       environment: "preview"
+  #   secrets: inherit
 
-  scan-preview-post-deploy:
-    name: Zap Scan
-    needs:
-        - deploy-preview
-    uses: ./.github/workflows/zap-scan.yml
-    with:
-        url: "https://fac-preview.app.cloud.gov/"
+  # scan-preview-post-deploy:
+  #   name: Zap Scan
+  #   needs:
+  #       - deploy-preview
+  #   uses: ./.github/workflows/zap-scan.yml
+  #   with:
+  #       url: "https://fac-preview.app.cloud.gov/"

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -23,19 +23,19 @@ jobs:
         autoapprove: true
     secrets: inherit
 
-  # deploy-preview:
-  #   name: Deploy application
-  #   needs:
-  #     - deploy-infrastructure-preview
-  #   uses: ./.github/workflows/deploy-application.yml
-  #   with:
-  #       environment: "preview"
-  #   secrets: inherit
+  deploy-preview:
+    name: Deploy application
+    needs:
+      - deploy-infrastructure-preview
+    uses: ./.github/workflows/deploy-application.yml
+    with:
+        environment: "preview"
+    secrets: inherit
 
-  # scan-preview-post-deploy:
-  #   name: Zap Scan
-  #   needs:
-  #       - deploy-preview
-  #   uses: ./.github/workflows/zap-scan.yml
-  #   with:
-  #       url: "https://fac-preview.app.cloud.gov/"
+  scan-preview-post-deploy:
+    name: Zap Scan
+    needs:
+        - deploy-preview
+    uses: ./.github/workflows/zap-scan.yml
+    with:
+        url: "https://fac-preview.app.cloud.gov/"

--- a/backend/manifests/vars/vars-preview.yml
+++ b/backend/manifests/vars/vars-preview.yml
@@ -1,7 +1,7 @@
 app_name: gsa-fac
-mem_amount: 2G
+mem_amount: 4G
 cf_env_name: PREVIEW
 env_name: preview
 service_name: preview
 endpoint: fac-preview.app.cloud.gov
-instances: 1
+instances: 2

--- a/backend/manifests/vars/vars-preview.yml
+++ b/backend/manifests/vars/vars-preview.yml
@@ -1,7 +1,7 @@
 app_name: gsa-fac
-mem_amount: 6G
+mem_amount: 2G
 cf_env_name: PREVIEW
 env_name: preview
 service_name: preview
 endpoint: fac-preview.app.cloud.gov
-instances: 2
+instances: 1

--- a/backend/manifests/vars/vars-preview.yml
+++ b/backend/manifests/vars/vars-preview.yml
@@ -1,7 +1,7 @@
 app_name: gsa-fac
-mem_amount: 2G
+mem_amount: 6G
 cf_env_name: PREVIEW
 env_name: preview
 service_name: preview
 endpoint: fac-preview.app.cloud.gov
-instances: 1
+instances: 2

--- a/backend/manifests/vars/vars-production.yml
+++ b/backend/manifests/vars/vars-production.yml
@@ -1,7 +1,7 @@
 app_name: gsa-fac
-mem_amount: 6G
+mem_amount: 8G
 cf_env_name: PRODUCTION
 env_name: prod
 service_name: production
 endpoint: app.fac.gov
-instances: 2
+instances: 10

--- a/terraform/dev/dev.tf
+++ b/terraform/dev/dev.tf
@@ -9,5 +9,6 @@ module "dev" {
   swagger_instances     = 1
   https_proxy_instances = 1
   smtp_proxy_instances  = 1
+  clamav_instances      = 1
   recursive_delete      = true
 }

--- a/terraform/preview/preview.tf
+++ b/terraform/preview/preview.tf
@@ -9,6 +9,7 @@ module "preview" {
   swagger_instances     = 1
   https_proxy_instances = 1
   smtp_proxy_instances  = 1
+  clamav_instances      = 2
   recursive_delete      = true
 }
 

--- a/terraform/preview/preview.tf
+++ b/terraform/preview/preview.tf
@@ -10,6 +10,7 @@ module "preview" {
   https_proxy_instances = 1
   smtp_proxy_instances  = 1
   clamav_instances      = 2
+  clamav_memory         = 2048
   recursive_delete      = true
 }
 

--- a/terraform/preview/preview.tf
+++ b/terraform/preview/preview.tf
@@ -10,7 +10,6 @@ module "preview" {
   https_proxy_instances = 1
   smtp_proxy_instances  = 1
   clamav_instances      = 2
-  clamav_memory         = 2048
   recursive_delete      = true
 }
 

--- a/terraform/production/production.tf
+++ b/terraform/production/production.tf
@@ -3,6 +3,7 @@ module "production" {
   cf_space_name         = "production"
   new_relic_license_key = var.new_relic_license_key
   pgrst_jwt_secret      = var.pgrst_jwt_secret
+  clamav_instances      = 4
   database_plan         = "xlarge-gp-psql-redundant"
 }
 

--- a/terraform/production/production.tf
+++ b/terraform/production/production.tf
@@ -3,7 +3,7 @@ module "production" {
   cf_space_name         = "production"
   new_relic_license_key = var.new_relic_license_key
   pgrst_jwt_secret      = var.pgrst_jwt_secret
-  clamav_instances      = 4
+  clamav_instances      = 6
   database_plan         = "xlarge-gp-psql-redundant"
 }
 

--- a/terraform/shared/modules/cg-logshipper/cg-logshipper.tf
+++ b/terraform/shared/modules/cg-logshipper/cg-logshipper.tf
@@ -8,7 +8,7 @@ data "cloudfoundry_space" "apps" {
 }
 
 module "s3-logshipper-storage" {
-  source = "github.com/18f/terraform-cloudgov//s3?ref=v0.7.1"
+  source = "github.com/18f/terraform-cloudgov//s3?ref=v0.8.0"
 
   cf_org_name      = var.cf_org_name
   cf_space_name    = var.cf_space_name

--- a/terraform/shared/modules/env/clamav.tf
+++ b/terraform/shared/modules/env/clamav.tf
@@ -1,14 +1,5 @@
 locals {
   clam_name = "fac-av-${var.cf_space_name}"
-  module_versions = {
-    clamav = "^8.x", # major version 8
-  }
-}
-
-module "version" {
-  for_each           = local.module_versions
-  source             = "github.com/18f/terraform-cloudgov//semver"
-  version_constraint = each.value
 }
 
 data "docker_registry_image" "clamav" {

--- a/terraform/shared/modules/env/clamav.tf
+++ b/terraform/shared/modules/env/clamav.tf
@@ -1,5 +1,14 @@
 locals {
   clam_name = "fac-av-${var.cf_space_name}"
+  module_versions = {
+    clamav = "^8.x", # major version 8
+  }
+}
+
+module "version" {
+  for_each           = local.module_versions
+  source             = "github.com/18f/terraform-cloudgov//semver"
+  version_constraint = each.value
 }
 
 data "docker_registry_image" "clamav" {
@@ -7,7 +16,7 @@ data "docker_registry_image" "clamav" {
 }
 
 module "clamav" {
-  source = "github.com/18f/terraform-cloudgov//clamav?ref=v0.8.0"
+  source = "github.com/18f/terraform-cloudgov//clamav?ref=v${module.version["clamav"].target_version}"
 
   # This generates eg "fac-av-staging.apps.internal", avoiding collisions with routes for other projects and spaces
   name           = local.clam_name

--- a/terraform/shared/modules/env/clamav.tf
+++ b/terraform/shared/modules/env/clamav.tf
@@ -1,6 +1,5 @@
 locals {
-  clam_name      = "fac-av-${var.cf_space_name}"
-  clamav_version = "github.com/18f/terraform-cloudgov//clamav?ref=v${module.version["clamav"].target_version}"
+  clam_name = "fac-av-${var.cf_space_name}"
 }
 
 data "docker_registry_image" "clamav" {
@@ -8,7 +7,7 @@ data "docker_registry_image" "clamav" {
 }
 
 module "clamav" {
-  source = local.clamav_version
+  source = "github.com/18f/terraform-cloudgov//clamav?ref=v0.8.0"
 
   # This generates eg "fac-av-staging.apps.internal", avoiding collisions with routes for other projects and spaces
   name           = local.clam_name

--- a/terraform/shared/modules/env/clamav.tf
+++ b/terraform/shared/modules/env/clamav.tf
@@ -18,6 +18,7 @@ module "clamav" {
   clamav_image  = "ghcr.io/gsa-tts/fac/clamav@${data.docker_registry_image.clamav.sha256_digest}"
   max_file_size = "30M"
   instances     = var.clamav_instances
+  clamav_memory = var.clamav_memory
 
   proxy_server   = module.https-proxy.domain
   proxy_port     = module.https-proxy.port

--- a/terraform/shared/modules/env/clamav.tf
+++ b/terraform/shared/modules/env/clamav.tf
@@ -7,7 +7,7 @@ data "docker_registry_image" "clamav" {
 }
 
 module "clamav" {
-  source = "github.com/18f/terraform-cloudgov//clamav?ref=v${module.version["clamav"].target_version}"
+  source = ["github.com/18f/terraform-cloudgov//clamav?ref=v${module.version["clamav"].target_version}"]
 
   # This generates eg "fac-av-staging.apps.internal", avoiding collisions with routes for other projects and spaces
   name           = local.clam_name

--- a/terraform/shared/modules/env/clamav.tf
+++ b/terraform/shared/modules/env/clamav.tf
@@ -7,7 +7,7 @@ data "docker_registry_image" "clamav" {
 }
 
 module "clamav" {
-  source = local.clamav_version
+  source = "github.com/18f/terraform-cloudgov//clamav?ref=v${module.version["clamav"].target_version}"
 
   # This generates eg "fac-av-staging.apps.internal", avoiding collisions with routes for other projects and spaces
   name           = local.clam_name

--- a/terraform/shared/modules/env/clamav.tf
+++ b/terraform/shared/modules/env/clamav.tf
@@ -7,7 +7,7 @@ data "docker_registry_image" "clamav" {
 }
 
 module "clamav" {
-  source = "github.com/18f/terraform-cloudgov//clamav?ref=v0.6.0"
+  source = "github.com/18f/terraform-cloudgov//clamav?ref=v0.8.0"
 
   # This generates eg "fac-av-staging.apps.internal", avoiding collisions with routes for other projects and spaces
   name           = local.clam_name
@@ -17,6 +17,7 @@ module "clamav" {
   cf_space_name = var.cf_space_name
   clamav_image  = "ghcr.io/gsa-tts/fac/clamav@${data.docker_registry_image.clamav.sha256_digest}"
   max_file_size = "30M"
+  instances     = 4
 
   proxy_server   = module.https-proxy.domain
   proxy_port     = module.https-proxy.port

--- a/terraform/shared/modules/env/clamav.tf
+++ b/terraform/shared/modules/env/clamav.tf
@@ -17,7 +17,7 @@ module "clamav" {
   cf_space_name = var.cf_space_name
   clamav_image  = "ghcr.io/gsa-tts/fac/clamav@${data.docker_registry_image.clamav.sha256_digest}"
   max_file_size = "30M"
-  instances     = 4
+  instances     = var.clamav_instances
 
   proxy_server   = module.https-proxy.domain
   proxy_port     = module.https-proxy.port

--- a/terraform/shared/modules/env/clamav.tf
+++ b/terraform/shared/modules/env/clamav.tf
@@ -1,5 +1,6 @@
 locals {
-  clam_name = "fac-av-${var.cf_space_name}"
+  clam_name      = "fac-av-${var.cf_space_name}"
+  clamav_version = "github.com/18f/terraform-cloudgov//clamav?ref=v${module.version["clamav"].target_version}"
 }
 
 data "docker_registry_image" "clamav" {
@@ -7,7 +8,7 @@ data "docker_registry_image" "clamav" {
 }
 
 module "clamav" {
-  source = ["github.com/18f/terraform-cloudgov//clamav?ref=v${module.version["clamav"].target_version}"]
+  source = local.clamav_version
 
   # This generates eg "fac-av-staging.apps.internal", avoiding collisions with routes for other projects and spaces
   name           = local.clam_name

--- a/terraform/shared/modules/env/clamav.tf
+++ b/terraform/shared/modules/env/clamav.tf
@@ -7,7 +7,7 @@ data "docker_registry_image" "clamav" {
 }
 
 module "clamav" {
-  source = "github.com/18f/terraform-cloudgov//clamav?ref=v${module.version["clamav"].target_version}"
+  source = local.clamav_version
 
   # This generates eg "fac-av-staging.apps.internal", avoiding collisions with routes for other projects and spaces
   name           = local.clam_name

--- a/terraform/shared/modules/env/env.tf
+++ b/terraform/shared/modules/env/env.tf
@@ -4,8 +4,6 @@ locals {
     s3       = "^0.x", # major version 0
     clamav   = "^0.x"  # major version 0
   }
-  database_version = "github.com/18f/terraform-cloudgov//database?ref=v${module.version["database"].target_version}"
-  s3_verion        = "github.com/18f/terraform-cloudgov//s3?ref=v${module.version["s3"].target_version}"
 }
 
 module "version" {
@@ -15,7 +13,7 @@ module "version" {
 }
 
 module "database" {
-  source = local.database_version
+  source = "github.com/18f/terraform-cloudgov//database?ref=v0.8.0"
 
   cf_org_name      = var.cf_org_name
   cf_space_name    = var.cf_space_name
@@ -26,7 +24,7 @@ module "database" {
 }
 
 module "s3-public" {
-  source = local.s3_version
+  source = "github.com/18f/terraform-cloudgov//s3?ref=v0.8.0"
 
   cf_org_name      = var.cf_org_name
   cf_space_name    = var.cf_space_name
@@ -37,7 +35,7 @@ module "s3-public" {
 }
 
 module "s3-private" {
-  source = local.s3_version
+  source = "github.com/18f/terraform-cloudgov//s3?ref=v0.8.0"
 
   cf_org_name      = var.cf_org_name
   cf_space_name    = var.cf_space_name

--- a/terraform/shared/modules/env/env.tf
+++ b/terraform/shared/modules/env/env.tf
@@ -2,6 +2,7 @@ locals {
   module_versions = {
     database = "^8.x", # major version 8
     s3       = "^8.x"  # major version 8
+    clamav   = "^8.x", # major version 8
   }
 }
 

--- a/terraform/shared/modules/env/env.tf
+++ b/terraform/shared/modules/env/env.tf
@@ -1,8 +1,8 @@
 locals {
   module_versions = {
-    database = "^8.x", # major version 8
-    s3       = "^8.x"  # major version 8
-    clamav   = "^8.x", # major version 8
+    database = "^8.x",
+    s3       = "^8.x",
+    clamav   = "^8.x"
   }
 }
 

--- a/terraform/shared/modules/env/env.tf
+++ b/terraform/shared/modules/env/env.tf
@@ -1,31 +1,47 @@
+locals {
+  module_versions = {
+    database = "^8.x", # major version 8
+    s3       = "^8.x"  # major version 8
+  }
+}
+
+module "version" {
+  for_each           = local.module_versions
+  source             = "github.com/18f/terraform-cloudgov//semver"
+  version_constraint = each.value
+}
+
 module "database" {
-  source = "github.com/18f/terraform-cloudgov//database?ref=v0.5.1"
+  source = "github.com/18f/terraform-cloudgov//database?ref=v${module.version["database"].target_version}"
 
   cf_org_name      = var.cf_org_name
   cf_space_name    = var.cf_space_name
   name             = "fac-db"
   recursive_delete = var.recursive_delete
+  tags             = ["rds"]
   rds_plan_name    = var.database_plan
 }
 
 module "s3-public" {
-  source = "github.com/18f/terraform-cloudgov//s3?ref=v0.5.1"
+  source = "github.com/18f/terraform-cloudgov//s3?ref=v${module.version["s3"].target_version}"
 
   cf_org_name      = var.cf_org_name
   cf_space_name    = var.cf_space_name
   name             = "fac-public-s3"
   recursive_delete = var.recursive_delete
   s3_plan_name     = "basic-public"
+  tags             = ["s3"]
 }
 
 module "s3-private" {
-  source = "github.com/18f/terraform-cloudgov//s3?ref=v0.5.1"
+  source = "github.com/18f/terraform-cloudgov//s3?ref=v${module.version["s3"].target_version}"
 
   cf_org_name      = var.cf_org_name
   cf_space_name    = var.cf_space_name
   name             = "fac-private-s3"
   recursive_delete = var.recursive_delete
   s3_plan_name     = "basic"
+  tags             = ["s3"]
 }
 
 # Stuff used for apps in this space

--- a/terraform/shared/modules/env/env.tf
+++ b/terraform/shared/modules/env/env.tf
@@ -1,12 +1,9 @@
 locals {
   module_versions = {
-    database = "^0.8.0",
-    s3       = "^0.8.0",
-    clamav   = "^0.8.0"
+    database = "^0.x", # major version 0
+    s3       = "^0.x", # major version 0
+    clamav   = "^0.x"  # major version 0
   }
-  database_version = "github.com/18f/terraform-cloudgov//database?ref=v${module.version["database"].target_version}"
-  s3_version       = "github.com/18f/terraform-cloudgov//s3?ref=v${module.version["s3"].target_version}"
-  clamav_version   = "github.com/18f/terraform-cloudgov//clamav?ref=v${module.version["clamav"].target_version}"
 }
 
 module "version" {
@@ -16,7 +13,7 @@ module "version" {
 }
 
 module "database" {
-  source = local.database_version
+  source = "github.com/18f/terraform-cloudgov//database?ref=v${module.version["database"].target_version}"
 
   cf_org_name      = var.cf_org_name
   cf_space_name    = var.cf_space_name
@@ -27,7 +24,7 @@ module "database" {
 }
 
 module "s3-public" {
-  source = local.s3_version
+  source = "github.com/18f/terraform-cloudgov//s3?ref=v${module.version["s3"].target_version}"
 
   cf_org_name      = var.cf_org_name
   cf_space_name    = var.cf_space_name
@@ -38,7 +35,7 @@ module "s3-public" {
 }
 
 module "s3-private" {
-  source = local.s3_version
+  source = "github.com/18f/terraform-cloudgov//s3?ref=v${module.version["s3"].target_version}"
 
   cf_org_name      = var.cf_org_name
   cf_space_name    = var.cf_space_name

--- a/terraform/shared/modules/env/env.tf
+++ b/terraform/shared/modules/env/env.tf
@@ -1,17 +1,3 @@
-locals {
-  module_versions = {
-    database = "^0.x", # major version 0
-    s3       = "^0.x", # major version 0
-    clamav   = "^0.x"  # major version 0
-  }
-}
-
-module "version" {
-  for_each           = local.module_versions
-  source             = "github.com/18f/terraform-cloudgov//semver"
-  version_constraint = each.value
-}
-
 module "database" {
   source = "github.com/18f/terraform-cloudgov//database?ref=v0.8.0"
 

--- a/terraform/shared/modules/env/env.tf
+++ b/terraform/shared/modules/env/env.tf
@@ -1,8 +1,8 @@
 locals {
   module_versions = {
-    database = "^8.x",
-    s3       = "^8.x",
-    clamav   = "^8.x"
+    database = "^0.x", # major version 0
+    s3       = "^0.x", # major version 0
+    clamav   = "^0.x"  # major version 0
   }
 }
 

--- a/terraform/shared/modules/env/env.tf
+++ b/terraform/shared/modules/env/env.tf
@@ -4,6 +4,8 @@ locals {
     s3       = "^0.x", # major version 0
     clamav   = "^0.x"  # major version 0
   }
+  database_version = "github.com/18f/terraform-cloudgov//database?ref=v${module.version["database"].target_version}"
+  s3_verion        = "github.com/18f/terraform-cloudgov//s3?ref=v${module.version["s3"].target_version}"
 }
 
 module "version" {
@@ -13,7 +15,7 @@ module "version" {
 }
 
 module "database" {
-  source = ["github.com/18f/terraform-cloudgov//database?ref=v${module.version["database"].target_version}"]
+  source = local.database_version
 
   cf_org_name      = var.cf_org_name
   cf_space_name    = var.cf_space_name
@@ -24,7 +26,7 @@ module "database" {
 }
 
 module "s3-public" {
-  source = ["github.com/18f/terraform-cloudgov//s3?ref=v${module.version["s3"].target_version}"]
+  source = local.s3_version
 
   cf_org_name      = var.cf_org_name
   cf_space_name    = var.cf_space_name
@@ -35,7 +37,7 @@ module "s3-public" {
 }
 
 module "s3-private" {
-  source = ["github.com/18f/terraform-cloudgov//s3?ref=v${module.version["s3"].target_version}"]
+  source = local.s3_version
 
   cf_org_name      = var.cf_org_name
   cf_space_name    = var.cf_space_name

--- a/terraform/shared/modules/env/env.tf
+++ b/terraform/shared/modules/env/env.tf
@@ -1,8 +1,8 @@
 locals {
   module_versions = {
-    database = "^0.x", # major version 0
-    s3       = "^0.x", # major version 0
-    clamav   = "^0.x"  # major version 0
+    database = "^8.0", # major version 8
+    s3       = "^8.0", # major version 8
+    clamav   = "^8.0"  # major version 8
   }
 }
 

--- a/terraform/shared/modules/env/env.tf
+++ b/terraform/shared/modules/env/env.tf
@@ -1,9 +1,12 @@
 locals {
   module_versions = {
-    database = "^8.0", # major version 8
-    s3       = "^8.0", # major version 8
-    clamav   = "^8.0"  # major version 8
+    database = "^0.8.0",
+    s3       = "^0.8.0",
+    clamav   = "^0.8.0"
   }
+  database_version = "github.com/18f/terraform-cloudgov//database?ref=v${module.version["database"].target_version}"
+  s3_version       = "github.com/18f/terraform-cloudgov//s3?ref=v${module.version["s3"].target_version}"
+  clamav_version   = "github.com/18f/terraform-cloudgov//clamav?ref=v${module.version["clamav"].target_version}"
 }
 
 module "version" {
@@ -13,7 +16,7 @@ module "version" {
 }
 
 module "database" {
-  source = "github.com/18f/terraform-cloudgov//database?ref=v${module.version["database"].target_version}"
+  source = local.database_version
 
   cf_org_name      = var.cf_org_name
   cf_space_name    = var.cf_space_name
@@ -24,7 +27,7 @@ module "database" {
 }
 
 module "s3-public" {
-  source = "github.com/18f/terraform-cloudgov//s3?ref=v${module.version["s3"].target_version}"
+  source = local.s3_version
 
   cf_org_name      = var.cf_org_name
   cf_space_name    = var.cf_space_name
@@ -35,7 +38,7 @@ module "s3-public" {
 }
 
 module "s3-private" {
-  source = "github.com/18f/terraform-cloudgov//s3?ref=v${module.version["s3"].target_version}"
+  source = local.s3_version
 
   cf_org_name      = var.cf_org_name
   cf_space_name    = var.cf_space_name

--- a/terraform/shared/modules/env/env.tf
+++ b/terraform/shared/modules/env/env.tf
@@ -13,7 +13,7 @@ module "version" {
 }
 
 module "database" {
-  source = "github.com/18f/terraform-cloudgov//database?ref=v${module.version["database"].target_version}"
+  source = ["github.com/18f/terraform-cloudgov//database?ref=v${module.version["database"].target_version}"]
 
   cf_org_name      = var.cf_org_name
   cf_space_name    = var.cf_space_name
@@ -24,7 +24,7 @@ module "database" {
 }
 
 module "s3-public" {
-  source = "github.com/18f/terraform-cloudgov//s3?ref=v${module.version["s3"].target_version}"
+  source = ["github.com/18f/terraform-cloudgov//s3?ref=v${module.version["s3"].target_version}"]
 
   cf_org_name      = var.cf_org_name
   cf_space_name    = var.cf_space_name
@@ -35,7 +35,7 @@ module "s3-public" {
 }
 
 module "s3-private" {
-  source = "github.com/18f/terraform-cloudgov//s3?ref=v${module.version["s3"].target_version}"
+  source = ["github.com/18f/terraform-cloudgov//s3?ref=v${module.version["s3"].target_version}"]
 
   cf_org_name      = var.cf_org_name
   cf_space_name    = var.cf_space_name

--- a/terraform/shared/modules/env/variables.tf
+++ b/terraform/shared/modules/env/variables.tf
@@ -74,6 +74,12 @@ variable "clamav_instances" {
   default     = 1
 }
 
+variable "clamav_memory" {
+  type        = number
+  description = "memory in MB to allocate to clamav app"
+  default     = 3072
+}
+
 variable "new_relic_license_key" {
   type        = string
   description = "the license key to use when setting up the New Relic agent"

--- a/terraform/shared/modules/env/variables.tf
+++ b/terraform/shared/modules/env/variables.tf
@@ -1,15 +1,15 @@
 # These variables expose what is open for customization in an environment. Where
 # there are defaults, they are the production defaults.
-# 
+#
 # Example usage:
-# 
+#
 # For production:
 #   module "production" {
 #     source        = "../shared/modules/base"
 #     cf_space_name = "production"
 #     # No further customization needed
 #   }
-# 
+#
 # For dev:
 #   module "dev" {
 #     cf_space_name = "dev"
@@ -66,6 +66,12 @@ variable "smtp_proxy_instances" {
   type        = number
   description = "the number of instances of the SMTP proxy application to run (default: 2)"
   default     = 2
+}
+
+variable "clamav_instances" {
+  type        = number
+  description = "the number of instances of the clamav application to run (default: 1)"
+  default     = 1
 }
 
 variable "new_relic_license_key" {

--- a/terraform/staging/staging.tf
+++ b/terraform/staging/staging.tf
@@ -9,6 +9,7 @@ module "staging" {
   swagger_instances     = 1
   https_proxy_instances = 1
   smtp_proxy_instances  = 1
+  clamav_instances      = 1
   recursive_delete      = true
 }
 


### PR DESCRIPTION
## Updates:
- Bring all module versions up to current `v0.8.0`.
- Updates to clamav module so we can scale horizontally
- Set all environments for the upcoming audit season