### PR TITLE
Add 'On Demand' Backup Operation

### DIFF
--- a/.github/workflows/fac-backup-util.yml
+++ b/.github/workflows/fac-backup-util.yml
@@ -25,6 +25,7 @@ on:
         options:
           - 'initial_backup'
           - 'deploy_backup'
+          - 'on_demand_backup'
 jobs:
   fac-backup:
     name: Perform Database Backup

--- a/backend/fac-backup-util.sh
+++ b/backend/fac-backup-util.sh
@@ -11,6 +11,7 @@ db_name="fac-db"
 backup_db_name="fac-snapshot-db"
 initial_date=$(date +%Y%m%d%H%M)
 scheduled_date=$(date +%m-%d-%H)
+on_demand_date=$(date +%m-%d-%H)
 daily_date=$(date +%m-%d)
 mkdir tmp && cd tmp || return
 
@@ -63,6 +64,18 @@ elif [ "$run_option" == "scheduled_backup" ]; then
     gonogo "row_count"
     RDSToS3Dump "$db_name" "$backup_s3_name" "scheduled/$scheduled_date"
     gonogo "db_to_s3"
+    AWSS3Sync "$s3_name" "$backup_s3_name"
+    gonogo "s3_sync"
+elif [ "$run_option" == "on_demand_backup" ]; then
+    GetUtil
+    InstallAWS
+    gonogo "install_aws"
+    RowCount "$db_name"
+    gonogo "row_count"
+    RDSToS3Dump "$db_name" "$backup_s3_name" "on-demand/$on_demand_date"
+    gonogo "db_to_s3"
+    RDSToRDS "$db_name" "$backup_db_name" "backup"
+    gonogo "db_to_db"
     AWSS3Sync "$s3_name" "$backup_s3_name"
     gonogo "s3_sync"
 elif [ "$run_option" == "daily_backup" ]; then


### PR DESCRIPTION
Expands the backup utility to accept an `on_demand_backup` operation.

Fundamentally, operates the exact same way as other backup commands, however, this one, after discussion with Sudha, will be prep for the SAC load. Instead of digging through the `scheduled` folder for the backup, we can isolate the data load to be at the following location: `s3://$BUCKET/backups/on-demand/MM-DD-HH/....` to better facilitate a smooth data loading operation.