### PR TITLE
Add option to only detected changed files

### DIFF
--- a/.github/workflows/testing-from-build.yml
+++ b/.github/workflows/testing-from-build.yml
@@ -55,6 +55,7 @@ jobs:
           skip_covered: true # Set to true to remove 100% covered from report
           fail_below_threshold: false # Fails the action if 90% threshold is not met
           show_missing: true
+          only_changed_files: true
           repo_token: ${{ secrets.GITHUB_TOKEN }}
 
   # a11y-testing:

--- a/.github/workflows/testing-from-ghcr.yml
+++ b/.github/workflows/testing-from-ghcr.yml
@@ -57,6 +57,7 @@ jobs:
           skip_covered: true # Set to true to remove 100% covered from report
           fail_below_threshold: false # Fails the action if 90% threshold is not met
           show_missing: true
+          only_changed_files: true
           repo_token: ${{ secrets.GITHUB_TOKEN }}
 
   # a11y-testing:


### PR DESCRIPTION
Dan and I agree, the coverage report is good, but its bloated, hard to read, and often ignored.

Now the only coverage added to the PR is if the code is changed/added, and used with Django/Coverage. Should make things a lot easier to read.