### PR TITLE
Convert new Admin API emails to lowercase

### DIFF
--- a/backend/support/api/admin_api_v1_1_0/create_functions.sql
+++ b/backend/support/api/admin_api_v1_1_0/create_functions.sql
@@ -126,7 +126,7 @@ BEGIN
         -- Are they already in the table?
         SELECT count(up.email) 
             FROM public.users_userpermission as up
-            WHERE email = params->>'email' INTO already_exists;
+            WHERE LOWER(email) = LOWER(params->>'email') INTO already_exists;
 
         -- If they are, we're going to exit.
         IF already_exists <> 0
@@ -146,7 +146,7 @@ BEGIN
             -- Can we make the 1 not magic... do a select into.
             INSERT INTO public.users_userpermission
                 (email, permission_id, user_id)
-                VALUES (params->>'email', read_tribal_id, null);
+                VALUES (LOWER(params->>'email'), read_tribal_id, null);
 
             RAISE INFO 'ADMIN_API add_tribal_access_email OK %', params->>'email';
             RETURN admin_api_v1_1_0_functions.log_admin_api_event('tribal-access-email-added', 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -17,6 +17,7 @@ We use [Django's test execution framework](https://docs.djangoproject.com/en/4.0
   - [Linting](#linting)
 - [End-to-end testing](#end-to-end-testing)
   - [Testing behind Login.gov](#testing-behind-logingov)
+- [Admin API testing](#admin-api-testing)
 
 ## Packages
  - [model_bakery](https://model-bakery.readthedocs.io/en/latest/), to help create data and instances within our tests
@@ -184,3 +185,30 @@ in files in [backend/cypress/e2e/](/backend/cypress/e2e). To run these tests:
  Github repository. To use them in a Github Actions workflow, use the [Github
  Actions secrets
  store](https://docs.github.com/en/actions/security-guides/encrypted-secrets)
+
+# Admin API Testing
+For interfacing the admin API locally, we will need to account for a few things.
+
+## Resources
+
+For communicating with the Postgrest API, you could use one of the following extensions if you are using Visual Studio Code:
+- [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client)
+- [Postman](https://marketplace.visualstudio.com/items?itemName=Postman.postman-for-vscode)
+
+Though keep in mind you should be able to use whatever API service you prefer to run.
+
+## Checklist
+
+1. When running `docker compose up`, make sure the `web-1` service completes the startup procedures.
+    - E.G., `STARTUP STARTUP_CHECK seed_cog_baseline PASS` should be one of the last startup logs. If this passes, then the API tables are up.
+2. Make sure you prepare your request headers with the following:
+    - `Authorization: Bearer {JWT}` is important for authenticating your requests.
+    - `x-api-user-id: {uuid}` should be populated with a user ID from the `support_administrative_key_uuids` table. You can create your own row in this table for local testing purposes.
+    - `x-api-key: {key}`
+    - `content-profile: {api-version}` is required for POST requests.
+    - `accept-profile: {api-version}` is required for GET requests.
+    - `Prefer: params=single-object` is needed for the API to read your payload. In most if not all cases, it is set to `params=single-object`.
+
+## "Cheat-sheet" for testing
+
+We have a `.rest` file in `/backend/support/api/admin_api_vX_X_X` that contains many of the admin API endpoints, as well the headers/parameters/payload that are needed to run it successfully.


### PR DESCRIPTION
Addresses #4187.

This SQL script gets, inserts, or deletes a user for the admin API depending on a few parameters. The proposed change involved with this PR ensures new users have their email reduced to lowercase. Any checks against users for the following events will account for lowercase emails:

- Removing Tribal API key access for a specified email.
- Adding read access to the Tribal API for a specified email.
- Removing Tribal access emails.
- Adding Tribal access emails.

While this should account for new accesses to the Admin API, it does not modify or overwrite existing accesses with upper case characters. @jadudm will be writing a script that handles these.

## PR Checklist: Submitter

- [ ]   Link to an issue if possible. If there’s no issue, describe what your branch does. Even if there is an issue, a brief description in the PR is still useful.
- [ ]   List any special steps reviewers have to follow to test the PR. For example, adding a local environment variable, creating a local test file, etc.
- [ ]   For extra credit, submit a screen recording like [this one](https://github.com/GSA-TTS/FAC/pull/1821).
- [ ]   Make sure you’ve merged `main` into your branch shortly before creating the PR. (You should also be merging `main` into your branch regularly during development.)
- [ ]   Make sure you’ve accounted for any migrations. When you’re about to create the PR, bring up the application locally and then run `git status | grep migrations`. If there are any results, you probably need to add them to the branch for the PR. Your PR should have only **one** new migration file for each of the component apps, except in rare circumstances; you may need to delete some and re-run `python manage.py makemigrations` to reduce the number to one. (Also, unless in exceptional circumstances, your PR should not delete any migration files.)
- [ ]   Make sure that whatever feature you’re adding has tests that cover the feature. This includes test coverage to make sure that the previous workflow still works, if applicable.
- [ ]   Make sure the full-submission.cy.js [Cypress test](https://github.com/GSA-TTS/FAC/blob/main/docs/testing.md#end-to-end-testing) passes, if applicable.
- [ ]   Do manual testing locally. Our tests are not good enough yet to allow us to skip this step. If that’s not applicable for some reason, check this box.
- [ ]   Verify that no Git surgery was necessary, or, if it was necessary at any point, repeat the testing after it’s finished.
- [ ]   Once a PR is merged, keep an eye on it until it’s deployed to dev, and do enough testing on dev to verify that it deployed successfully, the feature works as expected, and the happy path for the broad feature area (such as submission) still works.
- [ ]   Ensure that prior to merging, the working branch is up to date with main and the terraform plan is what you expect.

## PR Checklist: Reviewer

- [ ]   Pull the branch to your local environment and run `make docker-clean; make docker-first-run && docker compose up`; then run `docker compose exec web /bin/bash -c "python manage.py test"`
- [ ]   Manually test out the changes locally, or check this box to verify that it wasn’t applicable in this case.
- [ ]   Check that the PR has appropriate tests. Look out for changes in HTML/JS/JSON Schema logic that may need to be captured in Python tests even though the logic isn’t in Python.
- [ ]   Verify that no Git surgery is necessary at any point (such as during a merge party), or, if it was, repeat the testing after it’s finished.

The larger the PR, the stricter we should be about these points.

## Pre Merge Checklist: Merger

- [ ]   Ensure that prior to approving, the terraform plan is what we expect it to be. `-/+ resource "null_resource" "cors_header" ` should be destroying and recreating its self and ` ~ resource "cloudfoundry_app" "clamav_api" ` might be updating its `sha256` for the `fac-file-scanner` and `fac-av-${ENV}` by default.
- [ ]   Ensure that the branch is up to date with `main`.
- [ ]   Ensure that a terraform plan has been recently generated for the pull request.
