### PR TITLE
Undo the workflow changes [Post Freeze]

### DIFF
--- a/.github/workflows/auto-merge-staging-pr.yml
+++ b/.github/workflows/auto-merge-staging-pr.yml
@@ -1,9 +1,8 @@
 ---
 name: Auto Merge Pull Request With Approved Label
 on:
-#   repository_dispatch:
-#     types: [ ready-to-merge ]
-    workflow_dispatch: null
+  repository_dispatch:
+    types: [ ready-to-merge ]
 jobs:
   auto-merge:
     name: Auto Merge The Created Pull Request

--- a/.github/workflows/create-pull-request-to-staging.yml
+++ b/.github/workflows/create-pull-request-to-staging.yml
@@ -2,7 +2,7 @@
 name: Create Pull Request To Staging
 on:
   workflow_call:
-  workflow_dispatch: null
+  workflow_dispatch:
 
 env:
   GH_TOKEN: ${{ secrets.DEPLOY_TOKEN }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - v1.*
-  workflow_dispatch: null
 
 jobs:
   testing:

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -90,18 +90,18 @@ jobs:
       environment: "production"
     secrets: inherit
 
-  # repo-event:
-  #   if: ${{ github.base_ref == 'prod' && always() }}
-  #   name: Set Repository Event
-  #   permissions:
-  #     contents: write
-  #   runs-on: ubuntu-latest
-  #   needs: [terraform-plan-staging, testing-from-ghcr, testing-from-build]
-  #   steps:
-  #     - name: Repository Dispatch
-  #       uses: peter-evans/repository-dispatch@v3
-  #       with:
-  #         token: ${{ secrets.GITHUB_TOKEN }}
-  #         event-type: ready-to-merge
-  #         client-payload: '{"github": ${{ toJson(github) }}}'
-  #       if: github.event_name == 'pull_request'
+  repo-event:
+    if: ${{ github.base_ref == 'prod' && always() }}
+    name: Set Repository Event
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    needs: [terraform-plan-staging, testing-from-ghcr, testing-from-build]
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          event-type: ready-to-merge
+          client-payload: '{"github": ${{ toJson(github) }}}'
+        if: github.event_name == 'pull_request'

--- a/.github/workflows/staging-scheduled-deploy.yml
+++ b/.github/workflows/staging-scheduled-deploy.yml
@@ -31,7 +31,7 @@ jobs:
       work-dir: ./backend
 
   testing:
-    name: Run Django, Lighthouse, a11y and lint
+    name: Run Django and lint
     needs:
       - build-container
     uses: ./.github/workflows/testing-from-ghcr.yml

--- a/.github/workflows/staging-scheduled-deploy.yml
+++ b/.github/workflows/staging-scheduled-deploy.yml
@@ -1,10 +1,10 @@
 ---
 name: Scheduled Deploy From Main to Staging
 on:
-  # schedule:
+  schedule:
     # Invoke every Mon-Sat
-    # - cron: '0 10 * * 1-6'
-  workflow_dispatch: null
+    - cron: '0 10 * * 1-6'
+  workflow_dispatch:
 
 jobs:
   trivy-scan:
@@ -31,7 +31,7 @@ jobs:
       work-dir: ./backend
 
   testing:
-    name: Run Django and lint
+    name: Run Django, Lighthouse, a11y and lint
     needs:
       - build-container
     uses: ./.github/workflows/testing-from-ghcr.yml


### PR DESCRIPTION
Undoes the changes to the workflow for after code freeze. 

As it turns out, we can just disable the workflows natively in git without making any changes to the workflow. Good to know for the future.

![image](https://github.com/GSA-TTS/FAC/assets/130377221/bb813725-e62d-4139-b127-1e190fc00a47)
