### PR TITLE
Fixing type/compliance requirement validation error

### DIFF
--- a/backend/audit/intakelib/mapping_audit_findings.py
+++ b/backend/audit/intakelib/mapping_audit_findings.py
@@ -68,8 +68,8 @@ def extract_audit_findings(file, is_gsa_migration=False, auditee_uei=None):
 def audit_findings_named_ranges(errors):
     return _extract_named_ranges(
         errors,
-        audit_findings_field_mapping,
         audit_findings_column_mapping,
+        audit_findings_field_mapping,
         meta_mapping,
     )
 

--- a/backend/audit/intakelib/mapping_util.py
+++ b/backend/audit/intakelib/mapping_util.py
@@ -70,95 +70,83 @@ def _open_workbook(file):
 def _get_entries_by_path(dictionary, path):
     keys = path.split(".")
     val = dictionary
-
     for key in keys:
         try:
             val = val[key]
         except KeyError:
             return []
-
     return val
 
 
-def _extract_from_column_mapping(path, column_mapping, match=None):
+def _extract_from_column_mapping(path, row_index, column_mapping, match=None):
     """Extract named ranges from column mapping"""
     for key, value in column_mapping.items():
         if len(value) > 2 and (
             value[0] + "." + value[1] == path
             or (match and value[0] + "." + value[1] == path + "." + match.group(1))
         ):
-            return key
+            return key, row_index
+    return None, None
 
-    return None
 
-
-def _extract_from_field_mapping(path, field_mapping):
+def _extract_from_field_mapping(path, field_mapping, match=None):
     """Extract named ranges from field mapping"""
     for key, value in field_mapping.items():
-        if len(value) >= 2 and (path in [value[0], ".".join([value[0], value[1]])]):
-            return key
-
-    return None
-
-
-def _extract_from_meta_mapping(path, meta_mapping, match=None):
-    """Extract named ranges from meta mapping"""
-    for key, value in meta_mapping.items():
         if len(value) == 2 and (
-            value[0] == path or (value[0] == ".".join([path, match.group(1)]))
+            value[0] == path or (match and value[0] == ".".join([path, match.group(1)]))
         ):
-            return key
-
-    return None
+            return key, None
+    return None, None
 
 
 def _extract_error_details(error):
     if not bool(error.path):
         logger.info("No path found in error object")
         return None, None, None
-
     row_index = next((item for item in error.path if isinstance(item, int)), None)
     path = ".".join([item for item in error.path if not isinstance(item, int)])
     match = re.search(r"'(\w+)'", error.message) if error.message else None
-
     return path, row_index, match
 
 
-def _extract_key_from_award_entities(path, named_ranges):
+def _extract_key_from_award_entities(path, row_index, named_ranges):
     if path in [AWARD_ENTITY_NAME_PATH, AWARD_ENTITY_ID_PATH]:
         key = (
             AWARD_ENTITY_NAME_KEY
             if path == AWARD_ENTITY_NAME_PATH
             else AWARD_ENTITY_ID_KEY
         )
-
+        named_ranges.append((key, row_index))
         return key
-
     return None
 
 
 def _extract_named_ranges(errors, column_mapping, field_mapping, meta_mapping):
-    """Extract named ranges from mappings and errors"""
+    """Extract named ranges from column mapping and errors"""
     named_ranges = []
-
     for error in errors:
         path, row_index, match = _extract_error_details(error)
         if not path:
             continue
 
-        keyFound = _extract_key_from_award_entities(path, named_ranges)
-        if not keyFound:
-            keyFound = _extract_from_column_mapping(path, column_mapping, match)
+        # Extract named ranges from column mapping for award entities
+        keyFound = _extract_key_from_award_entities(path, row_index, named_ranges)
 
         if not keyFound:
-            keyFound = _extract_from_field_mapping(path, field_mapping)
+            keyFound, row_index = _extract_from_column_mapping(
+                path, row_index, column_mapping, match
+            )
+            if keyFound:
+                named_ranges.append((keyFound, row_index))
 
         if not keyFound:
