### PR TITLE
Prevent skipping submission steps 1 and 2

### DIFF
--- a/backend/report_submission/test_views.py
+++ b/backend/report_submission/test_views.py
@@ -188,8 +188,8 @@ class TestPreliminaryViews(TestCase):
         self.assertEqual(response.url, "/report_submission/auditeeinfo/")
 
         step2 = reverse("report_submission:auditeeinfo")
-        my_header = {"HTTP_REFERER": "report_submission/eligibility/"}
-        step2_get = self.client.get(step2, **my_header)
+        headers = {"HTTP_REFERER": "report_submission/eligibility/"}
+        step2_get = self.client.get(step2, **headers)
         self.assertEqual(step2_get.status_code, 200)
         self.assertTemplateUsed(step2_get, "report_submission/step-base.html")
         self.assertTemplateUsed(step2_get, "report_submission/step-2.html")
@@ -263,9 +263,9 @@ class TestPreliminaryViews(TestCase):
         user = baker.make(User)
         self.client.force_login(user)
         url = reverse("report_submission:auditeeinfo")
-        my_header = {"HTTP_REFERER": "report_submission/eligibility/"}
+        headers = {"HTTP_REFERER": "report_submission/eligibility/"}
 
-        get_response = self.client.get(url, **my_header)
+        get_response = self.client.get(url, **headers)
         self.assertTrue(user.is_authenticated)
         self.assertEqual(get_response.status_code, 200)
         self.assertTemplateUsed(get_response, "report_submission/step-base.html")
@@ -299,9 +299,9 @@ class TestPreliminaryViews(TestCase):
         user = baker.make(User)
         self.client.force_login(user)
         url = reverse("report_submission:auditeeinfo")
-        my_header = {"HTTP_REFERER": "report_submission/eligibility/"}
+        headers = {"HTTP_REFERER": "report_submission/eligibility/"}
 
-        get_response = self.client.get(url, **my_header)
+        get_response = self.client.get(url, **headers)
         self.assertTrue(user.is_authenticated)
         self.assertEqual(get_response.status_code, 200)
         self.assertTemplateUsed(get_response, "report_submission/step-base.html")
@@ -367,8 +367,8 @@ class TestPreliminaryViews(TestCase):
 
     def test_auditeeinfoformview_get_requires_login(self):
         url = reverse("report_submission:auditeeinfo")
-        my_header = {"HTTP_REFERER": "report_submission/eligibility/"}
-        response = self.client.get(url, **my_header)
+        headers = {"HTTP_REFERER": "report_submission/eligibility/"}
+        response = self.client.get(url, **headers)
 
         # Should redirect to login page
         self.assertIsInstance(response, HttpResponseRedirect)

--- a/backend/report_submission/test_views.py
+++ b/backend/report_submission/test_views.py
@@ -188,7 +188,8 @@ class TestPreliminaryViews(TestCase):
         self.assertEqual(response.url, "/report_submission/auditeeinfo/")
 
         step2 = reverse("report_submission:auditeeinfo")
-        step2_get = self.client.get(step2)
+        my_header = {"HTTP_REFERER": "report_submission/eligibility/"}
+        step2_get = self.client.get(step2, **my_header)
         self.assertEqual(step2_get.status_code, 200)
         self.assertTemplateUsed(step2_get, "report_submission/step-base.html")
         self.assertTemplateUsed(step2_get, "report_submission/step-2.html")
@@ -262,8 +263,9 @@ class TestPreliminaryViews(TestCase):
         user = baker.make(User)
         self.client.force_login(user)
         url = reverse("report_submission:auditeeinfo")
+        my_header = {"HTTP_REFERER": "report_submission/eligibility/"}
 
-        get_response = self.client.get(url)
+        get_response = self.client.get(url, **my_header)
         self.assertTrue(user.is_authenticated)
         self.assertEqual(get_response.status_code, 200)
         self.assertTemplateUsed(get_response, "report_submission/step-base.html")
@@ -297,8 +299,9 @@ class TestPreliminaryViews(TestCase):
         user = baker.make(User)
         self.client.force_login(user)
         url = reverse("report_submission:auditeeinfo")
+        my_header = {"HTTP_REFERER": "report_submission/eligibility/"}
 
-        get_response = self.client.get(url)
+        get_response = self.client.get(url, **my_header)
         self.assertTrue(user.is_authenticated)
         self.assertEqual(get_response.status_code, 200)
         self.assertTemplateUsed(get_response, "report_submission/step-base.html")
