### PR TITLE
Bug: Sorting a Search b y Cog/Over Yields 500

### DIFF
--- a/backend/dissemination/search.py
+++ b/backend/dissemination/search.py
@@ -37,6 +37,9 @@ logger = logging.getLogger(__name__)
 
 
 def is_advanced_search(params_dict):
+    """
+    Returns True if the 'advanced_search_flag' param is True.
+    """
     return params_dict.get("advanced_search_flag")
 
 
@@ -59,7 +62,6 @@ def search(params):
     if is_advanced_search(params):
         logger.info("search Searching `DisseminationCombined`")
         results = search_general(DisseminationCombined, params)
-        results = _sort_results(results, params)
         results = search_alns(results, params)
         results = search_findings(results, params)
         results = search_direct_funding(results, params)
@@ -69,9 +71,9 @@ def search(params):
     else:
         logger.info("search Searching `General`")
         results = search_general(General, params)
-        results = _sort_results(results, params)
 
-    results = results.distinct("report_id", params.get("order_by", "fac_accepted_date"))
+    results = _sort_results(results, params)
+    results = _make_distinct(results, params)
 
     t1 = time.time()
     report_timing("search", params, t0, t1)
@@ -93,9 +95,12 @@ def _set_general_defaults(params):
 
 
 def _sort_results(results, params):
+    """
+    Append an `.order_by()` to the results based on the 'order_by' and 'order_direction' params.
+    The 'cog_over' input field is split into its appropriate DB fields.
+    """
     # Instead of nesting conditions, we'll prep a string
     # for determining the sort direction.
-
     match params.get("order_direction"):
         case DIRECTION.ascending:
             direction = ""
@@ -114,10 +119,31 @@ def _sort_results(results, params):
             new_results = results.order_by(f"{direction}audit_year")
         case ORDER_BY.cog_over:
             if params.get("order_direction") == DIRECTION.ascending:
-                new_results = results.order_by("cognizant_agency")
+                # Ex. COG-01, COG-99, OVER-01, OVER-99
+                new_results = results.order_by("cognizant_agency", "oversight_agency")
             else:
-                new_results = results.order_by("oversight_agency")
+                # Ex. OVER-01, OVER-99, COG-01, COG-99
+                new_results = results.order_by("oversight_agency", "cognizant_agency")
         case _:
             new_results = results.order_by(f"{direction}fac_accepted_date")
 
     return new_results
+
+
+def _make_distinct(results, params):
+    """
+    Append a `.distinct()` to the results QuerySet, to prevent duplicate results.
+    Rows with duplicate report_ids exist when using AdvancedSearch/DisseminationCombined.
+    """
+    order_by = params.get("order_by", "fac_accepted_date")
+    order_direction = params.get("order_direction", "")
+
+    # cog_over needs to be broken out here in the same order it is broken out in _sort_results().
+    if order_by == "cog_over" and order_direction == "ascending":
+        results = results.distinct("report_id", "cognizant_agency", "oversight_agency")
+    elif order_by == "cog_over":
+        results = results.distinct("report_id", "oversight_agency", "cognizant_agency")
+    else:
+        results = results.distinct("report_id", order_by)
+
+    return results

--- a/backend/dissemination/search.py
+++ b/backend/dissemination/search.py
@@ -119,11 +119,11 @@ def _sort_results(results, params):
             new_results = results.order_by(f"{direction}audit_year")
         case ORDER_BY.cog_over:
             if params.get("order_direction") == DIRECTION.ascending:
-                # Ex. COG-01, COG-99, OVER-01, OVER-99
-                new_results = results.order_by("cognizant_agency", "oversight_agency")
-            else:
-                # Ex. OVER-01, OVER-99, COG-01, COG-99
+                # Ex. COG-01 -> COG-99, OVER-01 -> OVER-99
                 new_results = results.order_by("oversight_agency", "cognizant_agency")
+            else:
+                # Ex. OVER-99 -> OVER-01, COG-99 -> COG-01
+                new_results = results.order_by("-oversight_agency", "-cognizant_agency")
         case _:
             new_results = results.order_by(f"{direction}fac_accepted_date")
 
