### PR TITLE
Moves the MV function to 2a EST

### DIFF
--- a/.github/workflows/materialized-views.yml
+++ b/.github/workflows/materialized-views.yml
@@ -2,8 +2,8 @@
 name: Run the Materialized Views Function
 on:
   schedule:
-    # Invoke at 6 UTC EST every day
-    - cron: '0 6 * * *'
+    # Invoke at 7 UTC, 2 EST every day
+    - cron: '0 7 * * *'
   workflow_dispatch:
     inputs:
       environment:


### PR DESCRIPTION
Per discussion with Jadud, see #helpdesk in slack..
Last nights MV failed due to out of memory. We are currently ~12GB from cap, and running MV (6gb matrix) with Backups (9gb matrix) pushed it over the cap. 

Setting MV to an even hour `0700 UTC / 0200 EST` should fix that for now.

Potentially consider bringing quota from 80GB to 100GB in cloud.gov