### PR TITLE
3960 address historical report which failed validation with no error message

### DIFF
--- a/backend/audit/cross_validation/check_findings_count_consistency.py
+++ b/backend/audit/cross_validation/check_findings_count_consistency.py
@@ -1,3 +1,6 @@
+from django.conf import settings
+
+from census_historical_migration.invalid_record import InvalidRecord
 from .errors import (
     err_findings_count_inconsistent,
 )
@@ -19,10 +22,17 @@ def check_findings_count_consistency(sac_dict, *_args, **_kwargs):
     findings_uniform_guidance = findings_uniform_guidance_section.get(
         "findings_uniform_guidance_entries", []
     )
-
+    data_source = sac_dict.get("sf_sac_meta", {}).get("data_source", "")
     expected_award_refs_count = {}
     found_award_refs_count = defaultdict(int)
     errors = []
+    if (
+        data_source == settings.CENSUS_DATA_SOURCE
+        and "check_findings_count_consistency"
+        in InvalidRecord.fields["validations_to_skip"]
+    ):
+        # Skip this validation if it is an historical audit report with incorrect findings count
+        return errors
 
     for award in federal_awards:
         award_reference = award.get("award_reference", None)

--- a/backend/audit/cross_validation/check_ref_number_in_cap.py
+++ b/backend/audit/cross_validation/check_ref_number_in_cap.py
@@ -35,10 +35,9 @@ def check_ref_number_in_cap(sac_dict, *_args, **_kwargs):
     in_use_references = set()
     errors = []
 
-    skip_validation_function = InvalidRecord.fields["validations_to_skip"]
     if (
         data_source == settings.CENSUS_DATA_SOURCE
-        and "check_ref_number_in_cap" in skip_validation_function
+        and "check_ref_number_in_cap" in InvalidRecord.fields["validations_to_skip"]
     ):
         # Skip this validation if it is a historical audit report with non-matching reference numbers
         return errors

--- a/backend/audit/cross_validation/check_ref_number_in_findings_text.py
+++ b/backend/audit/cross_validation/check_ref_number_in_findings_text.py
@@ -29,10 +29,10 @@ def check_ref_number_in_findings_text(sac_dict, *_args, **_kwargs):
     in_use_references = set()
     errors = []
 
-    skip_validation_function = InvalidRecord.fields["validations_to_skip"]
     if (
         data_source == settings.CENSUS_DATA_SOURCE
-        and "check_ref_number_in_findings_text" in skip_validation_function
+        and "check_ref_number_in_findings_text"
+        in InvalidRecord.fields["validations_to_skip"]
     ):
         # Skip this validation if it is a historical audit report with non-matching reference numbers
         return errors

--- a/backend/census_historical_migration/invalid_migration_tags.py
+++ b/backend/census_historical_migration/invalid_migration_tags.py
@@ -10,3 +10,4 @@ class INVALID_MIGRATION_TAGS:
     EXTRA_FINDING_REFERENCE_NUMBERS_IN_FINDINGSTEXT = (
         "extra_finding_reference_numbers_in_findingstext"
     )
+    INCORRECT_FINDINGS_COUNT = "incorrect_findings_count"

--- a/backend/census_historical_migration/test_federal_awards_xforms.py
+++ b/backend/census_historical_migration/test_federal_awards_xforms.py
@@ -939,6 +939,8 @@ class TestTrackInvalidNumberOfAuditFindings(TestCase):
 
         mock_get_findings.assert_called_once_with("some_dbkey", "2024")
         self.assertEqual(len(InvalidRecord.fields["federal_award"]), 0)
+
+
 class TestXformMissingPrefix(SimpleTestCase):
     class MockAudit:
 

--- a/backend/census_historical_migration/test_federal_awards_xforms.py
+++ b/backend/census_historical_migration/test_federal_awards_xforms.py
@@ -904,7 +904,7 @@ class TestTrackInvalidNumberOfAuditFindings(TestCase):
                         {"column": "ELECAUDITSID", "value": "audit1"},
                         {"column": "FINDINGSCOUNT", "value": "2"},
                     ],
