### PR TITLE
Change Coverage Reporting Tool

### DIFF
--- a/.github/workflows/testing-from-build.yml
+++ b/.github/workflows/testing-from-build.yml
@@ -52,13 +52,13 @@ jobs:
         with:
           filename: ./coverage.xml
           badge: true
-          fail_below_min: false
+          fail_below_min: true
           format: markdown
           hide_branch_rate: false
           hide_complexity: true
           indicators: true
           output: both
-          thresholds: '85'
+          thresholds: '85 90'
 
       - name: Add Coverage PR Comment
         uses: marocchino/sticky-pull-request-comment@v2

--- a/.github/workflows/testing-from-build.yml
+++ b/.github/workflows/testing-from-build.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Post Coverage Report to Pull Request
         if: github.event_name == 'pull_request'
-        uses: orgoro/coverage@v3.1
+        uses: orgoro/coverage@v3.2
         with:
             coverageFile: ./coverage.xml
             token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/testing-from-build.yml
+++ b/.github/workflows/testing-from-build.yml
@@ -47,7 +47,7 @@ jobs:
           pwd
           ls -al | grep 'coverage'
 
-      - name: Coverage Action
+      - name: Post Coverage Report to Pull Request
         if: github.event_name == 'pull_request'
         uses: orgoro/coverage@v3.1
         with:

--- a/.github/workflows/testing-from-build.yml
+++ b/.github/workflows/testing-from-build.yml
@@ -47,19 +47,25 @@ jobs:
           pwd
           ls -al | grep 'coverage'
 
