### PR TITLE
Enable New Relic High Security Mode

### DIFF
--- a/backend/tools/setup_cgov_env.sh
+++ b/backend/tools/setup_cgov_env.sh
@@ -34,6 +34,9 @@ function setup_cgov_env {
     # Used for configuring the logging details sent to new relic
     export NEW_RELIC_CONFIG_FILE=newrelic.ini
 
+    # Used to enable High Security mode
+    export NEW_RELIC_HIGH_SECURITY=true
+
     # https://docs.newrelic.com/docs/security/security-privacy/compliance/fedramp-compliant-endpoints/
     export NEW_RELIC_HOST="gov-collector.newrelic.com"
     # https://docs.newrelic.com/docs/apm/agents/python-agent/configuration/python-agent-configuration/#proxy


### PR DESCRIPTION
PR simply adds a new New Relic environment variable at startup, allowing the instance to be in High Security Mode.

Once the deploys to `preview` are working again, im going to deploy this and look in new relic to ensure:
- logs are still operating as expected
- logshipper is still sending logs
- dashboards aren't broken

High Security Mode does change some underlying items, and we want to ensure everything is still functional as we expect.

https://docs.newrelic.com/docs/apm/agents/manage-apm-agents/configuration/high-security-mode/#version2description