### PR TITLE
3688 address historical federal program totals that are incorrect

### DIFF
--- a/backend/audit/intakelib/checks/runners.py
+++ b/backend/audit/intakelib/checks/runners.py
@@ -1,6 +1,8 @@
 from django.core.exceptions import ValidationError
 import logging
 
+from census_historical_migration.invalid_record import InvalidRecord
+
 from .check_finding_award_references_pattern import award_references_pattern
 from .check_cluster_names import check_cluster_names
 from audit.fixtures.excel import FORM_SECTIONS
@@ -146,43 +148,90 @@ secondary_auditors_checks = general_checks + [
     has_all_required_fields(FORM_SECTIONS.SECONDARY_AUDITORS),
 ]
 
+skippable_checks = {
+    "federal_program_total_is_correct": federal_program_total_is_correct
+}
+
 
 def run_all_checks(
     ir, list_of_checks, section_name=None, is_data_migration=False, auditee_uei=None
 ):
+    """Run all the checks in the list_of_checks on the IR.
+    If a section_name is provided, run the section check as well.
+    If this is a data migration, then there are some checks we do not want to run.
+    If this is not a data migration, then we want to make sure no one put in a GSA_MIGRATION keyword.
+    """
     errors = []
+
+    errors += run_section_check(ir, section_name)
+    list_of_checks = filter_checks_for_data_migration(list_of_checks, is_data_migration)
+    check_for_gsa_migration_keyword_if_needed(ir, is_data_migration)
+
+    for fun in list_of_checks:
+        res = run_check(fun, ir, is_data_migration, auditee_uei)
+        errors += process_check_result(res)
+
+    log_errors(errors)
+    if errors:
+        raise ValidationError(errors)
+
+
+def run_section_check(ir, section_name):
+    """Run the section check if it is provided."""
     if section_name:
         res = is_right_workbook(section_name)(ir)
         if res:
-            errors.append(res)
+            return [res]
+    return []
 
-    # If this is a data migration, then there are some checks we do not want to run.
-    #
-    if is_data_migration:
-        if list_of_checks == federal_awards_checks:
-            list_of_checks = list(
-                filter(lambda f: f != check_cluster_names, list_of_checks)
-            )
-    else:
-        # This is not a data migration.
-        # We want to make sure no one put in a GSA_MIGRATION keyword.
+
+def filter_checks_for_data_migration(list_of_checks, is_data_migration):
+    """If this is a data migration, then there are some checks we do not want to run."""
+    if is_data_migration and list_of_checks == federal_awards_checks:
+        return list(filter(lambda f: f != check_cluster_names, list_of_checks))
+    return list_of_checks
+
+
+def check_for_gsa_migration_keyword_if_needed(ir, is_data_migration):
+    """If this is not a data migration, then we want to make sure no one put in a GSA_MIGRATION keyword."""
+    if not is_data_migration:
         check_for_gsa_migration_keyword(ir)
 
-    for fun in list_of_checks:
-        if fun == verify_auditee_uei_match:
-            res = fun(ir, auditee_uei)
-        else:
-            res = fun(ir)
-        if isinstance(res, list) and all(map(lambda v: isinstance(v, tuple), res)):
-            errors = errors + res
-        elif isinstance(res, tuple):
-            errors.append(res)
-        else:
-            pass
+
+def get_key_by_value(d, target_value):
+    keys = [key for key, value in d.items() if value == target_value]
+    return keys[0] if keys else None
+
+
+def run_check(fun, ir, is_data_migration, auditee_uei):
+    """Run the validation check if it is not skippable, or if it is skippable, only run if this is not a data migration."""
+    fun_name = get_key_by_value(skippable_checks, fun)
+    if fun == verify_auditee_uei_match:
+        return fun(ir, auditee_uei)
+    elif (
+        is_data_migration
+        and fun_name
+        and fun_name in InvalidRecord.fields["validations_to_skip"]
+    ):
+        return None
+    else:
+        return fun(ir)
+
+
+def process_check_result(res):
+    """Process the result of a validation check and return a list of errors."""
+    if isinstance(res, list) and all(map(lambda v: isinstance(v, tuple), res)):
+        return res
+    elif isinstance(res, tuple):
+        return [res]
+    return []
+
+
+def log_errors(errors):
+    """Log the number of errors found in the IR passes."""
     logger.info(f"Found {len(errors)} errors in the IR passes.")
-    if len(errors) > 0:
+    if errors:
         logger.info("Raising a validation error.")
