### PR TITLE
Ignore named functions when processing named ranges

### DIFF
--- a/backend/audit/intakelib/intermediate_representation.py
+++ b/backend/audit/intakelib/intermediate_representation.py
@@ -282,7 +282,7 @@ def extract_workbook_as_ir(file):
                 process_destination(dn, title, coord, sheets_by_name, workbook)
             except StopIteration:
                 logger.info(f"No destinations found for {named_range_name}.")
-                raise_modified_workbook(WORKBOOK_MODIFIED_ERROR)
+                # raise_modified_workbook(WORKBOOK_MODIFIED_ERROR)
 
     # Build the IR, which is a list of sheets.
     sheets = []

--- a/backend/audit/test_intakelib.py
+++ b/backend/audit/test_intakelib.py
@@ -1,3 +1,4 @@
+import unittest
 from django.test import SimpleTestCase
 from copy import deepcopy
 from audit.intakelib.intermediate_representation import (
@@ -144,6 +145,9 @@ class TestExtractWorkbookAsIr(SimpleTestCase):
         with self.assertRaises(ValidationError):
             extract_workbook_as_ir("dummy_file_with_ref_error")
 
+    @unittest.skip(
+        "Skipping this test as we have turned off check for no destination found in extract_workbook_as_ir."
+    )
     @patch("audit.intakelib.intermediate_representation._open_workbook")
     def test_no_destination_found(self, mock_open_workbook):
         """Test handling of a workbook with no destinations found for a named range."""


### PR DESCRIPTION
Remove exception/error on named functions

We have discovered that some accounting packages add named functions to the defined names in a workbook.

These crash our code, because we assumed all named things were ranges. Named functions do not (for example) have cell references.

This change leaves a logging statement in place for this situation. We no longer report an error to the user. Why? Because the user may not know the functions even exist.

We will still reject workbooks that have named ranges we cannot recognize. We still only pull data from named ranges we recognize. But, we will allow the named functions to exist.


## PR checklist: submitters

- [ ]   Link to an issue if possible. If there’s no issue, describe what your branch does. Even if there is an issue, a brief description in the PR is still useful.
- [ ]   List any special steps reviewers have to follow to test the PR. For example, adding a local environment variable, creating a local test file, etc.
- [ ]   For extra credit, submit a screen recording like [this one](https://github.com/GSA-TTS/FAC/pull/1821).
- [ ]   Make sure you’ve merged `main` into your branch shortly before creating the PR. (You should also be merging `main` into your branch regularly during development.)
- [ ]   Make sure you’ve accounted for any migrations. When you’re about to create the PR, bring up the application locally and then run `git status | grep migrations`. If there are any results, you probably need to add them to the branch for the PR. Your PR should have only **one** new migration file for each of the component apps, except in rare circumstances; you may need to delete some and re-run `python manage.py makemigrations` to reduce the number to one. (Also, unless in exceptional circumstances, your PR should not delete any migration files.)
- [ ]   Make sure that whatever feature you’re adding has tests that cover the feature. This includes test coverage to make sure that the previous workflow still works, if applicable.
- [ ]   Make sure the full-submission.cy.js [Cypress test](https://github.com/GSA-TTS/FAC/blob/main/docs/testing.md#end-to-end-testing) passes, if applicable.
- [ ]   Do manual testing locally. Our tests are not good enough yet to allow us to skip this step. If that’s not applicable for some reason, check this box.
- [ ]   Verify that no Git surgery was necessary, or, if it was necessary at any point, repeat the testing after it’s finished.
- [ ]   Once a PR is merged, keep an eye on it until it’s deployed to dev, and do enough testing on dev to verify that it deployed successfully, the feature works as expected, and the happy path for the broad feature area (such as submission) still works.

## PR checklist: reviewers

- [ ]   Pull the branch to your local environment and run `make docker-clean; make docker-first-run && docker compose up`; then run `docker compose exec web /bin/bash -c "python manage.py test"`
- [ ]   Manually test out the changes locally, or check this box to verify that it wasn’t applicable in this case.
- [ ]   Check that the PR has appropriate tests. Look out for changes in HTML/JS/JSON Schema logic that may need to be captured in Python tests even though the logic isn’t in Python.
- [ ]   Verify that no Git surgery is necessary at any point (such as during a merge party), or, if it was, repeat the testing after it’s finished.

The larger the PR, the stricter we should be about these points.
