### PR TITLE
Change cors resource from timestamp() to md5

### DIFF
--- a/terraform/shared/modules/cors/cors-script.sh
+++ b/terraform/shared/modules/cors/cors-script.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
 # Modifying this file will cause terraform to update it in the system and re-apply the cors headers,
-# since the md5 will be changing.
+# since the md5 will be changing. To force a reapply of the cors headers, change the below value.
+# v0.001
 
 curl -L "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
 unzip -q awscliv2.zip && rm awscliv2.zip

--- a/terraform/shared/modules/cors/cors-script.sh
+++ b/terraform/shared/modules/cors/cors-script.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Modifying this file will cause terraform to update it in the system and re-apply the cors headers,
+# since the md5 will be changing.
+
 curl -L "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
 unzip -q awscliv2.zip && rm awscliv2.zip
 ./aws/install -i ~/usr -b ~/bin

--- a/terraform/shared/modules/cors/cors.tf
+++ b/terraform/shared/modules/cors/cors.tf
@@ -12,9 +12,6 @@ resource "null_resource" "cors_header" {
   # an md5 hash, which, once this goes into the system, will rarely (if ever)
   # be updated
   triggers = {
-    always_run = "${timestamp()}"
-  }
-  lifecycle {
-    prevent_destroy = true
+    md5 = "${filemd5("${path.module}/cors-script.sh")}"
   }
 }

--- a/terraform/shared/modules/cors/cors.tf
+++ b/terraform/shared/modules/cors/cors.tf
@@ -8,9 +8,8 @@ resource "null_resource" "cors_header" {
     command     = "./cors-script.sh ${var.cf_org_name} ${var.cf_space_name} ${local.script_path}"
   }
   # https://github.com/hashicorp/terraform/issues/8266#issuecomment-454377049
-  # A clever way to get this to run every time, otherwise we would be relying on
-  # an md5 hash, which, once this goes into the system, will rarely (if ever)
-  # be updated
+  # Using timestamp() seems to be breaking the terraform plans, so opting for the
+  # resource to be updated if a change occurs to the 'cors-script.sh'
   triggers = {
     md5 = "${filemd5("${path.module}/cors-script.sh")}"
   }

--- a/terraform/shared/modules/cors/cors.tf
+++ b/terraform/shared/modules/cors/cors.tf
@@ -14,4 +14,7 @@ resource "null_resource" "cors_header" {
   triggers = {
     always_run = "${timestamp()}"
   }
+  lifecycle {
+    prevent_destroy = true
+  }
 }


### PR DESCRIPTION
If the CORS header module that we recently implemented is acting up more, this can be used as a patch to lock its md5, and we can update it manually by changing the comment in `cors-script.sh`

## PR checklist: submitters

- [ ]   Link to an issue if possible. If there’s no issue, describe what your branch does. Even if there is an issue, a brief description in the PR is still useful.
- [ ]   List any special steps reviewers have to follow to test the PR. For example, adding a local environment variable, creating a local test file, etc.
- [ ]   For extra credit, submit a screen recording like [this one](https://github.com/GSA-TTS/FAC/pull/1821).
- [ ]   Make sure you’ve merged `main` into your branch shortly before creating the PR. (You should also be merging `main` into your branch regularly during development.)
- [ ]   Make sure you’ve accounted for any migrations. When you’re about to create the PR, bring up the application locally and then run `git status | grep migrations`. If there are any results, you probably need to add them to the branch for the PR. Your PR should have only **one** new migration file for each of the component apps, except in rare circumstances; you may need to delete some and re-run `python manage.py makemigrations` to reduce the number to one. (Also, unless in exceptional circumstances, your PR should not delete any migration files.)
- [ ]   Make sure that whatever feature you’re adding has tests that cover the feature. This includes test coverage to make sure that the previous workflow still works, if applicable.
- [ ]   Make sure the full-submission.cy.js [Cypress test](https://github.com/GSA-TTS/FAC/blob/main/docs/testing.md#end-to-end-testing) passes, if applicable.
- [ ]   Do manual testing locally. Our tests are not good enough yet to allow us to skip this step. If that’s not applicable for some reason, check this box.
- [ ]   Verify that no Git surgery was necessary, or, if it was necessary at any point, repeat the testing after it’s finished.
- [ ]   Once a PR is merged, keep an eye on it until it’s deployed to dev, and do enough testing on dev to verify that it deployed successfully, the feature works as expected, and the happy path for the broad feature area (such as submission) still works.

## PR checklist: reviewers

- [ ]   Pull the branch to your local environment and run `make docker-clean; make docker-first-run && docker compose up`; then run `docker compose exec web /bin/bash -c "python manage.py test"`
- [ ]   Manually test out the changes locally, or check this box to verify that it wasn’t applicable in this case.
- [ ]   Check that the PR has appropriate tests. Look out for changes in HTML/JS/JSON Schema logic that may need to be captured in Python tests even though the logic isn’t in Python.
- [ ]   Verify that no Git surgery is necessary at any point (such as during a merge party), or, if it was, repeat the testing after it’s finished.

The larger the PR, the stricter we should be about these points.
