### PR TITLE
Modify memory usage for all envs to pull away from quota threshold

### DIFF
--- a/backend/manifests/vars/vars-preview.yml
+++ b/backend/manifests/vars/vars-preview.yml
@@ -1,7 +1,7 @@
 app_name: gsa-fac
-mem_amount: 4G
+mem_amount: 2G
 cf_env_name: PREVIEW
 env_name: preview
 service_name: preview
 endpoint: fac-preview.app.cloud.gov
-instances: 2
+instances: 1

--- a/backend/manifests/vars/vars-staging.yml
+++ b/backend/manifests/vars/vars-staging.yml
@@ -1,5 +1,5 @@
 app_name: gsa-fac
-mem_amount: 4G
+mem_amount: 2G
 cf_env_name: STAGING
 env_name: staging
 service_name: staging

--- a/terraform/dev/dev.tf
+++ b/terraform/dev/dev.tf
@@ -8,10 +8,12 @@ module "dev" {
 
   database_plan         = "medium-gp-psql"
   postgrest_instances   = 1
+  postgrest_memory      = 512
   swagger_instances     = 1
   https_proxy_instances = 1
   smtp_proxy_instances  = 1
   clamav_instances      = 1
+  clamav_memory         = 2048
   clamav_fs_instances   = 1
   recursive_delete      = true
   json_params = jsonencode(

--- a/terraform/preview/preview.tf
+++ b/terraform/preview/preview.tf
@@ -8,10 +8,12 @@ module "preview" {
 
   database_plan         = "medium-gp-psql"
   postgrest_instances   = 1
+  postgrest_memory      = 512
   swagger_instances     = 1
   https_proxy_instances = 1
   smtp_proxy_instances  = 1
-  clamav_instances      = 2
+  clamav_instances      = 1
+  clamav_memory         = 2048
   clamav_fs_instances   = 1
   recursive_delete      = true
   json_params = jsonencode(

--- a/terraform/shared/modules/env/postgrest.tf
+++ b/terraform/shared/modules/env/postgrest.tf
@@ -22,7 +22,7 @@ resource "cloudfoundry_app" "postgrest" {
   space        = data.cloudfoundry_space.apps.id
   docker_image = "ghcr.io/gsa-tts/fac/postgrest@${data.docker_registry_image.postgrest.sha256_digest}"
   timeout      = 180
-  memory       = 1024
+  memory       = var.postgrest_memory
   disk_quota   = 256
   instances    = var.postgrest_instances
   strategy     = "rolling"

--- a/terraform/shared/modules/env/variables.tf
+++ b/terraform/shared/modules/env/variables.tf
@@ -50,6 +50,12 @@ variable "postgrest_instances" {
   default     = 2
 }
 
+variable "postgrest_memory" {
+  type        = number
+  description = "the number of instances of the postgrest application to run (default: 2)"
+  default     = 1024
+}
+
 variable "swagger_instances" {
   type        = number
   description = "the number of instances of the swagger application to run (default: 2)"

--- a/terraform/staging/staging.tf
+++ b/terraform/staging/staging.tf
@@ -8,10 +8,12 @@ module "staging" {
 
   database_plan         = "medium-gp-psql"
   postgrest_instances   = 1
+  postgrest_memory      = 512
   swagger_instances     = 1
   https_proxy_instances = 1
   smtp_proxy_instances  = 1
   clamav_instances      = 1
+  clamav_memory         = 2048
   clamav_fs_instances   = 1
   recursive_delete      = true
   json_params = jsonencode(


### PR DESCRIPTION
Based on current operations, we feel it necessary to trim some of the memory used across the system to give us a little more flexibility, and not have failing runs due to quota.