-        raise ValidationError(errors)
 
 
 def run_all_general_checks(ir, section_name, is_data_migration=False, auditee_uei=None):

--- a/backend/audit/intakelib/checks/runners.py
+++ b/backend/audit/intakelib/checks/runners.py
@@ -206,14 +206,14 @@ def get_key_by_value(d, target_value):
 def run_check(fun, ir, is_data_migration, auditee_uei):
     """Run the validation check if it is not skippable, or if it is skippable, only run if this is not a data migration."""
     fun_name = get_key_by_value(skippable_checks, fun)
-    if fun == verify_auditee_uei_match:
-        return fun(ir, auditee_uei)
-    elif (
+    if (
         is_data_migration
         and fun_name
         and fun_name in InvalidRecord.fields["validations_to_skip"]
     ):
         return None
+    elif fun == verify_auditee_uei_schema:
+        return fun(ir, auditee_uei)
     else:
         return fun(ir)
 

--- a/backend/audit/intakelib/checks/runners.py
+++ b/backend/audit/intakelib/checks/runners.py
@@ -212,7 +212,7 @@ def run_check(fun, ir, is_data_migration, auditee_uei):
         and fun_name in InvalidRecord.fields["validations_to_skip"]
     ):
         return None
-    elif fun == verify_auditee_uei_schema:
+    elif fun == verify_auditee_uei_match:
         return fun(ir, auditee_uei)
     else:
         return fun(ir)

--- a/backend/census_historical_migration/invalid_migration_tags.py
+++ b/backend/census_historical_migration/invalid_migration_tags.py
@@ -1,4 +1,5 @@
 class INVALID_MIGRATION_TAGS:
     """Constants for invalid migration tags."""
 
+    INVALID_FEDERAL_PROGRAM_TOTAL = "invalid_federal_program_total"
     DUPLICATE_FINDING_REFERENCE_NUMBERS = "duplicate_finding_reference_numbers"

--- a/backend/census_historical_migration/test_federal_awards_xforms.py
+++ b/backend/census_historical_migration/test_federal_awards_xforms.py
@@ -2,6 +2,10 @@ from unittest.mock import patch
 from django.conf import settings
 from django.test import SimpleTestCase
 
+from .invalid_migration_tags import INVALID_MIGRATION_TAGS
+
+from .invalid_record import InvalidRecord
+
 from .transforms.xform_string_to_string import (
     string_to_string,
 )
