### PR TITLE
Modify the file scanner clamav to have variable instances

### DIFF
--- a/terraform/dev/dev.tf
+++ b/terraform/dev/dev.tf
@@ -10,6 +10,7 @@ module "dev" {
   https_proxy_instances = 1
   smtp_proxy_instances  = 1
   clamav_instances      = 1
+  clamav_fs_instances   = 1
   recursive_delete      = true
   json_params = jsonencode(
     {

--- a/terraform/preview/preview.tf
+++ b/terraform/preview/preview.tf
@@ -10,6 +10,7 @@ module "preview" {
   https_proxy_instances = 1
   smtp_proxy_instances  = 1
   clamav_instances      = 2
+  clamav_fs_instances   = 1
   recursive_delete      = true
   json_params = jsonencode(
     {

--- a/terraform/production/production.tf
+++ b/terraform/production/production.tf
@@ -4,6 +4,7 @@ module "production" {
   new_relic_license_key = var.new_relic_license_key
   pgrst_jwt_secret      = var.pgrst_jwt_secret
   clamav_instances      = 8
+  clamav_fs_instances   = 4
   database_plan         = "xlarge-gp-psql-redundant"
   postgrest_instances   = 4
   json_params = jsonencode(

--- a/terraform/shared/modules/env/clamav.tf
+++ b/terraform/shared/modules/env/clamav.tf
@@ -38,7 +38,7 @@ module "file_scanner_clamav" {
   cf_space_name = var.cf_space_name
   clamav_image  = "ghcr.io/gsa-tts/fac/clamav@${data.docker_registry_image.clamav.sha256_digest}"
   max_file_size = "30M"
-  instances     = var.clamav_instances
+  instances     = var.clamav_fs_instances
   clamav_memory = var.clamav_memory
 
   proxy_server   = module.https-proxy.domain

--- a/terraform/shared/modules/env/variables.tf
+++ b/terraform/shared/modules/env/variables.tf
@@ -74,6 +74,12 @@ variable "clamav_instances" {
   default     = 1
 }
 
+variable "clamav_fs_instances" {
+  type        = number
+  description = "the number of instances of the clamav application to run (default: 1)"
+  default     = 1
+}
+
 variable "clamav_memory" {
   type        = number
   description = "memory in MB to allocate to clamav app"

--- a/terraform/staging/staging.tf
+++ b/terraform/staging/staging.tf
@@ -10,6 +10,7 @@ module "staging" {
   https_proxy_instances = 1
   smtp_proxy_instances  = 1
   clamav_instances      = 1
+  clamav_fs_instances   = 1
   recursive_delete      = true
   json_params = jsonencode(
     {


### PR DESCRIPTION
Small change to the dedicated ClamAV to reduce instances across the board, predominantly in `production` bringing the instance count down from 8 -> 4.