### PR TITLE
Disallow Submitting for Future Audit Years, Add 2024+ to Search

### DIFF
--- a/backend/dissemination/forms.py
+++ b/backend/dissemination/forms.py
@@ -1,5 +1,6 @@
 from django import forms
 from .searchlib.search_constants import text_input_delimiters, report_id_delimiters
+from datetime import date
 
 
 def clean_text_field(text_input, delimiters=text_input_delimiters):
@@ -58,8 +59,8 @@ class AdvancedSearchForm(forms.Form):
 
     # Multiple choice field Tuples. "choices" variable in field declaration.
     AY_choices = (("all_years", "All years"),) + tuple(
-        (x, str(x)) for x in reversed(range(2016, 2024))
-    )
+        (x, str(x)) for x in reversed(range(2016, date.today().year + 1))
+    )  # (("all_years", "All years"), (2016, "2016"), ..., (currentYear, "currentYear"))
     findings_choices = list(zip(*findings_field_mapping.values()))
     direct_funding_choices = (
         ("direct_funding", "Direct funding"),
@@ -207,8 +208,8 @@ class SearchForm(forms.Form):
 
     # Multiple choice field Tuples. "choices" variable in field declaration.
     AY_choices = (("all_years", "All years"),) + tuple(
-        (x, str(x)) for x in reversed(range(2016, 2024))
-    )
+        (x, str(x)) for x in reversed(range(2016, date.today().year + 1))
+    )  # (("all_years", "All years"), (2016, "2016"), ..., (currentYear, "currentYear"))
     entity_type_choices = list(zip(*entity_type_field_mapping.values()))
 
     # Query params

--- a/backend/dissemination/views.py
+++ b/backend/dissemination/views.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import date, timedelta
 import logging
 import math
 import time
@@ -42,6 +42,11 @@ from users.permissions import can_read_tribal
 import newrelic.agent
 
 logger = logging.getLogger(__name__)
+
+default_checked_audit_years = [
+    date.today().year,
+    date.today().year - 1,
+]  # Auto-check this and last year
 
 
 def _add_search_params_to_newrelic(search_parameters):
@@ -145,7 +150,7 @@ class AdvancedSearch(View):
             {
                 "advanced_search_flag": True,
                 "form": form,
-                "form_user_input": {"audit_year": ["2023"]},
+                "form_user_input": {"audit_year": default_checked_audit_years},
                 "state_abbrevs": STATE_ABBREVS,
                 "summary_report_download_limit": SUMMARY_REPORT_DOWNLOAD_LIMIT,
             },
@@ -242,7 +247,7 @@ class Search(View):
             {
                 "advanced_search_flag": False,
                 "form": form,
-                "form_user_input": {"audit_year": ["2023"]},
+                "form_user_input": {"audit_year": default_checked_audit_years},
                 "state_abbrevs": STATE_ABBREVS,
                 "summary_report_download_limit": SUMMARY_REPORT_DOWNLOAD_LIMIT,
             },

--- a/backend/report_submission/forms.py
+++ b/backend/report_submission/forms.py
@@ -57,9 +57,13 @@ class AuditeeInfoForm(forms.Form):
                 raise forms.ValidationError(
                     "Auditee fiscal period end date must be later than auditee fiscal period start date"
                 )
-            if auditee_fiscal_period_end >= date.today():
+
+            if (
+                auditee_fiscal_period_start >= date.today()
+                or auditee_fiscal_period_end >= date.today()
+            ):
                 raise forms.ValidationError(
-                    "Auditee fiscal period end date must be earlier than today"
+                    "Auditee fiscal period dates must be earlier than today"
                 )
 
 

--- a/backend/report_submission/forms.py
+++ b/backend/report_submission/forms.py
@@ -1,8 +1,10 @@
+from datetime import date
+
 from django import forms
 from django.core.validators import RegexValidator
-from config.settings import CHARACTER_LIMITS_GENERAL, STATE_ABBREVS
 
 from api.uei import get_uei_info_from_sam_gov
