### PR TITLE
Adds fac-prod.app.cloud.gov to cors file

### DIFF
--- a/terraform/shared/modules/cors/production-cors.json
+++ b/terraform/shared/modules/cors/production-cors.json
@@ -9,7 +9,8 @@
              "GET"
           ],
           "AllowedOrigins": [
-             "https://app.fac.gov"
+             "https://app.fac.gov",
+             "https://fac-prod.app.cloud.gov"
           ],
           "ExposeHeaders": [
              "ETag"


### PR DESCRIPTION
Small fix to AllowedOrigins in the cors.json file. _should_ solve the finding.

Follows: https://github.com/GSA-TTS/FAC/pull/4115