### PR TITLE
Reduce prod instance memory

### DIFF
--- a/backend/manifests/vars/vars-production.yml
+++ b/backend/manifests/vars/vars-production.yml
@@ -1,5 +1,5 @@
 app_name: gsa-fac
-mem_amount: 8G
+mem_amount: 6G
 cf_env_name: PRODUCTION
 env_name: prod
 service_name: production


### PR DESCRIPTION
```
Staging app and tracing logs...
organization's memory limit exceeded: staging requires 8192M memory
FAILED
```

10x 6GB -
![image](https://github.com/GSA-TTS/FAC/assets/130377221/6c79318e-fe58-4a82-9984-2bb7c0dfdd66)

![gif](https://media.tenor.co/images/14f3fa2e18c5745ae2405ccbbf481d0e/tenor.gif)