+from config.settings import CHARACTER_LIMITS_GENERAL, STATE_ABBREVS
 
 
 # Regex for words, includes non-[A-Z] ASCII characters like ñ and ī.
@@ -54,6 +56,10 @@ class AuditeeInfoForm(forms.Form):
             if auditee_fiscal_period_start >= auditee_fiscal_period_end:
                 raise forms.ValidationError(
                     "Auditee fiscal period end date must be later than auditee fiscal period start date"
+                )
+            if auditee_fiscal_period_end >= date.today():
+                raise forms.ValidationError(
+                    "Auditee fiscal period end date must be earlier than today"
                 )
 
 

--- a/backend/report_submission/templates/report_submission/step-2.html
+++ b/backend/report_submission/templates/report_submission/step-2.html
@@ -91,12 +91,14 @@
                                     aria-describedby="auditee_fiscal_period_start-hint"
                                     aria-required="true"
                                     required
-                                    data-validate-not-null=""/>
+                                    data-validate-not-null=""
+                                    data-validate-date-before-present="" />
                             </div>
                             <ul class="usa-error-message"
                                 id="auditee_fiscal_period_start-error-message"
                                 role="alert">
                                 <li id="auditee_fiscal_period_start-not-null" hidden>Can&#39;t be null</li>
+                                <li id="auditee_fiscal_period_start-date-before-present" hidden>Start date must be earlier than today</li>
                             </ul>
                         </div>
                     </div>

--- a/backend/report_submission/templates/report_submission/step-2.html
+++ b/backend/report_submission/templates/report_submission/step-2.html
@@ -118,13 +118,15 @@
                                     aria-required="true"
                                     required
                                     data-validate-not-null=""
-                                    data-validate-date-comes-after="auditee_fiscal_period_start" />
+                                    data-validate-date-comes-after="auditee_fiscal_period_start"
+                                    data-validate-date-before-present="" />
                             </div>
                             <ul class="usa-error-message"
                                 id="auditee_fiscal_period_end-error-message"
                                 role="alert">
                                 <li id="auditee_fiscal_period_end-not-null" hidden>Can&#39;t be null</li>
                                 <li id="auditee_fiscal_period_end-date-order" hidden>End date must be later than start date</li>
+                                <li id="auditee_fiscal_period_end-date-before-present" hidden>End date must be earlier than today</li>
                             </ul>
                         </div>
                     </div>

--- a/backend/report_submission/test_views.py
+++ b/backend/report_submission/test_views.py
@@ -328,7 +328,7 @@ class TestPreliminaryViews(TestCase):
     @patch("report_submission.forms.get_uei_info_from_sam_gov")
     def test_step_two_auditeeinfo_future_enddate(self, mock_get_uei_info):
         """
-        Check that the server validates that start date preceeds end date
+        Check that the server validates that end date preceeds current date
         """
         mock_get_uei_info.return_value = {"valid": True}
 
@@ -358,7 +358,7 @@ class TestPreliminaryViews(TestCase):
         errors = response.context["form"].non_field_errors()
         self.assertListEqual(
             errors,
-            ["Auditee fiscal period end date must be earlier than today"],
+            ["Auditee fiscal period dates must be earlier than today"],
         )
 
     def test_step_three_accessandsubmission_submission_fail(self):

