### PR TITLE
Update cloud.gov list of developers

### DIFF
--- a/backend/support/api/admin_api_v1_1_0/create_access_tables.sql
+++ b/backend/support/api/admin_api_v1_1_0/create_access_tables.sql
@@ -1,6 +1,6 @@
 -- This is explicitly not a Django managed table.
 -- In order to have an administrative key added,
--- it must be added via a Github commit, and a PR 
+-- it must be added via a Github commit, and a PR
 -- must be performed to merge the key into the tree.
 
 -- This is because administrative keys can read/write
@@ -9,7 +9,7 @@
 
 DROP TABLE IF EXISTS support_administrative_key_uuids;
 
-CREATE TABLE support_administrative_key_uuids 
+CREATE TABLE support_administrative_key_uuids
     (
         id BIGSERIAL PRIMARY KEY,
         email TEXT,
@@ -18,7 +18,7 @@ CREATE TABLE support_administrative_key_uuids
         added DATE
     );
 
-INSERT INTO support_administrative_key_uuids 
+INSERT INTO support_administrative_key_uuids
     (email, uuid, permissions, added)
     VALUES
     (
@@ -26,12 +26,6 @@ INSERT INTO support_administrative_key_uuids
         '61ba59b2-f545-4c2f-9b24-9655c706a06c',
         'CREATE,READ,DELETE',
         '2023-12-04'
-    ),
-    (
-        'timothy.ballard@gsa.gov',
-        '1e2845a0-c844-4a6f-84ac-f398b58ce7c9',
-        'CREATE,READ,DELETE',
-        '2023-12-08'
     ),
     (
         'daniel.swick@gsa.gov',

--- a/terraform/meta/config.tf
+++ b/terraform/meta/config.tf
@@ -20,9 +20,6 @@ locals {
     # TODO: Automate updates via GitHub's GraphQL API
     "bret.mogilefsky@gsa.gov",
     "james.person@gsa.gov",
-    "jeanmarie.mariadassou@gsa.gov",
-    "tadhg.ohiggins@gsa.gov",
-    "timothy.ballard@gsa.gov",
     "matthew.jadud@gsa.gov",
     "hassandeme.mamasambo@gsa.gov",
     "daniel.swick@gsa.gov",
@@ -41,10 +38,8 @@ locals {
     # TODO: Automate updates via GitHub's GraphQL API
     "bret.mogilefsky@gsa.gov",
     "daniel.swick@gsa.gov",
-    "jeanmarie.mariadassou@gsa.gov",
     "matthew.jadud@gsa.gov",
-    "tadhg.ohiggins@gsa.gov",
-    "timothy.ballard@gsa.gov",
+    "alexander.steel@gsa.gov",
   ]
 
   internal_asgs = [


### PR DESCRIPTION
Removes the following users from the developer and maintainer list:
- Tim
- Tadhg
- Jeanmarie

Adds the following user to the maintainer list:
- Alex