@@ -140,7 +140,7 @@ def _make_distinct(results, params):
 
     # cog_over needs to be broken out here in the same order it is broken out in _sort_results().
     if order_by == "cog_over" and order_direction == "ascending":
-        results = results.distinct("report_id", "cognizant_agency", "oversight_agency")
+        results = results.distinct("report_id", "oversight_agency", "cognizant_agency")
     elif order_by == "cog_over":
         results = results.distinct("report_id", "oversight_agency", "cognizant_agency")
     else:

--- a/backend/dissemination/search.py
+++ b/backend/dissemination/search.py
@@ -40,7 +40,7 @@ def is_advanced_search(params_dict):
     """
     Returns True if the 'advanced_search_flag' param is True.
     """
-    return params_dict.get("advanced_search_flag")
+    return params_dict.get("advanced_search_flag", False)
 
 
 def search(params):

--- a/backend/dissemination/test_search.py
+++ b/backend/dissemination/test_search.py
@@ -868,7 +868,7 @@ class SearchSortTests(TestCase):
         """
         When sorting on COG/OVER, the appropriate records should come back first.
         """
-        for agency_number in ["01", "03", "02"]:  # Generate out of order intentionally
+        for agency_number in ["02", "03", "01"]:  # Generate out of order intentionally
             baker.make(
                 General,
                 is_public=True,

--- a/backend/dissemination/test_search.py
+++ b/backend/dissemination/test_search.py
@@ -873,13 +873,13 @@ class SearchSortTests(TestCase):
                 General,
                 is_public=True,
                 cognizant_agency=agency_number,
-                oversight_agency=None,
+                oversight_agency="",
             )
             baker.make(
                 General,
                 is_public=True,
                 oversight_agency=agency_number,
-                cognizant_agency=None,
+                cognizant_agency="",
             )
 
         results_cognizant = search(
@@ -901,7 +901,7 @@ class SearchSortTests(TestCase):
             },
         )
         self.assertEqual(len(results_oversight), 6)
-        self.assertEqual(results_oversight[0].oversight_agency, "01")
+        self.assertEqual(results_oversight[0].oversight_agency, "03")
         self.assertEqual(
-            results_oversight[len(results_oversight) - 1].cognizant_agency, "03"
+            results_oversight[len(results_oversight) - 1].cognizant_agency, "01"
         )

--- a/backend/dissemination/test_search.py
+++ b/backend/dissemination/test_search.py
@@ -861,3 +861,47 @@ class SearchAdvancedFilterTests(TestMaterializedViewBuilder):
         }
         results = search(params)
         self.assertEqual(len(results), 2)
+
+
+class SearchSortTests(TestCase):
+    def test_sort_cog_over(self):
+        """
+        When sorting on COG/OVER, the appropriate records should come back first.
+        """
+        for agency_number in ["01", "03", "02"]:  # Generate out of order intentionally
+            baker.make(
+                General,
+                is_public=True,
+                cognizant_agency=agency_number,
+                oversight_agency=None,
+            )
+            baker.make(
+                General,
+                is_public=True,
+                oversight_agency=agency_number,
+                cognizant_agency=None,
+            )
+
+        results_cognizant = search(
+            {
+                "order_by": "cog_over",
+                "order_direction": "ascending",
+            },
+        )
+        self.assertEqual(len(results_cognizant), 6)
+        self.assertEqual(results_cognizant[0].cognizant_agency, "01")
+        self.assertEqual(
+            results_cognizant[len(results_cognizant) - 1].oversight_agency, "03"
+        )
+
+        results_oversight = search(
+            {
+                "order_by": "cog_over",
+                "order_direction": "descending",
+            },
+        )
+        self.assertEqual(len(results_oversight), 6)
+        self.assertEqual(results_oversight[0].oversight_agency, "01")
+        self.assertEqual(
+            results_oversight[len(results_oversight) - 1].cognizant_agency, "03"
+        )


### PR DESCRIPTION
# Bug: Sorting a Search b y Cog/Over Yields 500

Issue: https://github.com/GSA-TTS/FAC/issues/3736