--- a/backend/static/js/validate.js
+++ b/backend/static/js/validate.js
@@ -204,7 +204,7 @@ export const validations = {
   },
 
   validateDateBeforePresent: (field) => {
-    let endDate = new Date(field.value)
+    let endDate = new Date(field.value),
       currentDate = new Date();
     
     const result = {

--- a/backend/static/js/validate.js
+++ b/backend/static/js/validate.js
@@ -202,4 +202,17 @@ export const validations = {
 
     return startDate >= endDate ? { ...result, error: true } : result;
   },
+
+  validateDateBeforePresent: (field) => {
+    let endDate = new Date(field.value)
+      currentDate = new Date();
+    
+    const result = {
+      error: false,
+      fieldId: field.id,
+      validation: 'date-before-present',
+    };
+
+    return endDate >= currentDate ? { ...result, error: true } : result;
+  },
 };


### PR DESCRIPTION
# Disallow Submitting for Future Audit Years, Add 2024+ to Search

Otherwise known as disallowing chronomancy. Sorry, time wizards!

Issue: Closes https://github.com/GSA-TTS/FAC/issues/3659

## Changes:
1. Disallow submission with end date after today
    * A JS validation that shows upon entering the date
    * A Python validation that will reload the page with a display error if a bad date gets submitted
    * A related unit test
2. Include audit years 2024+ in the search filters
    * Have audit year choices include 2016 to the current year
    * Auto-check both the current and previous year (2024 and 2023, right now)

## How to test:
1. Switch to this branch and run normally. Ensure JS is rebuilt.
2. Start a submission, verify that too-late end dates are not enterable. 
3. Check out search, verify that the current year is included and checked, and that 2023 is still checked.

## Screenshots:
Trying to enter a too-late date:
![image](https://github.com/user-attachments/assets/34a03c02-972c-4464-a999-b8bb95335b7c)

_Somehow_ managing to submit a too-late-date:
![image](https://github.com/user-attachments/assets/30ce30c3-5ab2-4b89-8cc3-ab1141c12e9b)

Up to current year search, with current and previous year auto-checked:
![image](https://github.com/user-attachments/assets/b099f836-3ee3-48df-b21a-e9481d93e483)


## PR checklist: submitters

- [x]   Link to an issue if possible. If there’s no issue, describe what your branch does. Even if there is an issue, a brief description in the PR is still useful.
- [ ]   List any special steps reviewers have to follow to test the PR. For example, adding a local environment variable, creating a local test file, etc.
- [ ]   For extra credit, submit a screen recording like [this one](https://github.com/GSA-TTS/FAC/pull/1821).
- [ ]   Make sure you’ve merged `main` into your branch shortly before creating the PR. (You should also be merging `main` into your branch regularly during development.)
- [ ]   Make sure you’ve accounted for any migrations. When you’re about to create the PR, bring up the application locally and then run `git status | grep migrations`. If there are any results, you probably need to add them to the branch for the PR. Your PR should have only **one** new migration file for each of the component apps, except in rare circumstances; you may need to delete some and re-run `python manage.py makemigrations` to reduce the number to one. (Also, unless in exceptional circumstances, your PR should not delete any migration files.)
- [ ]   Make sure that whatever feature you’re adding has tests that cover the feature. This includes test coverage to make sure that the previous workflow still works, if applicable.
- [ ]   Make sure the full-submission.cy.js [Cypress test](https://github.com/GSA-TTS/FAC/blob/main/docs/testing.md#end-to-end-testing) passes, if applicable.
- [ ]   Do manual testing locally. Our tests are not good enough yet to allow us to skip this step. If that’s not applicable for some reason, check this box.
- [ ]   Verify that no Git surgery was necessary, or, if it was necessary at any point, repeat the testing after it’s finished.
- [ ]   Once a PR is merged, keep an eye on it until it’s deployed to dev, and do enough testing on dev to verify that it deployed successfully, the feature works as expected, and the happy path for the broad feature area (such as submission) still works.

## PR checklist: reviewers

- [ ]   Pull the branch to your local environment and run `make docker-clean; make docker-first-run && docker compose up`; then run `docker compose exec web /bin/bash -c "python manage.py test"`
- [ ]   Manually test out the changes locally, or check this box to verify that it wasn’t applicable in this case.
- [ ]   Check that the PR has appropriate tests. Look out for changes in HTML/JS/JSON Schema logic that may need to be captured in Python tests even though the logic isn’t in Python.
- [ ]   Verify that no Git surgery is necessary at any point (such as during a merge party), or, if it was, repeat the testing after it’s finished.

The larger the PR, the stricter we should be about these points.
