### PR TITLE
Remove workbook after successful submission

### DIFF
--- a/backend/audit/views/views.py
+++ b/backend/audit/views/views.py
@@ -58,7 +58,7 @@ from audit.validators import (
     validate_secondary_auditors_json,
 )
 
-from dissemination.remove_workbook_artifacts import removed_workbook_artifacts
+from dissemination.remove_workbook_artifacts import remove_workbook_artifacts
 from dissemination.file_downloads import get_download_url, get_filename
 from dissemination.models import General
 
@@ -743,7 +743,7 @@ class SubmissionView(CertifyingAuditeeRequiredMixin, generic.View):
                     event_type=SubmissionEvent.EventType.DISSEMINATED,
                 )
                 # Remove workbook artifacts after the report has been disseminated.
-                removed_workbook_artifacts(sac)
+                remove_workbook_artifacts(sac)
             else:
                 pass
                 # FIXME: We should now provide a reasonable error to the user.

--- a/backend/audit/views/views.py
+++ b/backend/audit/views/views.py
@@ -58,6 +58,7 @@ from audit.validators import (
     validate_secondary_auditors_json,
 )
 
+from dissemination.remove_workbook_artifacts import removed_workbook_artifacts
 from dissemination.file_downloads import get_download_url, get_filename
 from dissemination.models import General
 
@@ -741,6 +742,8 @@ class SubmissionView(CertifyingAuditeeRequiredMixin, generic.View):
                     event_user=request.user,
                     event_type=SubmissionEvent.EventType.DISSEMINATED,
                 )
+                # Remove workbook artifacts after the report has been disseminated.
+                removed_workbook_artifacts(sac)
             else:
                 pass
                 # FIXME: We should now provide a reasonable error to the user.

--- a/backend/dissemination/remove_workbook_artifacts.py
+++ b/backend/dissemination/remove_workbook_artifacts.py
@@ -8,7 +8,7 @@ from botocore.client import ClientError, Config
 logger = logging.getLogger(__name__)
 
 
-def removed_workbook_artifacts(sac):
+def remove_workbook_artifacts(sac):
     """
     Remove all workbook artifacts associated with the given sac.
     """

--- a/backend/dissemination/remove_workbook_artifacts.py
+++ b/backend/dissemination/remove_workbook_artifacts.py
@@ -1,7 +1,6 @@
 import logging
 
 from django.conf import settings
-from django.http import Http404
 from audit.models.models import ExcelFile
 from boto3 import client as boto3_client
 from botocore.client import ClientError, Config
@@ -35,8 +34,9 @@ def removed_workbook_artifacts(sac):
             f"Failed to delete files from fac-db and S3 for report: {sac.report_id}. Error: {e}"
         )
 
+
 def delete_files_in_bulk(filenames, sac):
-    """ Delete files from S3 in bulk. """
+    """Delete files from S3 in bulk."""
     # This client uses the internal endpoint URL because we're making a request to S3 from within the app
     s3_client = boto3_client(
         service_name="s3",

--- a/backend/dissemination/remove_workbook_artifacts.py
+++ b/backend/dissemination/remove_workbook_artifacts.py
@@ -65,7 +65,7 @@ def delete_files_in_bulk(filenames, sac):
         if errors:
             for error in errors:
                 logger.error(
-                    f"Failed to delete {error['Key']} from S3 for report: {sac.report_id}. Error: {error['Message']}"
+                    f"Failed to delete {error['Key']} from S3 for report: {sac.report_id}. Error: {error['Message']}"  # nosec B608
                 )
 
     except ClientError as e:

--- a/backend/dissemination/remove_workbook_artifacts.py
+++ b/backend/dissemination/remove_workbook_artifacts.py
@@ -1,0 +1,74 @@
+import logging
+
+from django.conf import settings
+from django.http import Http404
+from audit.models.models import ExcelFile
+from boto3 import client as boto3_client
+from botocore.client import ClientError, Config
+
+logger = logging.getLogger(__name__)
+
+
+def removed_workbook_artifacts(sac):
+    """
+    Remove all workbook artifacts associated with the given sac.
+    """
+    try:
+        excel_files = ExcelFile.objects.filter(sac=sac)
+        files = [f"excel/{excel_file.filename}" for excel_file in excel_files]
+
+        if files:
+            # Delete the records from the database
+            count = excel_files.count()
+            excel_files.delete()
+            logger.info(
+                f"Deleted {count} excelfile records from fac-db for report: {sac.report_id}"
+            )
+
+            # Delete the files from S3 in bulk
+            delete_files_in_bulk(files, sac)
+
+    except ExcelFile.DoesNotExist:
+        logger.info(f"No files found to delete for report: {sac.report_id}")
+    except Exception as e:
+        logger.error(
+            f"Failed to delete files from fac-db and S3 for report: {sac.report_id}. Error: {e}"
+        )
+
+def delete_files_in_bulk(filenames, sac):
+    """ Delete files from S3 in bulk. """
+    # This client uses the internal endpoint URL because we're making a request to S3 from within the app
+    s3_client = boto3_client(
+        service_name="s3",
+        region_name=settings.AWS_S3_PRIVATE_REGION_NAME,
+        aws_access_key_id=settings.AWS_PRIVATE_ACCESS_KEY_ID,
+        aws_secret_access_key=settings.AWS_PRIVATE_SECRET_ACCESS_KEY,
+        endpoint_url=settings.AWS_S3_PRIVATE_INTERNAL_ENDPOINT,
+        config=Config(signature_version="s3v4"),
+    )
+
+    try:
+        delete_objects = [{"Key": filename} for filename in filenames]
+
+        response = s3_client.delete_objects(
+            Bucket=settings.AWS_PRIVATE_STORAGE_BUCKET_NAME,
+            Delete={"Objects": delete_objects},
+        )
+
+        deleted_files = response.get("Deleted", [])
+        for deleted in deleted_files:
+            logger.info(
+                f"Successfully deleted {deleted['Key']} from S3 for report: {sac.report_id}"
+            )
+
+        errors = response.get("Errors", [])
+        if errors:
+            for error in errors:
+                logger.error(
+                    f"Failed to delete {error['Key']} from S3 for report: {sac.report_id}. Error: {error['Message']}"
+                )
+
+    except ClientError as e:
+        logger.error(
+            f"Failed to delete files from S3 for report: {sac.report_id}. Error: {e}"
+        )

--- a/backend/dissemination/test_remove_workbook_artifacts.py
+++ b/backend/dissemination/test_remove_workbook_artifacts.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 from audit.models.models import ExcelFile, SingleAuditChecklist
 from model_bakery import baker
 
-from dissemination.remove_workbook_artifacts import removed_workbook_artifacts
+from dissemination.remove_workbook_artifacts import remove_workbook_artifacts
 
 
 class RemovedWorkbookArtifactsTestCase(TestCase):
@@ -22,7 +22,7 @@ class RemovedWorkbookArtifactsTestCase(TestCase):
             ExcelFile, sac=sac, form_section="another_fake_section"
         )
 
