### PR TITLE
Tracking incorrect cluster totals

### DIFF
--- a/backend/audit/intakelib/checks/check_cluster_total.py
+++ b/backend/audit/intakelib/checks/check_cluster_total.py
@@ -6,7 +6,6 @@ from audit.intakelib.intermediate_representation import (
     get_range_by_name,
 )
 from audit.intakelib.common import get_message, build_cell_error_tuple
-from census_historical_migration.invalid_record import InvalidRecord
 
 logger = logging.getLogger(__name__)
 

--- a/backend/audit/intakelib/checks/check_cluster_total.py
+++ b/backend/audit/intakelib/checks/check_cluster_total.py
@@ -30,8 +30,7 @@ def cluster_total_is_correct(ir, is_data_migration=False):
 
     if (
         is_data_migration
-        and "cluster_total_is_correct"
-        in InvalidRecord.fields["validations_to_skip"]
+        and "cluster_total_is_correct" in InvalidRecord.fields["validations_to_skip"]
     ):
         # Skip this validation if it is an historical audit report with incorrect cluster total
         return errors

--- a/backend/audit/intakelib/checks/check_cluster_total.py
+++ b/backend/audit/intakelib/checks/check_cluster_total.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 # DESCRIPTION
 # The sum of the amount_expended for a given cluster should equal the corresponding cluster_total
 # K{0}=IF(G{0}="OTHER CLUSTER NOT LISTED ABOVE",SUMIFS(amount_expended,uniform_other_cluster_name,X{0}),IF(AND(OR(G{0}="N/A",G{0}=""),H{0}=""),0,IF(G{0}="STATE CLUSTER",SUMIFS(amount_expended,uniform_state_cluster_name,W{0}),SUMIFS(amount_expended,cluster_name,G{0}))))
-def cluster_total_is_correct(ir, is_data_migration=False):
+def cluster_total_is_correct(ir):
     uniform_other_cluster_names = get_range_values_by_name(
         ir, "uniform_other_cluster_name"
     )
@@ -27,13 +27,6 @@ def cluster_total_is_correct(ir, is_data_migration=False):
     amounts_expended = get_range_values_by_name(ir, "amount_expended")
 
     errors = []
-
-    if (
-        is_data_migration
-        and "cluster_total_is_correct" in InvalidRecord.fields["validations_to_skip"]
-    ):
-        # Skip this validation if it is an historical audit report with incorrect cluster total
-        return errors
 
     # Validating each cluster_total
     for idx, name in enumerate(cluster_names):