@@ -364,7 +367,8 @@ class TestPreliminaryViews(TestCase):
 
     def test_auditeeinfoformview_get_requires_login(self):
         url = reverse("report_submission:auditeeinfo")
-        response = self.client.get(url)
+        my_header = {"HTTP_REFERER": "report_submission/eligibility/"}
+        response = self.client.get(url, **my_header)
 
         # Should redirect to login page
         self.assertIsInstance(response, HttpResponseRedirect)
@@ -378,6 +382,17 @@ class TestPreliminaryViews(TestCase):
         self.assertIsInstance(response, HttpResponseRedirect)
         self.assertTrue("openid/login" in response.url)
 
+    def test_auditeeinfo_no_referer_redirect(self):
+        user = baker.make(User)
+        self.client.force_login(user)
+
+        # Not supplying required HTTP_REFERER header here
+        url = reverse("report_submission:auditeeinfo")
+        response = self.client.get(url)
+
+        # Should redirect to step 1 page since HTTP_REFERER isn't present
+        self.assertIsInstance(response, HttpResponseRedirect)
+        self.assertTrue("report_submission/eligibility" in response.url)
 
 class GeneralInformationFormViewTests(TestCase):
     def test_get_requires_login(self):

--- a/backend/report_submission/test_views.py
+++ b/backend/report_submission/test_views.py
@@ -392,7 +392,7 @@ class TestPreliminaryViews(TestCase):
         user = baker.make(User)
         user.profile.entry_form_data = {
             **self.step1_data,
-            "is_usa_based": False,
+            "is_usa_based": False,  # Ineligible
         }
         user.profile.save()
         self.client.force_login(user)
@@ -400,9 +400,22 @@ class TestPreliminaryViews(TestCase):
         url = reverse("report_submission:auditeeinfo")
         response = self.client.get(url)
 
-        # Should redirect to step 1 page since HTTP_REFERER isn't present
+        # Should redirect to step 1 page due to no eligibility
         self.assertIsInstance(response, HttpResponseRedirect)
         self.assertTrue("report_submission/eligibility" in response.url)
+
+    def test_accessandsubmission_no_auditee_info(self):
+        user = baker.make(User)
+        user.profile.entry_form_data = self.step1_data
+        user.profile.save()
+        self.client.force_login(user)
+
+        url = reverse("report_submission:accessandsubmission")
+        response = self.client.get(url)
+
+        # Should redirect to step 2 page since auditee info isn't present
+        self.assertIsInstance(response, HttpResponseRedirect)
+        self.assertTrue("report_submission/auditeeinfo" in response.url)
 
 
 class GeneralInformationFormViewTests(TestCase):

--- a/backend/report_submission/test_views.py
+++ b/backend/report_submission/test_views.py
@@ -74,12 +74,6 @@ EMAIL_TO_ROLE = {
     "auditor_contacts_email": "editor",
 }
 
-VALID_ELIGIBILITY_DATA = {
-    "is_usa_based": True,
-    "met_spending_threshold": True,
-    "user_provided_organization_type": "state",
-}
-
 
 class TestPreliminaryViews(TestCase):
     """
@@ -116,9 +110,9 @@ class TestPreliminaryViews(TestCase):
     }
 
     step2_data = {
-        "auditee_uei": "Lw4MXE7SKMV1",
-        "auditee_fiscal_period_start": "01/01/2021",
-        "auditee_fiscal_period_end": "12/31/2021",
+        "auditee_uei": "D7A4J33FUMJ1",
+        "auditee_fiscal_period_start": "2021-01-01",
+        "auditee_fiscal_period_end": "2021-12-31",
     }
 
     step3_data = {
@@ -266,7 +260,7 @@ class TestPreliminaryViews(TestCase):
         }
 
         user = baker.make(User)
-        user.profile.entry_form_data = VALID_ELIGIBILITY_DATA
+        user.profile.entry_form_data = self.step1_data
         user.profile.save()
         self.client.force_login(user)
         url = reverse("report_submission:auditeeinfo")
@@ -303,7 +297,7 @@ class TestPreliminaryViews(TestCase):
         mock_get_uei_info.return_value = {"valid": True}
 
         user = baker.make(User)
-        user.profile.entry_form_data = VALID_ELIGIBILITY_DATA
+        user.profile.entry_form_data = self.step1_data
         user.profile.save()
         self.client.force_login(user)
         url = reverse("report_submission:auditeeinfo")
@@ -338,6 +332,12 @@ class TestPreliminaryViews(TestCase):
         Check that the POST succeeds with appropriate data.
         """
         user = baker.make(User)
