### PR TITLE
Support configurable clamav-rest port

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -79,8 +79,9 @@ services:
     environment:
       MAX_FILE_SIZE: 30M
       SIGNATURE_CHECKS: 1
+      PORT: ${CLAMAV_PORT:-9000}
     ports:
-      - "9000:9000"
+      - ${CLAMAV_PORT:-9000:9000}
 
   #---------------------------------------------
   # Minio (S3 clone)

--- a/docs/development.md
+++ b/docs/development.md
@@ -54,7 +54,7 @@ DISABLE_AUTH =
 
 For local testing, you may need to specify a few other variables:
 
-* A port other than `9000` for clamav-rest: add `CLAMAV_PORT: {port number}` to your `.env` file.
+* A port other than `9000` for clamav-rest: add `CLAMAV_PORT = {port number}` to your `.env` file.
 * Cypress variables for running local end-to-end tests. See the [testing docs](https://github.com/GSA-TTS/FAC/blob/main/docs/testing.md#end-to-end-testing) for more.
 
 If you need to add these to your local environment (should end up in `~/.bash_profile`, `~/.bashrc`, `~/.zshrc`, or whatever flavor of shell you're using.)

--- a/docs/development.md
+++ b/docs/development.md
@@ -51,7 +51,11 @@ DJANGO_SECRET_LOGIN_KEY =
 LOGIN_CLIENT_ID =
 DISABLE_AUTH = 
 ```
-If you are using a MacBook with Apple M1 hardware, you will probably also have to add `DOCKERFILE = Apple_M1_Dockerfile` to the file.
+
+For local testing, you may need to specify a few other variables:
+
+* A port other than `9000` for clamav-rest: add `CLAMAV_PORT: {port number}` to your `.env` file.
+* Cypress variables for running local end-to-end tests. See the [testing docs](https://github.com/GSA-TTS/FAC/blob/main/docs/testing.md#end-to-end-testing) for more.
 
 If you need to add these to your local environment (should end up in `~/.bash_profile`, `~/.bashrc`, `~/.zshrc`, or whatever flavor of shell you're using.)
 


### PR DESCRIPTION
Some folks have found that other local programs might be camping out on `0.0.0.0:9000` (Zscaler, for example), preventing the local application from standing up. This PR makes that port configurable with a fallback to `9000`. It also updates the developer documentation with instructions on setting this variable.

## PR checklist: submitters

- [ ]   Link to an issue if possible. If there’s no issue, describe what your branch does. Even if there is an issue, a brief description in the PR is still useful.
- [ ]   List any special steps reviewers have to follow to test the PR. For example, adding a local environment variable, creating a local test file, etc.
- [ ]   For extra credit, submit a screen recording like [this one](https://github.com/GSA-TTS/FAC/pull/1821).
- [ ]   Make sure you’ve merged `main` into your branch shortly before creating the PR. (You should also be merging `main` into your branch regularly during development.)
- [ ]   Make sure you’ve accounted for any migrations. When you’re about to create the PR, bring up the application locally and then run `git status | grep migrations`. If there are any results, you probably need to add them to the branch for the PR. Your PR should have only **one** new migration file for each of the component apps, except in rare circumstances; you may need to delete some and re-run `python manage.py makemigrations` to reduce the number to one. (Also, unless in exceptional circumstances, your PR should not delete any migration files.)
- [ ]   Make sure that whatever feature you’re adding has tests that cover the feature. This includes test coverage to make sure that the previous workflow still works, if applicable.
- [ ]   Make sure the full-submission.cy.js [Cypress test](https://github.com/GSA-TTS/FAC/blob/main/docs/testing.md#end-to-end-testing) passes, if applicable.
- [ ]   Do manual testing locally. Our tests are not good enough yet to allow us to skip this step. If that’s not applicable for some reason, check this box.
- [ ]   Verify that no Git surgery was necessary, or, if it was necessary at any point, repeat the testing after it’s finished.
- [ ]   Once a PR is merged, keep an eye on it until it’s deployed to dev, and do enough testing on dev to verify that it deployed successfully, the feature works as expected, and the happy path for the broad feature area (such as submission) still works.

## PR checklist: reviewers

- [ ]   Pull the branch to your local environment and run `make docker-clean; make docker-first-run && docker compose up`; then run `docker compose exec web /bin/bash -c "python manage.py test"`
- [ ]   Manually test out the changes locally, or check this box to verify that it wasn’t applicable in this case.
- [ ]   Check that the PR has appropriate tests. Look out for changes in HTML/JS/JSON Schema logic that may need to be captured in Python tests even though the logic isn’t in Python.
- [ ]   Verify that no Git surgery is necessary at any point (such as during a merge party), or, if it was, repeat the testing after it’s finished.

The larger the PR, the stricter we should be about these points.