-      - name: Pre-processing Coverage Report
-        run: sed -i 's#filename="#filename="backend-api/src/#g' ./*.xml
-
-      - name: Publish Coverage Report to Pull Request
-        uses: 5monkeys/cobertura-action@master
+      - name: Code Coverage Summary Report
+        uses: irongut/CodeCoverageSummary@v1.3.0
         with:
-          path: ./coverage.xml
-          minimum_coverage: 85
-          skip_covered: true # Set to true to remove 100% covered from report
-          fail_below_threshold: false # Fails the action if 85% threshold is not met
-          show_missing: true
-          only_changed_files: true
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          filename: ./coverage.xml
+          badge: true
+          fail_below_min: false
+          format: markdown
+          hide_branch_rate: false
+          hide_complexity: true
+          indicators: true
+          output: both
+          thresholds: '85'
+
+      - name: Add Coverage PR Comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        if: github.event_name == 'pull_request'
+        with:
+          recreate: true
+          path: code-coverage-results.md
 
   a11y-testing:
     runs-on: ubuntu-latest

--- a/.github/workflows/testing-from-build.yml
+++ b/.github/workflows/testing-from-build.yml
@@ -47,15 +47,19 @@ jobs:
           pwd
           ls -al | grep 'coverage'
 
-      - name: Post Coverage Report to Pull Request
-        if: github.event_name == 'pull_request'
-        uses: orgoro/coverage@v3.2
+      - name: Pre-processing Coverage Report
+        run: sed -i 's#filename="#filename="backend-api/src/#g' ./*.xml
+
+      - name: Publish Coverage Report to Pull Request
+        uses: 5monkeys/cobertura-action@master
         with:
-            coverageFile: ./coverage.xml
-            token: ${{ secrets.GITHUB_TOKEN }}
-            thresholdNew: 0.9
-            thresholdModified: 0.9
-            thresholdAll: 0.85
+          path: ./coverage.xml
+          minimum_coverage: 85
+          skip_covered: true # Set to true to remove 100% covered from report
+          fail_below_threshold: false # Fails the action if 85% threshold is not met
+          show_missing: true
+          only_changed_files: true
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
 
   a11y-testing:
     runs-on: ubuntu-latest

--- a/.github/workflows/testing-from-build.yml
+++ b/.github/workflows/testing-from-build.yml
@@ -53,6 +53,9 @@ jobs:
         with:
             coverageFile: ./coverage.xml
             token: ${{ secrets.GITHUB_TOKEN }}
+            thresholdNew: 0.9
+            thresholdModified: 0.9
+            thresholdAll: 0.85
 
   a11y-testing:
     runs-on: ubuntu-latest

--- a/.github/workflows/testing-from-ghcr.yml
+++ b/.github/workflows/testing-from-ghcr.yml
@@ -49,19 +49,25 @@ jobs:
           pwd
           ls -al | grep 'coverage'
 
-      - name: Pre-processing Coverage Report
-        run: sed -i 's#filename="#filename="backend-api/src/#g' ./*.xml
-
-      - name: Publish Coverage Report to Pull Request
-        uses: 5monkeys/cobertura-action@master
+      - name: Code Coverage Summary Report
+        uses: irongut/CodeCoverageSummary@v1.3.0
         with:
-          path: ./coverage.xml
-          minimum_coverage: 85
-          skip_covered: true # Set to true to remove 100% covered from report
-          fail_below_threshold: false # Fails the action if 85% threshold is not met
-          show_missing: true
-          only_changed_files: true
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          filename: ./coverage.xml
+          badge: true
+          fail_below_min: false
+          format: markdown
+          hide_branch_rate: false
+          hide_complexity: true
+          indicators: true
+          output: both
+          thresholds: '85'
+
+      - name: Add Coverage PR Comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        if: github.event_name == 'pull_request'
+        with:
+          recreate: true
+          path: code-coverage-results.md
 
   a11y-testing:
     runs-on: ubuntu-latest

--- a/.github/workflows/testing-from-ghcr.yml
+++ b/.github/workflows/testing-from-ghcr.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Post Coverage Report to Pull Request
         if: github.event_name == 'pull_request'
-        uses: orgoro/coverage@v3.1
+        uses: orgoro/coverage@v3.2
         with:
             coverageFile: ./coverage.xml
             token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/testing-from-ghcr.yml
+++ b/.github/workflows/testing-from-ghcr.yml
@@ -49,15 +49,19 @@ jobs:
           pwd
           ls -al | grep 'coverage'
 
-      - name: Post Coverage Report to Pull Request
-        if: github.event_name == 'pull_request'
-        uses: orgoro/coverage@v3.2
+      - name: Pre-processing Coverage Report
+        run: sed -i 's#filename="#filename="backend-api/src/#g' ./*.xml
+
+      - name: Publish Coverage Report to Pull Request
+        uses: 5monkeys/cobertura-action@master
         with:
-            coverageFile: ./coverage.xml
-            token: ${{ secrets.GITHUB_TOKEN }}
-            thresholdNew: 0.9
-            thresholdModified: 0.9
-            thresholdAll: 0.85
+          path: ./coverage.xml
+          minimum_coverage: 85
+          skip_covered: true # Set to true to remove 100% covered from report
+          fail_below_threshold: false # Fails the action if 85% threshold is not met
+          show_missing: true
+          only_changed_files: true
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
 
   a11y-testing:
     runs-on: ubuntu-latest

--- a/.github/workflows/testing-from-ghcr.yml
+++ b/.github/workflows/testing-from-ghcr.yml
@@ -55,6 +55,9 @@ jobs:
         with:
             coverageFile: ./coverage.xml
             token: ${{ secrets.GITHUB_TOKEN }}
+            thresholdNew: 0.9
+            thresholdModified: 0.9
+            thresholdAll: 0.85
 
   a11y-testing:
     runs-on: ubuntu-latest

--- a/.github/workflows/testing-from-ghcr.yml
+++ b/.github/workflows/testing-from-ghcr.yml
@@ -49,7 +49,7 @@ jobs:
           pwd
           ls -al | grep 'coverage'
 
-      - name: Coverage Action
+      - name: Post Coverage Report to Pull Request
         if: github.event_name == 'pull_request'
         uses: orgoro/coverage@v3.1
         with:


### PR DESCRIPTION
The other major coverage tools output too much to the PR, and make it difficult to use for Review.
[cobertura-report](https://github.com/marketplace/actions/cobertura-report) has an outstanding issue with displaying modified files, as well as broke when the merge occurs due to this. It did not break when it output the entire coverage report to the PR
[code-coverage-report-action](https://github.com/marketplace/actions/code-coverage-report-action) while nice to have a diff on old coverage reports, outputs everything as if it were on the docker container and has no ability to hide 100% items.

The new action, while it doesnt display line numbers, gives the reviewer easy access to bring the testing up to 90% threshold, while keeping the pr clean.