### PR TITLE
Sk/3697 invalid cluster names

### DIFF
--- a/backend/census_historical_migration/test_federal_awards_xforms.py
+++ b/backend/census_historical_migration/test_federal_awards_xforms.py
@@ -21,6 +21,7 @@ from .workbooklib.federal_awards import (
     xform_replace_invalid_extension,
     xform_is_passthrough_award,
     is_valid_extension,
+    xform_cluster_names,
 )
 
 
@@ -585,3 +586,25 @@ class TestXformMatchNumberPassthroughNamesIds(SimpleTestCase):
 
         self.assertEqual(transformed_names, names)
         self.assertEqual(transformed_ids, expected_ids)
+
+
+class TestXformClusterNames(SimpleTestCase):
+    class MockAudit:
+        def __init__(self, cluster_name):
+            self.CLUSTERNAME = cluster_name
+
+    def test_cluster_name_not_other_cluster(self):
+        audits = []
+        audits.append(self.MockAudit("STUDENT FINANCIAL ASSISTANCE"))
+        audits.append(self.MockAudit("RESEARCH AND DEVELOPMENT"))
+        result = xform_cluster_names(audits)
+        for index in range(len(result)):
+            self.assertEqual(result[index].CLUSTERNAME, audits[index].CLUSTERNAME)
+
+    def test_cluster_name_other_cluster(self):
+        audits = []
+        audits.append(self.MockAudit("OTHER CLUSTER"))
+        audits.append(self.MockAudit("OTHER CLUSTER"))
+        result = xform_cluster_names(audits)
+        for audit in result:
+            self.assertEqual(audit.CLUSTERNAME, settings.OTHER_CLUSTER)

--- a/backend/census_historical_migration/workbooklib/federal_awards.py
+++ b/backend/census_historical_migration/workbooklib/federal_awards.py
@@ -517,8 +517,8 @@ def xform_cluster_names(audits):
     is_other_cluster_found = False
     for audit in audits:
         cluster_name = string_to_string(audit.CLUSTERNAME)