## Changes:
1. Move the `.distinct()` call into its own function
    * The cog/over sort was broken because a `.distinct()` call needs to contain the same fields as the preceding `.order_by()`
    * We break the "cog_over" parameter into "cognizant_agency" and "oversight_agency" when filtering, so now we do the same for the `.distinct()` call
2. Sorting on cog/over now sorts on both.
Previously, where the first field is sorted, but the second field isn't:
`COG-01, COG-50, COG-99, OVER-50, OVER-99, OVER-01`
Now, where both are sorted such that they appear alphabetical
`COG-01, COG-50, COG-99, OVER-01, OVER-50, OVER-99` and
`OVER-99, OVER-50, OVER-01, COG-99, COG-50, COG-01`
3. A test for the cog/over sorting functionality.
4. Docstrings for some of the search helper functions.

## How to test:
1. Switch to this branch and run normally
2. Ensure there is data in your dissemination tables
    * DB dumps exist for the `dissemination_*` tables
    * The materialized view (DisseminationCombined for advanced search) is generated via `python manage.py materialized_views --create`
3. Navigate to basic search and make a search such that both COG/OVER results are shown. For example, "All years" and name "test". Verify that the cog/over sort works.
4. Do the same for advanced search. Here, I like using ALN "08". Verify that the cog/over sort works.

## Screenshots:
Basic - All years, name "test". Ascending sort.
![image](https://github.com/GSA-TTS/FAC/assets/91098850/bfa19e6a-0490-45cb-b545-3cbc2d5511d8)

Advanced - All years, ALN "08". Descending sort.
![image](https://github.com/GSA-TTS/FAC/assets/91098850/1530f8a0-4873-4fe3-bc11-45769e825d40)

## PR checklist: submitters

- [x]   Link to an issue if possible. If there’s no issue, describe what your branch does. Even if there is an issue, a brief description in the PR is still useful.
- [x]   List any special steps reviewers have to follow to test the PR. For example, adding a local environment variable, creating a local test file, etc.
- [ ]   For extra credit, submit a screen recording like [this one](https://github.com/GSA-TTS/FAC/pull/1821).
- [x]   Make sure you’ve merged `main` into your branch shortly before creating the PR. (You should also be merging `main` into your branch regularly during development.)
- [x]   Make sure you’ve accounted for any migrations. When you’re about to create the PR, bring up the application locally and then run `git status | grep migrations`. If there are any results, you probably need to add them to the branch for the PR. Your PR should have only **one** new migration file for each of the component apps, except in rare circumstances; you may need to delete some and re-run `python manage.py makemigrations` to reduce the number to one. (Also, unless in exceptional circumstances, your PR should not delete any migration files.)
- [x]   Make sure that whatever feature you’re adding has tests that cover the feature. This includes test coverage to make sure that the previous workflow still works, if applicable.
- [x]   Make sure the full-submission.cy.js [Cypress test](https://github.com/GSA-TTS/FAC/blob/main/docs/testing.md#end-to-end-testing) passes, if applicable.
- [x]   Do manual testing locally. Our tests are not good enough yet to allow us to skip this step. If that’s not applicable for some reason, check this box.
- [x]   Verify that no Git surgery was necessary, or, if it was necessary at any point, repeat the testing after it’s finished.
- [ ]   Once a PR is merged, keep an eye on it until it’s deployed to dev, and do enough testing on dev to verify that it deployed successfully, the feature works as expected, and the happy path for the broad feature area (such as submission) still works.

## PR checklist: reviewers

- [ ]   Pull the branch to your local environment and run `make docker-clean; make docker-first-run && docker compose up`; then run `docker compose exec web /bin/bash -c "python manage.py test"`
- [ ]   Manually test out the changes locally, or check this box to verify that it wasn’t applicable in this case.
- [ ]   Check that the PR has appropriate tests. Look out for changes in HTML/JS/JSON Schema logic that may need to be captured in Python tests even though the logic isn’t in Python.
- [ ]   Verify that no Git surgery is necessary at any point (such as during a merge party), or, if it was, repeat the testing after it’s finished.

The larger the PR, the stricter we should be about these points.
