### PR TITLE
Remove pre-deploy zap scan from staging and prod deploy

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -14,18 +14,10 @@ jobs:
     uses: ./.github/workflows/linting.yml
     secrets: inherit
 
-  # up to date scan of the staging instance
-  scan-staging:
-    name: ZAP scan of the staging site
-    uses: ./.github/workflows/zap-scan.yml
-    with:
-      url: "https://fac-staging.app.cloud.gov/"
-
   deploy-infrastructure-production:
     name: Deploy infrastructure (production)
     needs:
       - testing
-      - scan-staging
     uses: ./.github/workflows/terraform-apply-env.yml
     with:
       environment: "production"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -14,17 +14,10 @@ jobs:
     uses: ./.github/workflows/linting.yml
     secrets: inherit
 
-  scan-dev:
-    name: Zap Scan
-    uses: ./.github/workflows/zap-scan.yml
-    with:
-      url: "https://fac-dev.app.cloud.gov/"
-
   deploy-infrastructure-staging:
     name: Deploy infrastructure (staging)
     needs:
       - testing
-      - scan-dev
     uses: ./.github/workflows/terraform-apply-env.yml
     with:
       environment: "staging"


### PR DESCRIPTION
Removes the dev zap scan from the staging deployment.

v14 of zap action upgraded their `upload-artifact` version, which seems to not like having an existing artifact name in place. During a dev deployment, zap is done as one of the last steps. Rescanning before a staging deploy feels unnecessary.