-            keyFound = _extract_from_meta_mapping(path, meta_mapping, match)
+            keyFound, _ = _extract_from_field_mapping(path, field_mapping, match)
+            if not keyFound:
+                keyFound, _ = _extract_from_field_mapping(path, meta_mapping, match)
+            if keyFound:
+                named_ranges.append((keyFound, None))
 
-        if keyFound:
-            named_ranges.append((keyFound, row_index))
-        else:
+        if not keyFound:
             logger.info(f"No named range matches this error path: {error.path}")
 
     return named_ranges

--- a/backend/audit/intakelib/mapping_util.py
+++ b/backend/audit/intakelib/mapping_util.py
@@ -70,7 +70,7 @@ def _open_workbook(file):
 def _get_entries_by_path(dictionary, path):
     keys = path.split(".")
     val = dictionary
-    
+
     for key in keys:
         try:
             val = val[key]
@@ -140,9 +140,7 @@ def _extract_named_ranges(errors, column_mapping, field_mapping, meta_mapping):
         keyFound = _extract_key_from_award_entities(path, named_ranges)
 
         if not keyFound:
-            keyFound = _extract_from_column_mapping(
-                path, column_mapping, match
-            )
+            keyFound = _extract_from_column_mapping(path, column_mapping, match)
 
         if not keyFound:
             keyFound = _extract_from_field_mapping(path, field_mapping, match)

--- a/backend/audit/intakelib/mapping_util.py
+++ b/backend/audit/intakelib/mapping_util.py
@@ -137,19 +137,19 @@ def _extract_named_ranges(errors, column_mapping, field_mapping, meta_mapping):
         if not path:
             continue
 
-        keyFound = _extract_key_from_award_entities(path, named_ranges)
+        key_found = _extract_key_from_award_entities(path, named_ranges)
 
-        if not keyFound:
-            keyFound = _extract_from_column_mapping(path, column_mapping, match)
+        if not key_found:
+            key_found = _extract_from_column_mapping(path, column_mapping, match)
 
-        if not keyFound:
-            keyFound = _extract_from_field_mapping(path, field_mapping, match)
+        if not key_found:
+            key_found = _extract_from_field_mapping(path, field_mapping, match)
 
-        if not keyFound:
-            keyFound = _extract_from_field_mapping(path, meta_mapping, match)
+        if not key_found:
+            key_found = _extract_from_field_mapping(path, meta_mapping, match)
 
-        if keyFound:
-            named_ranges.append((keyFound, row_index))
+        if key_found:
+            named_ranges.append((key_found, row_index))
         else:
             logger.info(f"No named range matches this error path: {error.path}")
 

--- a/backend/audit/intakelib/mapping_util.py
+++ b/backend/audit/intakelib/mapping_util.py
@@ -95,12 +95,11 @@ def _extract_from_column_mapping(path, column_mapping, match=None):
 def _extract_from_field_mapping(path, field_mapping):
     """Extract named ranges from field mapping"""
     for key, value in field_mapping.items():
-        if len(value) >= 2 and (
-            path in [value[0], ".".join([value[0], value[1]])]
-        ):
+        if len(value) >= 2 and (path in [value[0], ".".join([value[0], value[1]])]):
             return key
 
     return None
+
 
 def _extract_from_meta_mapping(path, meta_mapping, match=None):
     """Extract named ranges from meta mapping"""
@@ -149,9 +148,7 @@ def _extract_named_ranges(errors, column_mapping, field_mapping, meta_mapping):
 
         keyFound = _extract_key_from_award_entities(path, named_ranges)
         if not keyFound:
-            keyFound = _extract_from_column_mapping(
-                path, column_mapping, match
-            )
+            keyFound = _extract_from_column_mapping(path, column_mapping, match)
 
         if not keyFound:
             keyFound = _extract_from_field_mapping(path, field_mapping)

--- a/backend/audit/intakelib/mapping_util.py
+++ b/backend/audit/intakelib/mapping_util.py
@@ -70,83 +70,98 @@ def _open_workbook(file):
 def _get_entries_by_path(dictionary, path):
     keys = path.split(".")
     val = dictionary
+
     for key in keys:
         try:
             val = val[key]
         except KeyError:
             return []
+
     return val
 
 