@@ -9,6 +13,7 @@ from .transforms.xform_string_to_string import (
 from .exception_utils import DataMigrationError
 from .workbooklib.federal_awards import (
     is_valid_prefix,
+    track_invalid_federal_program_total,
     xform_match_number_passthrough_names_ids,
     xform_missing_amount_expended,
     xform_missing_program_total,
@@ -758,3 +763,55 @@ class TestXformSanitizeAdditionalAwardIdentification(SimpleTestCase):
         expected = ["", None, "12345"]
         result = xform_sanitize_additional_award_identification(audits, identifications)
         self.assertEqual(result, expected)
+
+
+class TestTrackInvalidFederalProgramTotal(SimpleTestCase):
+    class MockAudit:
+        def __init__(self, PROGRAMTOTAL, AMOUNT):
+            self.PROGRAMTOTAL = PROGRAMTOTAL
+            self.AMOUNT = AMOUNT
+
+    def setUp(self):
+        self.audits = [
+            self.MockAudit(PROGRAMTOTAL="100", AMOUNT="50"),
+            self.MockAudit(PROGRAMTOTAL="200", AMOUNT="200"),
+            self.MockAudit(PROGRAMTOTAL="150", AMOUNT="100"),
+        ]
+        self.cfda_key_values = ["1234", "5678", "1234"]
+
+        # Reset InvalidRecord before each test
+        InvalidRecord.reset()
+
+    def test_track_invalid_federal_program_total(self):
+        """Test for invalid federal program total"""
+
+        track_invalid_federal_program_total(self.audits, self.cfda_key_values)
+
+        # Check the results in InvalidRecord
+        self.assertEqual(len(InvalidRecord.fields["federal_award"]), 1)
+        self.assertIn(
+            "federal_program_total_is_correct",
+            InvalidRecord.fields["validations_to_skip"],
+        )
+        self.assertIn(
+            INVALID_MIGRATION_TAGS.INVALID_FEDERAL_PROGRAM_TOTAL,
+            InvalidRecord.fields["invalid_migration_tag"],
+        )
+
+    def test_no_invalid_federal_program_total(self):
+        # Adjust mock data for no invalid records
+        self.audits = [
+            self.MockAudit(PROGRAMTOTAL="150", AMOUNT="50"),
+            self.MockAudit(PROGRAMTOTAL="200", AMOUNT="200"),
+            self.MockAudit(PROGRAMTOTAL="150", AMOUNT="100"),
+        ]
+
+        track_invalid_federal_program_total(self.audits, self.cfda_key_values)
+
+        # Check that no invalid records are added
+        self.assertEqual(len(InvalidRecord.fields["federal_award"]), 0)
+        self.assertNotIn(
+            "federal_program_total_is_correct",
+            InvalidRecord.fields["validations_to_skip"],
+        )
+        self.assertNotIn

--- a/backend/census_historical_migration/workbooklib/excel_creation_utils.py
+++ b/backend/census_historical_migration/workbooklib/excel_creation_utils.py
@@ -79,6 +79,17 @@ def set_range(wb, range_name, values, default=None, conversion_fun=str):
         ws.cell(row=row, column=col, value=converted_value)
 
 
+def get_range_values(in_db_name, records, default, conversion_fun):
+    """Helper to get a range of values."""
+    values = map(lambda r: getattr(r, in_db_name), records)
+    values_in_worksheet = []
+    for value in values:
+        converted_value = apply_conversion_function(value, default, conversion_fun)
+        values_in_worksheet.append(converted_value)
+
+    return values_in_worksheet
+
+
 def apply_conversion_function(value, default, conversion_function):
     """
     Helper to apply a conversion function to a value, or use a default value

--- a/backend/census_historical_migration/workbooklib/federal_awards.py
+++ b/backend/census_historical_migration/workbooklib/federal_awards.py
@@ -709,6 +709,8 @@ def track_invalid_federal_program_total(audits, cfda_key_values):
 
         census_data_tuples = [
             ("PROGRAMTOTAL", federal_program_total_values[idx]),
+            ("AMOUNT", amount_expended_values[idx]),
+            ("CFDA", key),
         ]
         track_invalid_records(
             census_data_tuples,

--- a/backend/census_historical_migration/workbooklib/federal_awards.py
+++ b/backend/census_historical_migration/workbooklib/federal_awards.py
@@ -1,4 +1,5 @@
 from audit.intakelib.checks.check_cluster_total import expected_cluster_total
+from ..invalid_migration_tags import INVALID_MIGRATION_TAGS
 from ..transforms.xform_retrieve_uei import xform_retrieve_uei
 from ..transforms.xform_string_to_int import string_to_int
 from ..transforms.xform_string_to_string import string_to_string
@@ -6,10 +7,12 @@ from ..transforms.xform_uppercase_y_or_n import uppercase_y_or_n
 from ..exception_utils import DataMigrationError
 from .excel_creation_utils import (
     get_audits,
+    get_range_values,
     set_workbook_uei,
     map_simple_columns,
     set_range,
     sort_by_field,
+    track_invalid_records,
     track_transformations,
 )
 from ..base_field_maps import (
@@ -28,7 +31,7 @@ from ..change_record import (
     InspectionRecord,
     GsaFacRecord,
 )
-
+from ..invalid_record import InvalidRecord
 import openpyxl as pyxl
 
 import logging
@@ -682,6 +685,46 @@ def xform_cluster_names(audits):
     return audits
 
 
+def track_invalid_federal_program_total(audits, cfda_key_values):
+    """
+    Tracks invalid federal program totals.
+    """
+    federal_program_total_values = get_range_values("PROGRAMTOTAL", audits, None, int)
+    amount_expended_values = get_range_values("AMOUNT", audits, None, int)
+    invalid_records = []
+    amount_expended_values = get_range_values("AMOUNT", audits, None, int)
+    has_invalid_federal_program_total = False
+    # Validating each federal_program_total
+    for idx, key in enumerate(cfda_key_values):
+        # Compute the sum for current cfda_key
+        computed_sum = sum(
+            [
+                amount
+                for k, amount in zip(cfda_key_values, amount_expended_values)
+                if k == key
+            ]
+        )
+        if computed_sum != federal_program_total_values[idx]:
+            has_invalid_federal_program_total = True
+
+        census_data_tuples = [
+            ("PROGRAMTOTAL", federal_program_total_values[idx]),
+        ]
+        track_invalid_records(
+            census_data_tuples,
+            "federal_program_total",
+            computed_sum,
+            invalid_records,
+        )
+
+    if has_invalid_federal_program_total and invalid_records:
+        InvalidRecord.append_invalid_federal_awards_records(invalid_records)
+        InvalidRecord.append_validations_to_skip("federal_program_total_is_correct")
+        InvalidRecord.append_invalid_migration_tag(
+            INVALID_MIGRATION_TAGS.INVALID_FEDERAL_PROGRAM_TOTAL
+        )
+
+
 def generate_federal_awards(audit_header, outfile):
     """
     Generates a federal awards workbook for all awards associated with a given audit header.
@@ -779,7 +822,7 @@ def generate_federal_awards(audit_header, outfile):
         "loan_balance_at_audit_period_end",
         loan_balances,
     )
-
+    track_invalid_federal_program_total(audits, full_cfdas)
     # Total amount expended must be calculated and inserted
     total = 0
     for audit in audits:


### PR DESCRIPTION
## Description

Some historical reports failed migration due to incorrect federal program total in the federal awards section. Our current validation rule does not allow incorrect federal program total in the federal awards workbook. The team has decided to migrate these reports as is by skipping that validation rule for those specific reports. This PR addresses that issue. The solution involves:

- Adding logic to look for incorrect federal program total in federal awards records before the creation of the federal awards workbook in the migration module.
- When a duplicate is detected, tracking the bad records and setting a global flag that will allow the report to bypass the corresponding validation rule once it reaches that logic.
- If the report does not break any other validation rule, saving the tracked bad records into the InvalidAuditRecord table and updating the ReportMigrationStatus table; otherwise, clearing the track.
- Clear the flag

## To test:

1. Launch the stack from the main branch.
2. Attempt to migrate the audit report with `dbkey = 182165` and `audit_year = 2022` and notice the migration failure.
3. Switch to this PR branch and re-run the migration for the same report and observe that it processes properly.
4. Check the InvalidAuditRecord table and ReportMigrationStatus table for records related to this audit.

## PR checklist: submitters

- [ ]   Link to an issue if possible. If there’s no issue, describe what your branch does. Even if there is an issue, a brief description in the PR is still useful.
- [ ]   List any special steps reviewers have to follow to test the PR. For example, adding a local environment variable, creating a local test file, etc.
- [ ]   For extra credit, submit a screen recording like [this one](https://github.com/GSA-TTS/FAC/pull/1821).
- [ ]   Make sure you’ve merged `main` into your branch shortly before creating the PR. (You should also be merging `main` into your branch regularly during development.)
- [ ]   Make sure you’ve accounted for any migrations. When you’re about to create the PR, bring up the application locally and then run `git status | grep migrations`. If there are any results, you probably need to add them to the branch for the PR. Your PR should have only **one** new migration file for each of the component apps, except in rare circumstances; you may need to delete some and re-run `python manage.py makemigrations` to reduce the number to one. (Also, unless in exceptional circumstances, your PR should not delete any migration files.)
- [ ]   Make sure that whatever feature you’re adding has tests that cover the feature. This includes test coverage to make sure that the previous workflow still works, if applicable.
- [ ]   Make sure the full-submission.cy.js [Cypress test](https://github.com/GSA-TTS/FAC/blob/main/docs/testing.md#end-to-end-testing) passes, if applicable.
- [ ]   Do manual testing locally. Our tests are not good enough yet to allow us to skip this step. If that’s not applicable for some reason, check this box.
- [ ]   Verify that no Git surgery was necessary, or, if it was necessary at any point, repeat the testing after it’s finished.
- [ ]   Once a PR is merged, keep an eye on it until it’s deployed to dev, and do enough testing on dev to verify that it deployed successfully, the feature works as expected, and the happy path for the broad feature area (such as submission) still works.

## PR checklist: reviewers

- [ ]   Pull the branch to your local environment and run `make docker-clean; make docker-first-run && docker compose up`; then run `docker compose exec web /bin/bash -c "python manage.py test"`
- [ ]   Manually test out the changes locally, or check this box to verify that it wasn’t applicable in this case.
- [ ]   Check that the PR has appropriate tests. Look out for changes in HTML/JS/JSON Schema logic that may need to be captured in Python tests even though the logic isn’t in Python.
- [ ]   Verify that no Git surgery is necessary at any point (such as during a merge party), or, if it was, repeat the testing after it’s finished.

The larger the PR, the stricter we should be about these points.