-        if cluster_name != settings.OTHER_CLUSTER:
-            if "OTHER CLUSTER" in cluster_name:
+        if "OTHER CLUSTER" in cluster_name:
+            if cluster_name != settings.OTHER_CLUSTER:
                 is_other_cluster_found = True
                 track_transformations(
                     "CLUSTERNAME",

--- a/backend/census_historical_migration/workbooklib/federal_awards.py
+++ b/backend/census_historical_migration/workbooklib/federal_awards.py
@@ -541,18 +541,17 @@ def xform_cluster_names(audits):
     is_other_cluster_found = False
     for audit in audits:
         cluster_name = string_to_string(audit.CLUSTERNAME)
-        if cluster_name and "OTHER CLUSTER" == cluster_name.upper():
-            if cluster_name != settings.OTHER_CLUSTER:
-                is_other_cluster_found = True
-                track_transformations(
-                    "CLUSTERNAME",
-                    audit.CLUSTERNAME,
-                    "cluster_name",
-                    settings.OTHER_CLUSTER,
-                    ["xform_cluster_names"],
-                    change_records,
-                )
-                audit.CLUSTERNAME = settings.OTHER_CLUSTER
+        if cluster_name and cluster_name.upper() == "OTHER CLUSTER":
+            is_other_cluster_found = True
+            track_transformations(
+                "CLUSTERNAME",
+                audit.CLUSTERNAME,
+                "cluster_name",
+                settings.OTHER_CLUSTER,
+                ["xform_cluster_names"],
+                change_records,
+            )
+            audit.CLUSTERNAME = settings.OTHER_CLUSTER
 
     if change_records and is_other_cluster_found:
         InspectionRecord.append_federal_awards_changes(change_records)

--- a/backend/census_historical_migration/workbooklib/federal_awards.py
+++ b/backend/census_historical_migration/workbooklib/federal_awards.py
@@ -508,6 +508,33 @@ def xform_populate_default_passthrough_amount(audits):
     return passthrough_amounts
 
 
+def xform_cluster_names(audits):
+    """
+    If 'OTHER CLUSTER' is present in the clustername,
+    replace audit.CLUSTERNAME with settings.OTHER_CLUSTER and track transformation.
+    """
+    change_records = []
+    is_other_cluster_found = False
+    for audit in audits:
+        cluster_name = string_to_string(audit.CLUSTERNAME)
+        if cluster_name != settings.OTHER_CLUSTER:
+            if "OTHER CLUSTER" in cluster_name:
+                is_other_cluster_found = True
+                track_transformations(
+                    "CLUSTERNAME",
+                    audit.CLUSTERNAME,
+                    "cluster_name",
+                    settings.OTHER_CLUSTER,
+                    ["xform_cluster_names"],
+                    change_records,
+                )
+                audit.CLUSTERNAME = settings.OTHER_CLUSTER
+
+    if change_records and is_other_cluster_found:
+        InspectionRecord.append_federal_awards_changes(change_records)
+    return audits
+
+
 def generate_federal_awards(audit_header, outfile):
     """
     Generates a federal awards workbook for all awards associated with a given audit header.
@@ -522,6 +549,7 @@ def generate_federal_awards(audit_header, outfile):
     uei = xform_retrieve_uei(audit_header.UEI)
     set_workbook_uei(wb, uei)
     audits = get_audits(audit_header.DBKEY, audit_header.AUDITYEAR)
+    audits = xform_cluster_names(audits)
 
     (
         cluster_names,
@@ -572,7 +600,7 @@ def generate_federal_awards(audit_header, outfile):
     set_range(
         wb,
         "award_reference",
-        [f"AWARD-{n+1:04}" for n in range(len(audits))],
+        [f"AWARD-{n + 1:04}" for n in range(len(audits))],
     )
 
     # passthrough amount

--- a/backend/census_historical_migration/workbooklib/federal_awards.py
+++ b/backend/census_historical_migration/workbooklib/federal_awards.py
@@ -541,7 +541,7 @@ def xform_cluster_names(audits):
     is_other_cluster_found = False
     for audit in audits:
         cluster_name = string_to_string(audit.CLUSTERNAME)
-        if "OTHER CLUSTER" in cluster_name:
+        if cluster_name and "OTHER CLUSTER" == cluster_name.upper():
             if cluster_name != settings.OTHER_CLUSTER:
                 is_other_cluster_found = True
                 track_transformations(


### PR DESCRIPTION
**Closes:** https://github.com/GSA-TTS/FAC/issues/3697

**Testing:**
1. Run Test cases:
- Run fac test census_historical_migration.test_federal_awards_xforms
- Result:
<img width="479" alt="Screenshot 2024-05-01 at 9 52 14 AM" src="https://github.com/GSA-TTS/FAC/assets/135276194/43020398-d53f-4b62-9393-1a8ecb69c069">

2. Test with a failed audit: dbkey = 33900, audit_year = 2019, if access to census data in Preview is available.
- Run 'docker compose run --rm web python manage.py historic_data_migrator --years 'my_year' --dbkeys 'my_dbkey''
- Verify that cluster_name in  dissemination_federalaward is set to 'OTHER CLUSTER NOT LISTED ABOVE'.
- Verify that migration inspection record is updated in dissemination_migrationinspectionrecord table.

3. Test by changing CLUSTERNAME in an audit:
- Find an audit that has CLUSTERNAME of 'OTHER CLUSTER NOT LISTED ABOVE'.
- Change CLUSTERNAME 'OTHER CLUSTER NOT LISTED ABOVE' in census elecaudits table to 'OTHER CLUSTER' 
- Run 'docker compose run --rm web python manage.py historic_data_migrator --years 'my_year' --dbkeys 'my_dbkey''
- Verify that cluster_name in  dissemination_federalaward is set to 'OTHER CLUSTER NOT LISTED ABOVE'.
- Verify that migration inspection record is updated in dissemination_migrationinspectionrecord table.

## PR checklist: submitters

- [ ]   Link to an issue if possible. If there’s no issue, describe what your branch does. Even if there is an issue, a brief description in the PR is still useful.
- [ ]   List any special steps reviewers have to follow to test the PR. For example, adding a local environment variable, creating a local test file, etc.
- [ ]   For extra credit, submit a screen recording like [this one](https://github.com/GSA-TTS/FAC/pull/1821).
- [ ]   Make sure you’ve merged `main` into your branch shortly before creating the PR. (You should also be merging `main` into your branch regularly during development.)
- [ ]   Make sure you’ve accounted for any migrations. When you’re about to create the PR, bring up the application locally and then run `git status | grep migrations`. If there are any results, you probably need to add them to the branch for the PR. Your PR should have only **one** new migration file for each of the component apps, except in rare circumstances; you may need to delete some and re-run `python manage.py makemigrations` to reduce the number to one. (Also, unless in exceptional circumstances, your PR should not delete any migration files.)
- [ ]   Make sure that whatever feature you’re adding has tests that cover the feature. This includes test coverage to make sure that the previous workflow still works, if applicable.
- [ ]   Make sure the full-submission.cy.js [Cypress test](https://github.com/GSA-TTS/FAC/blob/main/docs/testing.md#end-to-end-testing) passes, if applicable.
- [ ]   Do manual testing locally. Our tests are not good enough yet to allow us to skip this step. If that’s not applicable for some reason, check this box.
- [ ]   Verify that no Git surgery was necessary, or, if it was necessary at any point, repeat the testing after it’s finished.
- [ ]   Once a PR is merged, keep an eye on it until it’s deployed to dev, and do enough testing on dev to verify that it deployed successfully, the feature works as expected, and the happy path for the broad feature area (such as submission) still works.

## PR checklist: reviewers

- [ ]   Pull the branch to your local environment and run `make docker-clean; make docker-first-run && docker compose up`; then run `docker compose exec web /bin/bash -c "python manage.py test"`
- [ ]   Manually test out the changes locally, or check this box to verify that it wasn’t applicable in this case.
- [ ]   Check that the PR has appropriate tests. Look out for changes in HTML/JS/JSON Schema logic that may need to be captured in Python tests even though the logic isn’t in Python.
- [ ]   Verify that no Git surgery is necessary at any point (such as during a merge party), or, if it was, repeat the testing after it’s finished.

The larger the PR, the stricter we should be about these points.