-        removed_workbook_artifacts(sac)
+        remove_workbook_artifacts(sac)
 
         # Assert that the ExcelFile instances are deleted
         self.assertFalse(ExcelFile.objects.filter(sac=sac).exists())
@@ -47,7 +47,7 @@ class RemovedWorkbookArtifactsTestCase(TestCase):
         # Ensure no ExcelFile instances exist for this SAC
         ExcelFile.objects.filter(sac=sac).delete()
 
-        removed_workbook_artifacts(sac)
+        remove_workbook_artifacts(sac)
 
         # Assert that no ExcelFile instances exist
         self.assertFalse(ExcelFile.objects.filter(sac=sac).exists())

--- a/backend/dissemination/test_remove_workbook_artifacts.py
+++ b/backend/dissemination/test_remove_workbook_artifacts.py
@@ -1,4 +1,3 @@
-import logging
 from django.test import TestCase
 from unittest.mock import patch
 from audit.models.models import ExcelFile, SingleAuditChecklist
@@ -10,9 +9,7 @@ from dissemination.remove_workbook_artifacts import removed_workbook_artifacts
 class RemovedWorkbookArtifactsTestCase(TestCase):
 
     @patch("dissemination.remove_workbook_artifacts.delete_files_in_bulk")
-    def test_removed_workbook_artifacts_success(
-        self, mock_delete_files_in_bulk
-    ):
+    def test_removed_workbook_artifacts_success(self, mock_delete_files_in_bulk):
         sac = baker.make(
             SingleAuditChecklist,
             submission_status=SingleAuditChecklist.STATUS.IN_PROGRESS,
@@ -57,5 +54,3 @@ class RemovedWorkbookArtifactsTestCase(TestCase):
 
         # Assert S3 bulk delete was not called
         mock_delete_files_in_bulk.assert_not_called()
-
-

--- a/backend/dissemination/test_remove_workbook_artifacts.py
+++ b/backend/dissemination/test_remove_workbook_artifacts.py
@@ -1,0 +1,61 @@
+import logging
+from django.test import TestCase
+from unittest.mock import patch
+from audit.models.models import ExcelFile, SingleAuditChecklist
+from model_bakery import baker
+
+from dissemination.remove_workbook_artifacts import removed_workbook_artifacts
+
+
+class RemovedWorkbookArtifactsTestCase(TestCase):
+
+    @patch("dissemination.remove_workbook_artifacts.delete_files_in_bulk")
+    def test_removed_workbook_artifacts_success(
+        self, mock_delete_files_in_bulk
+    ):
+        sac = baker.make(
+            SingleAuditChecklist,
+            submission_status=SingleAuditChecklist.STATUS.IN_PROGRESS,
+            report_id="test_report_id",
+        )
+
+        # Create ExcelFile instances
+        excel_file_1 = baker.make(ExcelFile, sac=sac, form_section="fake_section")
+        excel_file_2 = baker.make(
+            ExcelFile, sac=sac, form_section="another_fake_section"
+        )
+
+        removed_workbook_artifacts(sac)
+
+        # Assert that the ExcelFile instances are deleted
+        self.assertFalse(ExcelFile.objects.filter(sac=sac).exists())
+
+        # Assert S3 bulk delete was called with the correct filenames
+        mock_delete_files_in_bulk.assert_called_once_with(
+            [
+                f"excel/{sac.report_id}--{excel_file_1.form_section}.xlsx",
+                f"excel/{sac.report_id}--{excel_file_2.form_section}.xlsx",
+            ],
+            sac,
+        )
+
+    @patch("dissemination.remove_workbook_artifacts.delete_files_in_bulk")
+    def test_removed_workbook_artifacts_no_files(self, mock_delete_files_in_bulk):
+        sac = baker.make(
+            SingleAuditChecklist,
+            submission_status=SingleAuditChecklist.STATUS.IN_PROGRESS,
+            report_id="test_report_id",
+        )
+
+        # Ensure no ExcelFile instances exist for this SAC
+        ExcelFile.objects.filter(sac=sac).delete()
+
+        removed_workbook_artifacts(sac)
+
+        # Assert that no ExcelFile instances exist
+        self.assertFalse(ExcelFile.objects.filter(sac=sac).exists())
+
+        # Assert S3 bulk delete was not called
+        mock_delete_files_in_bulk.assert_not_called()
+
+


### PR DESCRIPTION
## Description

This ticket introduces logic to automatically remove workbook artifacts once the audit report is submitted and disseminated.

## How to Test

1. Launch the stack locally and begin the report submission process.
2. As you progress through the submission steps, monitor MinIO at `localhost:9002` to verify that files are being uploaded.
3. Check the `audit_excelfile` database table to ensure that Excel file records are being created as you upload the files.
4. After submitting your report, check MinIO and the database table again. All uploaded files and their corresponding records should have been removed.

## PR Checklist: Submitter

- [ ]   Link to an issue if possible. If there’s no issue, describe what your branch does. Even if there is an issue, a brief description in the PR is still useful.
- [ ]   List any special steps reviewers have to follow to test the PR. For example, adding a local environment variable, creating a local test file, etc.
- [ ]   For extra credit, submit a screen recording like [this one](https://github.com/GSA-TTS/FAC/pull/1821).
- [ ]   Make sure you’ve merged `main` into your branch shortly before creating the PR. (You should also be merging `main` into your branch regularly during development.)
- [ ]   Make sure you’ve accounted for any migrations. When you’re about to create the PR, bring up the application locally and then run `git status | grep migrations`. If there are any results, you probably need to add them to the branch for the PR. Your PR should have only **one** new migration file for each of the component apps, except in rare circumstances; you may need to delete some and re-run `python manage.py makemigrations` to reduce the number to one. (Also, unless in exceptional circumstances, your PR should not delete any migration files.)
- [ ]   Make sure that whatever feature you’re adding has tests that cover the feature. This includes test coverage to make sure that the previous workflow still works, if applicable.
- [ ]   Make sure the full-submission.cy.js [Cypress test](https://github.com/GSA-TTS/FAC/blob/main/docs/testing.md#end-to-end-testing) passes, if applicable.
- [ ]   Do manual testing locally. Our tests are not good enough yet to allow us to skip this step. If that’s not applicable for some reason, check this box.
- [ ]   Verify that no Git surgery was necessary, or, if it was necessary at any point, repeat the testing after it’s finished.
- [ ]   Once a PR is merged, keep an eye on it until it’s deployed to dev, and do enough testing on dev to verify that it deployed successfully, the feature works as expected, and the happy path for the broad feature area (such as submission) still works.
- [ ]   Ensure that prior to merging, the working branch is up to date with main and the terraform plan is what you expect.

## PR Checklist: Reviewer

- [ ]   Pull the branch to your local environment and run `make docker-clean; make docker-first-run && docker compose up`; then run `docker compose exec web /bin/bash -c "python manage.py test"`
- [ ]   Manually test out the changes locally, or check this box to verify that it wasn’t applicable in this case.
- [ ]   Check that the PR has appropriate tests. Look out for changes in HTML/JS/JSON Schema logic that may need to be captured in Python tests even though the logic isn’t in Python.
- [ ]   Verify that no Git surgery is necessary at any point (such as during a merge party), or, if it was, repeat the testing after it’s finished.

The larger the PR, the stricter we should be about these points.

## Pre Merge Checklist: Merger

- [ ]   Ensure that prior to approving, the terraform plan is what we expect it to be. `-/+ resource "null_resource" "cors_header" ` should be destroying and recreating its self and ` ~ resource "cloudfoundry_app" "clamav_api" ` might be updating its `sha256` for the `fac-file-scanner` and `fac-av-${ENV}` by default.
- [ ]   Ensure that the branch is up to date with `main`.
- [ ]   Ensure that a terraform plan has been recently generated for the pull request.
