### PR TITLE
#4476 Updated logic to count findings based on distinct reference number

### DIFF
--- a/backend/dissemination/views.py
+++ b/backend/dissemination/views.py
@@ -371,7 +371,11 @@ class AuditSummaryView(View):
         Wrap that data into a dict, and return it.
         """
         awards = FederalAward.objects.filter(report_id=report_id)
-        audit_findings = Finding.objects.filter(report_id=report_id)
+        audit_findings = (
+            Finding.objects.filter(report_id=report_id)
+            .order_by("reference_number")
+            .distinct("reference_number")
+        )
         audit_findings_text = FindingText.objects.filter(report_id=report_id)
         corrective_action_plan = CapText.objects.filter(report_id=report_id)
         notes_to_sefa = Note.objects.filter(report_id=report_id)


### PR DESCRIPTION
## Description 
A Federal awards workbook has over 400 entries (023-06-GSAFAC-0000016423), and the user declared the same finding reference number (2023-001) for most of them, with one associated finding text. Our frontend logic interprets the count based on the number of declared findings, not the uniqueness of the finding reference number. This results in approximately 400 findings being counted instead of one. However, since all findings share the same reference number, the user was expecting the tocal count to be one. This PR is to remedy the issue.
## How to test
1. Launch the application locally from the **main branch**.
2. Submit a report with at least two findings. Ensure that at least two of these findings share the same finding reference number.
   - **Example:** Submit a report with the following findings:
     - Finding 1: `reference_number = 2024-001`
     - Finding 2: `reference_number = 2024-001`
     - Finding 3: `reference_number = 2024-002`
3. After submitting the report, refresh the materialized view table. Then, access the report via the search page and confirm that the **total finding count** matches the **total number of findings declared**.
   - **Example:** If you declared 3 findings (as shown above), the total finding count displayed should be **3**.
4. Switch to the **PR branch** and repeat the same steps.
5. After submitting the report, refresh the materialized view table. Then, access the report via the search page and confirm that the **total finding count** matches the **total number of distinct finding reference numbers** in your report.
   - **Example:** With the same input as above, the distinct finding reference numbers are:
     - `2024-001`
     - `2024-002`
     The total finding count displayed should now be **2** (since `2024-001` appears twice but is counted only once).

Before
![image](https://github.com/user-attachments/assets/2b364fe6-8a6f-4615-9095-4c262ff2725d)
After
![image](https://github.com/user-attachments/assets/c487ae0c-04ad-4427-aa0f-65162fe52c59)

## PR Checklist: Submitter

- [ ]   Link to an issue if possible. If there’s no issue, describe what your branch does. Even if there is an issue, a brief description in the PR is still useful.
- [ ]   List any special steps reviewers have to follow to test the PR. For example, adding a local environment variable, creating a local test file, etc.
- [ ]   For extra credit, submit a screen recording like [this one](https://github.com/GSA-TTS/FAC/pull/1821).
- [ ]   Make sure you’ve merged `main` into your branch shortly before creating the PR. (You should also be merging `main` into your branch regularly during development.)
- [ ]   Make sure you’ve accounted for any migrations. When you’re about to create the PR, bring up the application locally and then run `git status | grep migrations`. If there are any results, you probably need to add them to the branch for the PR. Your PR should have only **one** new migration file for each of the component apps, except in rare circumstances; you may need to delete some and re-run `python manage.py makemigrations` to reduce the number to one. (Also, unless in exceptional circumstances, your PR should not delete any migration files.)
- [ ]   Make sure that whatever feature you’re adding has tests that cover the feature. This includes test coverage to make sure that the previous workflow still works, if applicable.
- [ ]   Make sure the full-submission.cy.js [Cypress test](https://github.com/GSA-TTS/FAC/blob/main/docs/testing.md#end-to-end-testing) passes, if applicable.
- [ ]   Do manual testing locally. Our tests are not good enough yet to allow us to skip this step. If that’s not applicable for some reason, check this box.
- [ ]   Verify that no Git surgery was necessary, or, if it was necessary at any point, repeat the testing after it’s finished.
- [ ]   Once a PR is merged, keep an eye on it until it’s deployed to dev, and do enough testing on dev to verify that it deployed successfully, the feature works as expected, and the happy path for the broad feature area (such as submission) still works.
- [ ]   Ensure that prior to merging, the working branch is up to date with main and the terraform plan is what you expect.

## PR Checklist: Reviewer

- [ ]   Pull the branch to your local environment and run `make docker-clean; make docker-first-run && docker compose up`; then run `docker compose exec web /bin/bash -c "python manage.py test"`
- [ ]   Manually test out the changes locally, or check this box to verify that it wasn’t applicable in this case.
- [ ]   Check that the PR has appropriate tests. Look out for changes in HTML/JS/JSON Schema logic that may need to be captured in Python tests even though the logic isn’t in Python.
- [ ]   Verify that no Git surgery is necessary at any point (such as during a merge party), or, if it was, repeat the testing after it’s finished.

The larger the PR, the stricter we should be about these points.

## Pre Merge Checklist: Merger

- [ ]   Ensure that prior to approving, the terraform plan is what we expect it to be. `-/+ resource "null_resource" "cors_header" ` should be destroying and recreating its self and ` ~ resource "cloudfoundry_app" "clamav_api" ` might be updating its `sha256` for the `fac-file-scanner` and `fac-av-${ENV}` by default.
- [ ]   Ensure that the branch is up to date with `main`.
- [ ]   Ensure that a terraform plan has been recently generated for the pull request.