+        user.profile.entry_form_data = {
+            **self.step1_data,
+            **self.step2_data,
+            **self.step3_data,
+        }
+        user.profile.save()
         self.client.force_login(user)
         url = reverse("report_submission:accessandsubmission")
 
@@ -391,7 +391,7 @@ class TestPreliminaryViews(TestCase):
     def test_auditeeinfo_no_eligibility(self):
         user = baker.make(User)
         user.profile.entry_form_data = {
-            **VALID_ELIGIBILITY_DATA,
+            **self.step1_data,
             "is_usa_based": False,
         }
         user.profile.save()

--- a/backend/report_submission/test_views.py
+++ b/backend/report_submission/test_views.py
@@ -394,6 +394,7 @@ class TestPreliminaryViews(TestCase):
         self.assertIsInstance(response, HttpResponseRedirect)
         self.assertTrue("report_submission/eligibility" in response.url)
 
+
 class GeneralInformationFormViewTests(TestCase):
     def test_get_requires_login(self):
         """Requests to the GET endpoint require the user to be authenticated"""

--- a/backend/report_submission/test_views.py
+++ b/backend/report_submission/test_views.py
@@ -266,9 +266,7 @@ class TestPreliminaryViews(TestCase):
         }
 
         user = baker.make(User)
-        user.profile.entry_form_data = (
-            VALID_ELIGIBILITY_DATA
-        )
+        user.profile.entry_form_data = VALID_ELIGIBILITY_DATA
         user.profile.save()
         self.client.force_login(user)
         url = reverse("report_submission:auditeeinfo")
@@ -305,9 +303,7 @@ class TestPreliminaryViews(TestCase):
         mock_get_uei_info.return_value = {"valid": True}
 
         user = baker.make(User)
-        user.profile.entry_form_data = (
-            VALID_ELIGIBILITY_DATA
-        )
+        user.profile.entry_form_data = VALID_ELIGIBILITY_DATA
         user.profile.save()
         self.client.force_login(user)
         url = reverse("report_submission:auditeeinfo")
@@ -394,12 +390,10 @@ class TestPreliminaryViews(TestCase):
 
     def test_auditeeinfo_no_eligibility(self):
         user = baker.make(User)
-        user.profile.entry_form_data = (
-            {
-                **VALID_ELIGIBILITY_DATA,
-                "is_usa_based": False,
-            }
-        )
+        user.profile.entry_form_data = {
+            **VALID_ELIGIBILITY_DATA,
+            "is_usa_based": False,
+        }
         user.profile.save()
         self.client.force_login(user)
 

--- a/backend/report_submission/views.py
+++ b/backend/report_submission/views.py
@@ -53,8 +53,11 @@ class EligibilityFormView(LoginRequiredMixin, View):
 # Step 2
 class AuditeeInfoFormView(LoginRequiredMixin, View):
     def get(self, request):
-        referer = request.META.get("HTTP_REFERER")
-        if not (referer and referer.endswith("report_submission/eligibility/")):
+        entry_form_data = request.user.profile.entry_form_data
+        eligible = api.views.eligibility_check(request.user, entry_form_data)
+
+        # Prevent users from skipping the eligibility form
+        if not eligible.get("eligible"):
             return redirect(reverse("report_submission:eligibility"))
         else:
             args = {}

--- a/backend/report_submission/views.py
+++ b/backend/report_submission/views.py
@@ -53,10 +53,14 @@ class EligibilityFormView(LoginRequiredMixin, View):
 # Step 2
 class AuditeeInfoFormView(LoginRequiredMixin, View):
     def get(self, request):
-        args = {}
-        args["step"] = 2
-        args["form"] = AuditeeInfoForm()
-        return render(request, "report_submission/step-2.html", args)
+        referer = request.META.get("HTTP_REFERER")
+        if not (referer and referer.endswith("report_submission/eligibility/")):
+            return redirect(reverse("report_submission:eligibility"))
+        else:
+            args = {}
+            args["step"] = 2
+            args["form"] = AuditeeInfoForm()
+            return render(request, "report_submission/step-2.html", args)
 
     # render auditee info form
 

--- a/backend/report_submission/views.py
+++ b/backend/report_submission/views.py
@@ -102,9 +102,15 @@ class AuditeeInfoFormView(LoginRequiredMixin, View):
 # Step 3
 class AccessAndSubmissionFormView(LoginRequiredMixin, View):
     def get(self, request):
