### PR TITLE
prod - Set 6 instances w/ 8G mem

### DIFF
--- a/backend/manifests/vars/vars-production.yml
+++ b/backend/manifests/vars/vars-production.yml
@@ -1,7 +1,7 @@
 app_name: gsa-fac
-mem_amount: 6G
+mem_amount: 8G
 cf_env_name: PRODUCTION
 env_name: prod
 service_name: production
 endpoint: app.fac.gov
-instances: 10
+instances: 6


### PR DESCRIPTION
10x6 won't allow tasks to run, we need more headroom than this.

Every 2 hours 2 7G instances do backups, so with current allocations, this brings us to 104.6G running, +14G gives us 9.4G spare