--- a/backend/audit/intakelib/checks/runners.py
+++ b/backend/audit/intakelib/checks/runners.py
@@ -168,29 +168,22 @@ def run_all_checks(
         # We want to make sure no one put in a GSA_MIGRATION keyword.
         check_for_gsa_migration_keyword(ir)
 
-    str_to_checks_lambdas = (
+    checks_with_special_args = (
         {  # Mapping these to prevent over-complexity in the loop below
-            "verify_auditee_uei_match": lambda: verify_auditee_uei_match(
-                ir, auditee_uei
+            verify_auditee_uei_match: lambda: verify_auditee_uei_match(
+                ir,
+                auditee_uei,
             ),
-            "cluster_total_is_correct": lambda: cluster_total_is_correct(
+            cluster_total_is_correct: lambda: cluster_total_is_correct(
                 ir,
                 is_data_migration,
             ),
         }
     )
-    checks_with_special_args = [verify_auditee_uei_match, cluster_total_is_correct]
-    str_to_checks_with_special_args = {
-        "verify_auditee_uei_match": verify_auditee_uei_match,
-        "cluster_total_is_correct": cluster_total_is_correct,
-    }
 
     for fun in list_of_checks:
         if fun in checks_with_special_args:
-            check_str = list(str_to_checks_with_special_args.keys())[
-                list(str_to_checks_with_special_args.values()).index(fun)
-            ]
-            res = str_to_checks_lambdas[check_str]()
+            res = checks_with_special_args[fun]()
         else:
             res = fun(ir)
 

--- a/backend/audit/intakelib/checks/runners.py
+++ b/backend/audit/intakelib/checks/runners.py
@@ -171,6 +171,8 @@ def run_all_checks(
     for fun in list_of_checks:
         if fun == verify_auditee_uei_match:
             res = fun(ir, auditee_uei)
+        elif fun == cluster_total_is_correct:
+            res = fun(ir, is_data_migration)
         else:
             res = fun(ir)
         if isinstance(res, list) and all(map(lambda v: isinstance(v, tuple), res)):

--- a/backend/audit/intakelib/checks/runners.py
+++ b/backend/audit/intakelib/checks/runners.py
@@ -168,18 +168,29 @@ def run_all_checks(
         # We want to make sure no one put in a GSA_MIGRATION keyword.
         check_for_gsa_migration_keyword(ir)
 
-    checks_with_special_args = (
+    str_to_checks_lambdas = (
         {  # Mapping these to prevent over-complexity in the loop below
-            verify_auditee_uei_match: lambda: verify_auditee_uei_match(ir, auditee_uei),
-            cluster_total_is_correct: lambda: cluster_total_is_correct(
-                ir, is_data_migration
+            "verify_auditee_uei_match": lambda: verify_auditee_uei_match(
+                ir, auditee_uei
+            ),
+            "cluster_total_is_correct": lambda: cluster_total_is_correct(
+                ir,
+                is_data_migration,
             ),
         }
     )
+    checks_with_special_args = [verify_auditee_uei_match, cluster_total_is_correct]
+    str_to_checks_with_special_args = {
+        "verify_auditee_uei_match": verify_auditee_uei_match,
+        "cluster_total_is_correct": cluster_total_is_correct,
+    }
 
     for fun in list_of_checks:
         if fun in checks_with_special_args:
-            res = checks_with_special_args[fun]
+            check_str = list(str_to_checks_with_special_args.keys())[
+                list(str_to_checks_with_special_args.values()).index(fun)
+            ]
+            res = str_to_checks_lambdas[check_str]()
         else:
             res = fun(ir)
 

--- a/backend/audit/intakelib/checks/runners.py
+++ b/backend/audit/intakelib/checks/runners.py
@@ -197,6 +197,7 @@ def check_for_gsa_migration_keyword_if_needed(ir, is_data_migration):
     if not is_data_migration:
         check_for_gsa_migration_keyword(ir)
 
+
 def get_key_by_value(d, target_value):
     keys = [key for key, value in d.items() if value == target_value]
     return keys[0] if keys else None

--- a/backend/audit/intakelib/checks/runners.py
+++ b/backend/audit/intakelib/checks/runners.py
@@ -149,7 +149,8 @@ secondary_auditors_checks = general_checks + [
 ]
 
 skippable_checks = {
-    "federal_program_total_is_correct": federal_program_total_is_correct
+    "federal_program_total_is_correct": federal_program_total_is_correct,
+    "cluster_total_is_correct": cluster_total_is_correct
 }
 
 
@@ -205,18 +206,6 @@ def get_key_by_value(d, target_value):
 
 def run_check(fun, ir, is_data_migration, auditee_uei):
     """Run the validation check if it is not skippable, or if it is skippable, only run if this is not a data migration."""
-    checks_with_special_args = (
-        {  # Mapping these to prevent over-complexity in the loop below
-            verify_auditee_uei_match: lambda: verify_auditee_uei_match(
-                ir,
-                auditee_uei,
-            ),
-            cluster_total_is_correct: lambda: cluster_total_is_correct(
-                ir,
-                is_data_migration,
-            ),
-        }
-    )
 
     fun_name = get_key_by_value(skippable_checks, fun)
     if (
@@ -225,8 +214,8 @@ def run_check(fun, ir, is_data_migration, auditee_uei):
         and fun_name in InvalidRecord.fields["validations_to_skip"]
     ):
         return None
-    elif fun in checks_with_special_args:
-        return checks_with_special_args[fun]()
+    elif fun == verify_auditee_uei_match:
+        return fun(ir, auditee_uei)
     else:
         return fun(ir)
 

--- a/backend/audit/intakelib/checks/runners.py
+++ b/backend/audit/intakelib/checks/runners.py
@@ -150,7 +150,7 @@ secondary_auditors_checks = general_checks + [
 
 skippable_checks = {
     "federal_program_total_is_correct": federal_program_total_is_correct,
-    "cluster_total_is_correct": cluster_total_is_correct
+    "cluster_total_is_correct": cluster_total_is_correct,
 }
 
 

--- a/backend/audit/intakelib/checks/runners.py
+++ b/backend/audit/intakelib/checks/runners.py
@@ -149,8 +149,8 @@ secondary_auditors_checks = general_checks + [
 ]
 
 skippable_checks = {
-    "federal_program_total_is_correct": federal_program_total_is_correct,
     "cluster_total_is_correct": cluster_total_is_correct,
+    "federal_program_total_is_correct": federal_program_total_is_correct,
 }
 
 
@@ -206,7 +206,6 @@ def get_key_by_value(d, target_value):
 
 def run_check(fun, ir, is_data_migration, auditee_uei):
     """Run the validation check if it is not skippable, or if it is skippable, only run if this is not a data migration."""
-
     fun_name = get_key_by_value(skippable_checks, fun)
     if (
         is_data_migration

--- a/backend/census_historical_migration/invalid_migration_tags.py
+++ b/backend/census_historical_migration/invalid_migration_tags.py
@@ -2,3 +2,4 @@ class INVALID_MIGRATION_TAGS:
     """Constants for invalid migration tags."""
 
     DUPLICATE_FINDING_REFERENCE_NUMBERS = "duplicate_finding_reference_numbers"
+    INCORRECT_CLUSTER_TOTAL = "incorrect_cluster_total"

--- a/backend/census_historical_migration/test_federal_awards_xforms.py
+++ b/backend/census_historical_migration/test_federal_awards_xforms.py
@@ -3,9 +3,7 @@ from django.conf import settings
 from django.test import SimpleTestCase
 
 from .invalid_migration_tags import INVALID_MIGRATION_TAGS
-
 from .invalid_record import InvalidRecord
-
 from .transforms.xform_string_to_string import (
     string_to_string,
 )

--- a/backend/census_historical_migration/test_federal_awards_xforms.py
+++ b/backend/census_historical_migration/test_federal_awards_xforms.py
@@ -583,7 +583,12 @@ class TestXformMissingClusterTotal(SimpleTestCase):
             [
                 [
                     {
-                        "census_data": [{"column": "CLUSTERTOTAL", "value": 33}],
+                        "census_data": [
+                            {"column": "CLUSTERTOTAL", "value": 33},
+                            {'column': 'CLUSTERNAME', 'value': 'Cluster A'},
+                            {'column': 'STATECLUSTERNAME', 'value': ''},
+                            {'column': 'OTHERCLUSTERNAME', 'value': ''},
+                        ],
                         "gsa_fac_data": {"field": "cluster_total", "value": 150},
                     }
                 ]

--- a/backend/census_historical_migration/test_federal_awards_xforms.py
+++ b/backend/census_historical_migration/test_federal_awards_xforms.py
@@ -579,10 +579,14 @@ class TestXformMissingClusterTotal(SimpleTestCase):
         )
         self.assertEqual(
             InvalidRecord.fields["federal_award"],
-            [[{
-                'census_data': [{'column': 'CLUSTERTOTAL', 'value': 33}],
-                'gsa_fac_data': {'field': 'cluster_total', 'value': 150},
-            }]],
+            [
+                [
+                    {
+                        "census_data": [{"column": "CLUSTERTOTAL", "value": 33}],
+                        "gsa_fac_data": {"field": "cluster_total", "value": 150},
+                    }
+                ]
+            ],
         )
 
 

--- a/backend/census_historical_migration/test_federal_awards_xforms.py
+++ b/backend/census_historical_migration/test_federal_awards_xforms.py
@@ -585,9 +585,9 @@ class TestXformMissingClusterTotal(SimpleTestCase):
                     {
                         "census_data": [
                             {"column": "CLUSTERTOTAL", "value": 33},
-                            {'column': 'CLUSTERNAME', 'value': 'Cluster A'},
-                            {'column': 'STATECLUSTERNAME', 'value': ''},
-                            {'column': 'OTHERCLUSTERNAME', 'value': ''},
+                            {"column": "CLUSTERNAME", "value": "Cluster A"},
+                            {"column": "STATECLUSTERNAME", "value": ""},
+                            {"column": "OTHERCLUSTERNAME", "value": ""},
                         ],
                         "gsa_fac_data": {"field": "cluster_total", "value": 150},
                     }

--- a/backend/census_historical_migration/test_federal_awards_xforms.py
+++ b/backend/census_historical_migration/test_federal_awards_xforms.py
@@ -26,7 +26,6 @@ from .workbooklib.federal_awards import (
     xform_cluster_names,
     xform_sanitize_additional_award_identification,
 )
-from census_historical_migration.invalid_migration_tags import INVALID_MIGRATION_TAGS
 from census_historical_migration.invalid_record import InvalidRecord
 
 

--- a/backend/census_historical_migration/test_federal_awards_xforms.py
+++ b/backend/census_historical_migration/test_federal_awards_xforms.py
@@ -31,7 +31,6 @@ from .workbooklib.federal_awards import (
     xform_cluster_names,
     xform_sanitize_additional_award_identification,
 )
-from census_historical_migration.invalid_record import InvalidRecord
 
 
 class TestXformConstructsClusterNames(SimpleTestCase):

--- a/backend/census_historical_migration/test_federal_awards_xforms.py
+++ b/backend/census_historical_migration/test_federal_awards_xforms.py
@@ -12,7 +12,7 @@ from .workbooklib.federal_awards import (
     xform_match_number_passthrough_names_ids,
     xform_missing_amount_expended,
     xform_missing_program_total,
-    xform_missing_cluster_total,
+    xform_missing_cluster_total_v2,
     xform_populate_default_award_identification_values,
     xform_populate_default_loan_balance,
     xform_constructs_cluster_names,
@@ -483,7 +483,7 @@ class TestXformMissingClusterTotal(SimpleTestCase):
         state_cluster_names = ["", "", ""]
         expected_totals = ["250", "150", "250"]
 
-        xform_missing_cluster_total(
+        xform_missing_cluster_total_v2(
             audits, cluster_names, other_cluster_names, state_cluster_names
         )
 
@@ -515,7 +515,7 @@ class TestXformMissingClusterTotal(SimpleTestCase):
         state_cluster_names = ["", "State Cluster A", "", "State Cluster A"]
         expected_totals = ["250", "300", "250", "300"]
 
-        xform_missing_cluster_total(
+        xform_missing_cluster_total_v2(
             audits, cluster_names, other_cluster_names, state_cluster_names
         )
 
@@ -547,7 +547,7 @@ class TestXformMissingClusterTotal(SimpleTestCase):
         other_cluster_names = ["", "Other Cluster A", "", "Other Cluster A"]
         expected_totals = ["250", "300", "250", "300"]
 
-        xform_missing_cluster_total(
+        xform_missing_cluster_total_v2(
             audits, cluster_names, other_cluster_names, state_cluster_names
         )
 

--- a/backend/census_historical_migration/workbooklib/federal_awards.py
+++ b/backend/census_historical_migration/workbooklib/federal_awards.py
@@ -1,4 +1,6 @@
 from audit.intakelib.checks.check_cluster_total import expected_cluster_total
+from ..invalid_migration_tags import INVALID_MIGRATION_TAGS
+from ..invalid_record import InvalidRecord
 from ..transforms.xform_retrieve_uei import xform_retrieve_uei
 from ..transforms.xform_string_to_int import string_to_int
 from ..transforms.xform_string_to_string import string_to_string
@@ -10,6 +12,7 @@ from .excel_creation_utils import (
     map_simple_columns,
     set_range,
     sort_by_field,
+    track_invalid_records,
     track_transformations,
 )
 from ..base_field_maps import (
@@ -28,6 +31,7 @@ from ..change_record import (
     InspectionRecord,
     GsaFacRecord,
 )
+
 
 import openpyxl as pyxl
 
@@ -206,7 +210,7 @@ def xform_missing_cluster_total(
     other_cluster_names,
     state_cluster_names,
 ):
-    """Calculates missing cluster total for each award."""
+    """Calculates missing cluster total for each award. This method is now deprecated."""
     uniform_state_cluster_names = [name.upper() for name in state_cluster_names]
     uniform_other_cluster_names = [name.upper() for name in other_cluster_names]
     amounts_expended = [
@@ -247,6 +251,78 @@ def xform_missing_cluster_total(
     # See Transformation Method Change Recording at the top of this file.
     if change_records and is_empty_cluster_total_found:
         InspectionRecord.append_federal_awards_changes(change_records)
+
+
+def xform_missing_cluster_total_v2(
+    audits,
+    cluster_names,
+    other_cluster_names,
+    state_cluster_names,
+):
+    """Calculates missing cluster total for each award."""
+    uniform_state_cluster_names = [name.upper() for name in state_cluster_names]
+    uniform_other_cluster_names = [name.upper() for name in other_cluster_names]
+    amounts_expended = [
+        string_to_int(audit.AMOUNT) if string_to_string(audit.AMOUNT) else 0
+        for audit in audits
+    ]
+
+    change_records = []
+    invalid_records = []
+    is_empty_cluster_total_found = False
+
+    for idx, (name, audit) in enumerate(zip(cluster_names, audits)):
+        cluster_total = string_to_string(audit.CLUSTERTOTAL)
+        if not cluster_total:
+            is_empty_cluster_total_found = True
+        else:
+            cluster_total = string_to_int(cluster_total)
+
+        gsa_cluster_total = expected_cluster_total(
+            idx=idx,
+            name=name,
+            uniform_other_cluster_names=uniform_other_cluster_names,
+            uniform_state_cluster_names=uniform_state_cluster_names,
+            state_cluster_names=state_cluster_names,
+            cluster_names=cluster_names,
+            amounts_expended=amounts_expended,
+        )
+
+        if cluster_total != '' and cluster_total != gsa_cluster_total:
+            census_data_tuples = [
+                ("CLUSTERTOTAL", audit.CLUSTERTOTAL),
+            ]
+            track_invalid_records(
+                census_data_tuples,
+                "cluster_total",
+                gsa_cluster_total,
+                invalid_records,
+            )
+        else:
+            cluster_total = gsa_cluster_total
+
+        track_transformations(
+            "CLUSTERTOTAL",
+            audit.CLUSTERTOTAL,
+            "cluster_total",
+            cluster_total,
+            ["xform_missing_cluster_total_v2"],
+            change_records,
+        )
+        audit.CLUSTERTOTAL = str(cluster_total)
+
+    # See Transformation Method Change Recording at the top of this file.
+    if change_records and is_empty_cluster_total_found:
+        InspectionRecord.append_federal_awards_changes(change_records)
+
+    if invalid_records:
+        InvalidRecord.append_invalid_federal_awards_records(invalid_records)
+        InvalidRecord.append_validations_to_skip(
+            "cluster_total_is_correct"
+        )
+        InvalidRecord.append_invalid_migration_tag(
+            INVALID_MIGRATION_TAGS.INCORRECT_CLUSTER_TOTAL,
+        )
 
 
 def xform_is_passthrough_award(audits):
@@ -704,7 +780,7 @@ def generate_federal_awards(audit_header, outfile):
         state_cluster_names,
     ) = xform_constructs_cluster_names(audits)
 
-    xform_missing_cluster_total(
+    xform_missing_cluster_total_v2(
         audits, cluster_names, other_cluster_names, state_cluster_names
     )
     xform_missing_program_total(audits)

--- a/backend/census_historical_migration/workbooklib/federal_awards.py
+++ b/backend/census_historical_migration/workbooklib/federal_awards.py
@@ -288,13 +288,18 @@ def xform_missing_cluster_total_v2(
             amounts_expended=amounts_expended,
         )
 
-        if not is_empty_cluster_total_found and cluster_total != gsa_cluster_total:
+        if cluster_total != "" and cluster_total != gsa_cluster_total:
             is_incorrect_cluster_total_found = True
         else:
             cluster_total = gsa_cluster_total
 
         track_invalid_records(
-            [("CLUSTERTOTAL", cluster_total)],
+            [
+                ("CLUSTERTOTAL", cluster_total),
+                ("CLUSTERNAME", audit.CLUSTERNAME),
+                ("STATECLUSTERNAME", audit.STATECLUSTERNAME),
+                ("OTHERCLUSTERNAME", audit.OTHERCLUSTERNAME),
+            ],
             "cluster_total",
             gsa_cluster_total,
             invalid_records,

--- a/backend/census_historical_migration/workbooklib/federal_awards.py
+++ b/backend/census_historical_migration/workbooklib/federal_awards.py
@@ -290,7 +290,7 @@ def xform_missing_cluster_total_v2(
 
         if cluster_total != '' and cluster_total != gsa_cluster_total:
             census_data_tuples = [
-                ("CLUSTERTOTAL", audit.CLUSTERTOTAL),
+                ("CLUSTERTOTAL", cluster_total),
             ]
             track_invalid_records(
                 census_data_tuples,

--- a/backend/census_historical_migration/workbooklib/federal_awards.py
+++ b/backend/census_historical_migration/workbooklib/federal_awards.py
@@ -32,7 +32,6 @@ from ..change_record import (
     GsaFacRecord,
 )
 
-
 import openpyxl as pyxl
 
 import logging
@@ -288,7 +287,7 @@ def xform_missing_cluster_total_v2(
             amounts_expended=amounts_expended,
         )
 
-        if cluster_total != '' and cluster_total != gsa_cluster_total:
+        if cluster_total != "" and cluster_total != gsa_cluster_total:
             census_data_tuples = [
                 ("CLUSTERTOTAL", cluster_total),
             ]
@@ -317,9 +316,7 @@ def xform_missing_cluster_total_v2(
 
     if invalid_records:
         InvalidRecord.append_invalid_federal_awards_records(invalid_records)
-        InvalidRecord.append_validations_to_skip(
-            "cluster_total_is_correct"
-        )
+        InvalidRecord.append_validations_to_skip("cluster_total_is_correct")
         InvalidRecord.append_invalid_migration_tag(
             INVALID_MIGRATION_TAGS.INCORRECT_CLUSTER_TOTAL,
         )


### PR DESCRIPTION
Closes https://github.com/GSA-TTS/FAC/issues/3686

In this PR:
- Some historic audits contain cluster totals that are incorrect, which (correctly) fails our validations. Removing these incorrect values is ideally avoided since these audits have already been accepted/approved.
- This fix adds logic to cluster total xform to track incorrect cluster totals
- Using `is_data_migration` to determine if the validation should be skipped
- `run_all_checks` now has a map for method with special args, otherwise the linter complained all the ifs/elses were getting too complex
- Adding unit test

Testing:
- Find an audit in the elecaudits table with an incorrect `CLUSTERTOTAL`, or create one that already exists (set some existing number to 0, for example)
- Run `historic_data_migrator` on that audit and it should migrate without issue
- The `cluster_total` value in the dissemination_federalawards table should be your invalid value
- If using preview data, dbkey 135840, audit year 2021 should pass
- Cross validation should pass as normal when creating an audit in the app

## PR checklist: submitters

- [ ]   Link to an issue if possible. If there’s no issue, describe what your branch does. Even if there is an issue, a brief description in the PR is still useful.
- [ ]   List any special steps reviewers have to follow to test the PR. For example, adding a local environment variable, creating a local test file, etc.
- [ ]   For extra credit, submit a screen recording like [this one](https://github.com/GSA-TTS/FAC/pull/1821).
- [ ]   Make sure you’ve merged `main` into your branch shortly before creating the PR. (You should also be merging `main` into your branch regularly during development.)
- [ ]   Make sure you’ve accounted for any migrations. When you’re about to create the PR, bring up the application locally and then run `git status | grep migrations`. If there are any results, you probably need to add them to the branch for the PR. Your PR should have only **one** new migration file for each of the component apps, except in rare circumstances; you may need to delete some and re-run `python manage.py makemigrations` to reduce the number to one. (Also, unless in exceptional circumstances, your PR should not delete any migration files.)
- [ ]   Make sure that whatever feature you’re adding has tests that cover the feature. This includes test coverage to make sure that the previous workflow still works, if applicable.
- [ ]   Make sure the full-submission.cy.js [Cypress test](https://github.com/GSA-TTS/FAC/blob/main/docs/testing.md#end-to-end-testing) passes, if applicable.
- [ ]   Do manual testing locally. Our tests are not good enough yet to allow us to skip this step. If that’s not applicable for some reason, check this box.
- [ ]   Verify that no Git surgery was necessary, or, if it was necessary at any point, repeat the testing after it’s finished.
- [ ]   Once a PR is merged, keep an eye on it until it’s deployed to dev, and do enough testing on dev to verify that it deployed successfully, the feature works as expected, and the happy path for the broad feature area (such as submission) still works.

## PR checklist: reviewers

- [ ]   Pull the branch to your local environment and run `make docker-clean; make docker-first-run && docker compose up`; then run `docker compose exec web /bin/bash -c "python manage.py test"`
- [ ]   Manually test out the changes locally, or check this box to verify that it wasn’t applicable in this case.
- [ ]   Check that the PR has appropriate tests. Look out for changes in HTML/JS/JSON Schema logic that may need to be captured in Python tests even though the logic isn’t in Python.
- [ ]   Verify that no Git surgery is necessary at any point (such as during a merge party), or, if it was, repeat the testing after it’s finished.

The larger the PR, the stricter we should be about these points.