-        args = {}
-        args["step"] = 3
-        return render(request, "report_submission/step-3.html", args)
+        info_check = api.views.auditee_info_check(
+            request.user, request.user.profile.entry_form_data
+        )
+        if info_check.get("errors"):
+            return redirect(reverse("report_submission:auditeeinfo"))
+        else:
+            args = {}
+            args["step"] = 3
+            return render(request, "report_submission/step-3.html", args)
 
     # render access-submission form
 

--- a/backend/report_submission/views.py
+++ b/backend/report_submission/views.py
@@ -105,6 +105,8 @@ class AccessAndSubmissionFormView(LoginRequiredMixin, View):
         info_check = api.views.auditee_info_check(
             request.user, request.user.profile.entry_form_data
         )
+
+        # Prevent users from skipping the auditee info form
         if info_check.get("errors"):
             return redirect(reverse("report_submission:auditeeinfo"))
         else:


### PR DESCRIPTION
Closes https://github.com/GSA-TTS/FAC/issues/2118

In this PR:
- Previously you could go directly to `report_submission/auditeeinfo/` via url and skip step 1 of the submission process, or to `report_submission/accessandsubmission/` to skip step 2
- This fix checks for the needed data gathered in the previous steps so that neither step can be skipped. If the data isn't there, it will redirect you to the previous step.
- Unit tests
  - Fixing `step2_data` so the fields validate correctly

Testing:
- Before completing any steps:
  - Going directly to http://localhost:8000/report_submission/auditeeinfo/ should redirect you to step 1
  - Going directly to http://localhost:8000/report_submission/accessandsubmission/ should redirect you to step 1
- After completing step 1/eligibility:
  - Going directly to http://localhost:8000/report_submission/auditeeinfo/ should work as normal
  - Going directly to http://localhost:8000/report_submission/accessandsubmission/ should redirect you to step 2
- After completing step 2/auditeeinfo:
  - Going directly to http://localhost:8000/report_submission/accessandsubmission/ should work as normal
- After completing step 3/accessandsubmission:
  - User profile data should be reset, so going directly to http://localhost:8000/report_submission/auditeeinfo/ or http://localhost:8000/report_submission/accessandsubmission/ should redirect you to step 1 again
- Normal audit creation (step 1 -> step 2 -> step 3) should work as expected
- Cypress test passes

## PR checklist: submitters

- [ ]   Link to an issue if possible. If there’s no issue, describe what your branch does. Even if there is an issue, a brief description in the PR is still useful.
- [ ]   List any special steps reviewers have to follow to test the PR. For example, adding a local environment variable, creating a local test file, etc.
- [ ]   For extra credit, submit a screen recording like [this one](https://github.com/GSA-TTS/FAC/pull/1821).
- [ ]   Make sure you’ve merged `main` into your branch shortly before creating the PR. (You should also be merging `main` into your branch regularly during development.)
- [ ]   Make sure you’ve accounted for any migrations. When you’re about to create the PR, bring up the application locally and then run `git status | grep migrations`. If there are any results, you probably need to add them to the branch for the PR. Your PR should have only **one** new migration file for each of the component apps, except in rare circumstances; you may need to delete some and re-run `python manage.py makemigrations` to reduce the number to one. (Also, unless in exceptional circumstances, your PR should not delete any migration files.)
- [ ]   Make sure that whatever feature you’re adding has tests that cover the feature. This includes test coverage to make sure that the previous workflow still works, if applicable.
- [ ]   Make sure the full-submission.cy.js [Cypress test](https://github.com/GSA-TTS/FAC/blob/main/docs/testing.md#end-to-end-testing) passes, if applicable.
- [ ]   Do manual testing locally. Our tests are not good enough yet to allow us to skip this step. If that’s not applicable for some reason, check this box.
- [ ]   Verify that no Git surgery was necessary, or, if it was necessary at any point, repeat the testing after it’s finished.
- [ ]   Once a PR is merged, keep an eye on it until it’s deployed to dev, and do enough testing on dev to verify that it deployed successfully, the feature works as expected, and the happy path for the broad feature area (such as submission) still works.

## PR checklist: reviewers

- [ ]   Pull the branch to your local environment and run `make docker-clean; make docker-first-run && docker compose up`; then run `docker compose exec web /bin/bash -c "python manage.py test"`
- [ ]   Manually test out the changes locally, or check this box to verify that it wasn’t applicable in this case.
- [ ]   Check that the PR has appropriate tests. Look out for changes in HTML/JS/JSON Schema logic that may need to be captured in Python tests even though the logic isn’t in Python.
- [ ]   Verify that no Git surgery is necessary at any point (such as during a merge party), or, if it was, repeat the testing after it’s finished.

The larger the PR, the stricter we should be about these points.