-def _extract_from_column_mapping(path, row_index, column_mapping, match=None):
+def _extract_from_column_mapping(path, column_mapping, match=None):
     """Extract named ranges from column mapping"""
     for key, value in column_mapping.items():
         if len(value) > 2 and (
             value[0] + "." + value[1] == path
             or (match and value[0] + "." + value[1] == path + "." + match.group(1))
         ):
-            return key, row_index
-    return None, None
+            return key
+
+    return None
 
 
-def _extract_from_field_mapping(path, field_mapping, match=None):
+def _extract_from_field_mapping(path, field_mapping):
     """Extract named ranges from field mapping"""
     for key, value in field_mapping.items():
-        if len(value) == 2 and (
-            value[0] == path or (match and value[0] == ".".join([path, match.group(1)]))
+        if len(value) >= 2 and (
+            path in [value[0], ".".join([value[0], value[1]])]
         ):
-            return key, None
-    return None, None
+            return key
+
+    return None
+
+def _extract_from_meta_mapping(path, meta_mapping, match=None):
+    """Extract named ranges from meta mapping"""
+    for key, value in meta_mapping.items():
+        if len(value) == 2 and (
+            value[0] == path or (value[0] == ".".join([path, match.group(1)]))
+        ):
+            return key
+
+    return None
 
 
 def _extract_error_details(error):
     if not bool(error.path):
         logger.info("No path found in error object")
         return None, None, None
+
     row_index = next((item for item in error.path if isinstance(item, int)), None)
     path = ".".join([item for item in error.path if not isinstance(item, int)])
     match = re.search(r"'(\w+)'", error.message) if error.message else None
+
     return path, row_index, match
 
 
-def _extract_key_from_award_entities(path, row_index, named_ranges):
+def _extract_key_from_award_entities(path, named_ranges):
     if path in [AWARD_ENTITY_NAME_PATH, AWARD_ENTITY_ID_PATH]:
         key = (
             AWARD_ENTITY_NAME_KEY
             if path == AWARD_ENTITY_NAME_PATH
             else AWARD_ENTITY_ID_KEY
         )
-        named_ranges.append((key, row_index))
+
         return key
+
     return None
 
 
 def _extract_named_ranges(errors, column_mapping, field_mapping, meta_mapping):
-    """Extract named ranges from column mapping and errors"""
+    """Extract named ranges from mappings and errors"""
     named_ranges = []
+
     for error in errors:
         path, row_index, match = _extract_error_details(error)
         if not path:
             continue
 
-        # Extract named ranges from column mapping for award entities
-        keyFound = _extract_key_from_award_entities(path, row_index, named_ranges)
-
+        keyFound = _extract_key_from_award_entities(path, named_ranges)
         if not keyFound:
-            keyFound, row_index = _extract_from_column_mapping(
-                path, row_index, column_mapping, match
+            keyFound = _extract_from_column_mapping(
+                path, column_mapping, match
             )
-            if keyFound:
-                named_ranges.append((keyFound, row_index))
 
         if not keyFound:
-            keyFound, _ = _extract_from_field_mapping(path, field_mapping, match)
-            if not keyFound:
-                keyFound, _ = _extract_from_field_mapping(path, meta_mapping, match)
-            if keyFound:
-                named_ranges.append((keyFound, None))
+            keyFound = _extract_from_field_mapping(path, field_mapping)
 
         if not keyFound:
+            keyFound = _extract_from_meta_mapping(path, meta_mapping, match)
+
+        if keyFound:
+            named_ranges.append((keyFound, row_index))
+        else:
             logger.info(f"No named range matches this error path: {error.path}")
 
     return named_ranges

--- a/backend/audit/test_intake_to_dissemination.py
+++ b/backend/audit/test_intake_to_dissemination.py
@@ -263,7 +263,7 @@ class IntakeToDisseminationTests(TestCase):
                             "program_name": "N/A",
                             "federal_agency_prefix": "12",
                             "three_digit_extension": "123",
-                            "compliance_requirement": "A",
+                            "compliance_requirement": "asdfasdf",
                             "additional_award_identification": "egd",
                         },
                         "findings": {

--- a/backend/audit/test_intake_to_dissemination.py
+++ b/backend/audit/test_intake_to_dissemination.py
@@ -263,7 +263,7 @@ class IntakeToDisseminationTests(TestCase):
                             "program_name": "N/A",
                             "federal_agency_prefix": "12",
                             "three_digit_extension": "123",
-                            "compliance_requirement": "asdfasdf",
+                            "compliance_requirement": "A",
                             "additional_award_identification": "egd",
                         },
                         "findings": {


### PR DESCRIPTION
Closes https://github.com/GSA-TTS/FAC/issues/4593

In this PR:
- Fixing a bug where specifying a bad compliance requirement (column C) in the findings workbook would error, as it should, but no error message would be displayed. This was caused by a mixup of parameters in `mapping_audit_findings.py`.
- I also cleaned up some of the code in `mapping_util.py`, which mostly includes simplifying the if-statements for finding the named range keys, removing the `row_index` param from some calls, and snake-casing `keyFound`

Testing:
- On main try uploading a findings workbook that has a bad compliance requirement. Because the column restricts its values, you can copy something like "asdf" and paste it to get around that. It will tell you there are errors, but none show up.
- Switching to this branch and uploading the same workbook should now show the error correctly
- A blank value should error correctly as well
- full-submission should pass

## PR Checklist: Submitter

- [ ]   Link to an issue if possible. If there’s no issue, describe what your branch does. Even if there is an issue, a brief description in the PR is still useful.
- [ ]   List any special steps reviewers have to follow to test the PR. For example, adding a local environment variable, creating a local test file, etc.
- [ ]   For extra credit, submit a screen recording like [this one](https://github.com/GSA-TTS/FAC/pull/1821).
- [ ]   Make sure you’ve merged `main` into your branch shortly before creating the PR. (You should also be merging `main` into your branch regularly during development.)
- [ ]   Make sure you’ve accounted for any migrations. When you’re about to create the PR, bring up the application locally and then run `git status | grep migrations`. If there are any results, you probably need to add them to the branch for the PR. Your PR should have only **one** new migration file for each of the component apps, except in rare circumstances; you may need to delete some and re-run `python manage.py makemigrations` to reduce the number to one. (Also, unless in exceptional circumstances, your PR should not delete any migration files.)
- [ ]   Make sure that whatever feature you’re adding has tests that cover the feature. This includes test coverage to make sure that the previous workflow still works, if applicable.
- [ ]   Make sure the full-submission.cy.js [Cypress test](https://github.com/GSA-TTS/FAC/blob/main/docs/testing.md#end-to-end-testing) passes, if applicable.
- [ ]   Do manual testing locally. Our tests are not good enough yet to allow us to skip this step. If that’s not applicable for some reason, check this box.
- [ ]   Verify that no Git surgery was necessary, or, if it was necessary at any point, repeat the testing after it’s finished.
- [ ]   Once a PR is merged, keep an eye on it until it’s deployed to dev, and do enough testing on dev to verify that it deployed successfully, the feature works as expected, and the happy path for the broad feature area (such as submission) still works.
- [ ]   Ensure that prior to merging, the working branch is up to date with main and the terraform plan is what you expect.

## PR Checklist: Reviewer

- [ ]   Pull the branch to your local environment and run `make docker-clean; make docker-first-run && docker compose up`; then run `docker compose exec web /bin/bash -c "python manage.py test"`
- [ ]   Manually test out the changes locally, or check this box to verify that it wasn’t applicable in this case.
- [ ]   Check that the PR has appropriate tests. Look out for changes in HTML/JS/JSON Schema logic that may need to be captured in Python tests even though the logic isn’t in Python.
- [ ]   Verify that no Git surgery is necessary at any point (such as during a merge party), or, if it was, repeat the testing after it’s finished.

The larger the PR, the stricter we should be about these points.

## Pre Merge Checklist: Merger

- [ ]   Ensure that prior to approving, the terraform plan is what we expect it to be. `-/+ resource "null_resource" "cors_header" ` should be destroying and recreating its self and ` ~ resource "cloudfoundry_app" "clamav_api" ` might be updating its `sha256` for the `fac-file-scanner` and `fac-av-${ENV}` by default.
- [ ]   Ensure that the branch is up to date with `main`.
- [ ]   Ensure that a terraform plan has been recently generated for the pull request.