-                    "gsa_fac_data": {"field": "findings_count", "value": "0"},
+                    "gsa_fac_data": {"field": "findings_count", "value": "2"},
                 },
                 {
                     "census_data": [

--- a/backend/census_historical_migration/test_federal_awards_xforms.py
+++ b/backend/census_historical_migration/test_federal_awards_xforms.py
@@ -1,6 +1,6 @@
 from unittest.mock import patch
 from django.conf import settings
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, TestCase
 
 from .invalid_migration_tags import INVALID_MIGRATION_TAGS
 from .invalid_record import InvalidRecord
@@ -11,6 +11,7 @@ from .exception_utils import DataMigrationError
 from .workbooklib.federal_awards import (
     is_valid_prefix,
     track_invalid_federal_program_total,
+    track_invalid_number_of_audit_findings,
     xform_match_number_passthrough_names_ids,
     xform_missing_amount_expended,
     xform_missing_program_total,
@@ -851,3 +852,88 @@ class TestTrackInvalidFederalProgramTotal(SimpleTestCase):
             InvalidRecord.fields["validations_to_skip"],
         )
         self.assertNotIn
+
+
+class TestTrackInvalidNumberOfAuditFindings(TestCase):
+
+    class MockAudit:
+        def __init__(self, elec_audits_id, findings_count):
+            self.ELECAUDITSID = elec_audits_id
+            self.FINDINGSCOUNT = findings_count
+
+    class MockFinding:
+        def __init__(self, elec_audits_id):
+            self.ELECAUDITSID = elec_audits_id
+
+    class MockAuditHeader:
+        def __init__(self, dbkey, audityear):
+            self.DBKEY = dbkey
+            self.AUDITYEAR = audityear
+
+    def setUp(self):
+
+        InvalidRecord.reset()
+
+    @patch("census_historical_migration.workbooklib.findings.get_findings")
+    def test_track_invalid_number_of_audit_findings(self, mock_get_findings):
+        """Test tracking for invalid number of audit findings"""
+        # Mock the findings and audits data
+        mock_findings = [
+            self.MockFinding("audit1"),
+            self.MockFinding("audit1"),
+        ]
+
+        mock_audits = [
+            self.MockAudit("audit1", "2"),
+            self.MockAudit("audit2", "1"),
+        ]
+
+        mock_audit_header = self.MockAuditHeader("some_dbkey", "2024")
+
+        mock_get_findings.return_value = mock_findings
+
+        track_invalid_number_of_audit_findings(mock_audits, mock_audit_header)
+        mock_get_findings.assert_called_once_with("some_dbkey", "2024")
+        # Check if the invalid records were appended correctly
+        expected_invalid_records = [
+            [
+                {
+                    "census_data": [
+                        {"column": "ELECAUDITSID", "value": "audit1"},
+                        {"column": "FINDINGSCOUNT", "value": "2"},
+                    ],
+                    "gsa_fac_data": {"field": "findings_count", "value": "0"},
+                },
+                {
+                    "census_data": [
+                        {"column": "ELECAUDITSID", "value": "audit2"},
+                        {"column": "FINDINGSCOUNT", "value": "1"},
+                    ],
+                    "gsa_fac_data": {"field": "findings_count", "value": "0"},
+                },
+            ]
+        ]
+
+        for expected_record in expected_invalid_records:
+            self.assertIn(expected_record, InvalidRecord.fields["federal_award"])
+
+    @patch("census_historical_migration.workbooklib.federal_awards.get_findings")
+    def test_no_tracking_with_valid_number_of_audit_findings(self, mock_get_findings):
+        """Test no tracking for valid number of audit findings"""
+        # Mock the findings and audits data
+        mock_findings = [
+            self.MockFinding("audit1"),
+            self.MockFinding("audit1"),
+        ]
+
+        mock_audits = [
+            self.MockAudit("audit1", "2"),
+        ]
+
+        mock_audit_header = self.MockAuditHeader("some_dbkey", "2024")
+        mock_get_findings.return_value = mock_findings
+
+        track_invalid_number_of_audit_findings(mock_audits, mock_audit_header)
+
+        mock_get_findings.assert_called_once_with("some_dbkey", "2024")
+        self.assertEqual(len(InvalidRecord.fields["federal_award"]), 0)

--- a/backend/census_historical_migration/test_federal_awards_xforms.py
+++ b/backend/census_historical_migration/test_federal_awards_xforms.py
@@ -876,7 +876,7 @@ class TestTrackInvalidNumberOfAuditFindings(TestCase):
 
         InvalidRecord.reset()
 
-    @patch("census_historical_migration.workbooklib.findings.get_findings")
+    @patch("census_historical_migration.workbooklib.federal_awards.get_findings")
     def test_track_invalid_number_of_audit_findings(self, mock_get_findings):
         """Test tracking for invalid number of audit findings"""
         # Mock the findings and audits data

--- a/backend/census_historical_migration/workbooklib/corrective_action_plan.py
+++ b/backend/census_historical_migration/workbooklib/corrective_action_plan.py
@@ -92,8 +92,8 @@ def track_invalid_records_with_more_captexts_less_findings(findings, captexts):
     captext_refnums = get_reference_numbers_from_text_records(captexts)
     invalid_records = []
     extra_captexts = captext_refnums.difference(finding_refnums)
-    if len(extra_captexts) > 0:
-        invalid_records = []
+    missing_captexts = finding_refnums.difference(captext_refnums)
+    if len(extra_captexts):
         for captext_refnum in captext_refnums:
             census_data_tuples = [
                 ("FINDINGREFNUMS", captext_refnum),
@@ -104,9 +104,21 @@ def track_invalid_records_with_more_captexts_less_findings(findings, captexts):
                 captext_refnum,
                 invalid_records,
             )
+        InvalidRecord.append_invalid_cap_text_records(invalid_records)
+    elif len(missing_captexts):
+        for finding_refnum in missing_captexts:
+            census_data_tuples = [
+                ("FINDINGREFNUMS", finding_refnum),
+            ]
+            track_invalid_records(
+                census_data_tuples,
+                "reference_number",
+                finding_refnum,
+                invalid_records,
+            )
+        InvalidRecord.append_invalid_finding_records(invalid_records)
 
     if invalid_records:
-        InvalidRecord.append_invalid_cap_text_records(invalid_records)
         InvalidRecord.append_validations_to_skip("check_ref_number_in_cap")
         InvalidRecord.append_invalid_migration_tag(
             INVALID_MIGRATION_TAGS.EXTRA_FINDING_REFERENCE_NUMBERS_IN_CAPTEXT

--- a/backend/census_historical_migration/workbooklib/federal_awards.py
+++ b/backend/census_historical_migration/workbooklib/federal_awards.py
@@ -128,9 +128,6 @@ def xform_missing_major_program(audits):
         InspectionRecord.append_federal_awards_changes(change_records)
 
 
-from collections import defaultdict
-
-
 def track_invalid_number_of_audit_findings(audits, audit_header):
     """Track invalid number of audit findings."""
     findings = get_findings(audit_header.DBKEY, audit_header.AUDITYEAR)

--- a/backend/census_historical_migration/workbooklib/findings_text.py
+++ b/backend/census_historical_migration/workbooklib/findings_text.py
@@ -96,8 +96,9 @@ def track_invalid_records_with_more_findings_texts_than_findings(
     findings_text_refnums = get_reference_numbers_from_text_records(findings_texts)
     invalid_records = []
     extra_findings_texts = findings_text_refnums.difference(finding_refnums)
-    if len(extra_findings_texts) > 0:
-        invalid_records = []
+    missing_findings_texts = finding_refnums.difference(findings_text_refnums)
+
+    if len(extra_findings_texts):
         for findings_text_refnum in findings_text_refnums:
             census_data_tuples = [
                 ("FINDINGREFNUMS", findings_text_refnum),
@@ -108,9 +109,20 @@ def track_invalid_records_with_more_findings_texts_than_findings(
                 findings_text_refnum,
                 invalid_records,
             )
-
-    if invalid_records:
         InvalidRecord.append_invalid_finding_text_records(invalid_records)
+    elif len(missing_findings_texts):
+        for finding_refnum in missing_findings_texts:
+            census_data_tuples = [
+                ("FINDINGREFNUMS", finding_refnum),
+            ]
+            track_invalid_records(
+                census_data_tuples,
+                "reference_number",
+                finding_refnum,
+                invalid_records,
+            )
+        InvalidRecord.append_invalid_finding_records(invalid_records)
+    if invalid_records:
         InvalidRecord.append_validations_to_skip("check_ref_number_in_findings_text")
         InvalidRecord.append_invalid_migration_tag(
             INVALID_MIGRATION_TAGS.EXTRA_FINDING_REFERENCE_NUMBERS_IN_FINDINGSTEXT


### PR DESCRIPTION
## Description
A historical report failed to migrate with the following error message:
`You reported ## findings for award AWARD-#### in the Federal Awards workbook, but declared ### findings for the same award in the Federal Awards Audit Findings workbook.` As the error message indicates, the report has a mismatch between the reported findings count and the calculated findings count. 
The solution involved:
-  Tracking the invalid record and adding logic to allow this report to migrate without error (i.e. skip validation).
-  Fixing the logic around extra/missing reference number in cap text and finding text.

## How to test
1. Launch the stack from the main branch.
2. Attempt to migrate the historical report with  `audit_year=2018 and dbkey=171944` and notice how it fails due to "missing additional award identification"
3.  Switch to this PR branch and re-run the migration for the same report and observe that it processes properly.

## PR checklist: submitters

- [ ]   Link to an issue if possible. If there’s no issue, describe what your branch does. Even if there is an issue, a brief description in the PR is still useful.
- [ ]   List any special steps reviewers have to follow to test the PR. For example, adding a local environment variable, creating a local test file, etc.
- [ ]   For extra credit, submit a screen recording like [this one](https://github.com/GSA-TTS/FAC/pull/1821).
- [ ]   Make sure you’ve merged `main` into your branch shortly before creating the PR. (You should also be merging `main` into your branch regularly during development.)
- [ ]   Make sure you’ve accounted for any migrations. When you’re about to create the PR, bring up the application locally and then run `git status | grep migrations`. If there are any results, you probably need to add them to the branch for the PR. Your PR should have only **one** new migration file for each of the component apps, except in rare circumstances; you may need to delete some and re-run `python manage.py makemigrations` to reduce the number to one. (Also, unless in exceptional circumstances, your PR should not delete any migration files.)
- [ ]   Make sure that whatever feature you’re adding has tests that cover the feature. This includes test coverage to make sure that the previous workflow still works, if applicable.
- [ ]   Make sure the full-submission.cy.js [Cypress test](https://github.com/GSA-TTS/FAC/blob/main/docs/testing.md#end-to-end-testing) passes, if applicable.
- [ ]   Do manual testing locally. Our tests are not good enough yet to allow us to skip this step. If that’s not applicable for some reason, check this box.
- [ ]   Verify that no Git surgery was necessary, or, if it was necessary at any point, repeat the testing after it’s finished.
- [ ]   Once a PR is merged, keep an eye on it until it’s deployed to dev, and do enough testing on dev to verify that it deployed successfully, the feature works as expected, and the happy path for the broad feature area (such as submission) still works.

## PR checklist: reviewers

- [ ]   Pull the branch to your local environment and run `make docker-clean; make docker-first-run && docker compose up`; then run `docker compose exec web /bin/bash -c "python manage.py test"`
- [ ]   Manually test out the changes locally, or check this box to verify that it wasn’t applicable in this case.
- [ ]   Check that the PR has appropriate tests. Look out for changes in HTML/JS/JSON Schema logic that may need to be captured in Python tests even though the logic isn’t in Python.
- [ ]   Verify that no Git surgery is necessary at any point (such as during a merge party), or, if it was, repeat the testing after it’s finished.

The larger the PR, the stricter we should be about these points.
