### PR TITLE
Adding @verify_status decorator to unlock endpoints

### DIFF
--- a/backend/audit/verify_status.py
+++ b/backend/audit/verify_status.py
@@ -1,0 +1,44 @@
+import logging
+
+from django.shortcuts import redirect
+from django.core.exceptions import PermissionDenied
+
+from audit.models import SingleAuditChecklist
+
+
+logging.basicConfig(
+    format="%(asctime)s %(levelname)-8s %(module)s:%(lineno)d %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+
+def verify_status(status):
+    """
+    Decorator to be applied to view request methods (i.e. get, post) to verify
+    that the submission is in the correct state before allowing the user to
+    proceed. An incorrect status usually happens via direct URL access. If the
+    given status does not match the submission's, it will redirect them back to
+    the submission progress page.
+    """
+
+    def decorator_verify_status(request_method):
+        def verify(view, request, *args, **kwargs):
+            report_id = kwargs["report_id"]
+
+            try:
+                sac = SingleAuditChecklist.objects.get(report_id=report_id)
+            except SingleAuditChecklist.DoesNotExist:
+                raise PermissionDenied("You do not have access to this audit.")
+
+            # Return to checklist, the Audit is not in the correct state.
+            if sac.submission_status != status:
+                logger.warning(
+                    f"Expected submission status {status} but it's currently {sac.submission_status}"
+                )
+                return redirect(f"/audit/submission-progress/{sac.report_id}")
+            else:
+                return request_method(view, request, *args, **kwargs)
+
+        return verify
+
+    return decorator_verify_status

--- a/backend/audit/views/unlock_after_certification.py
+++ b/backend/audit/views/unlock_after_certification.py
@@ -4,6 +4,7 @@ from django.core.exceptions import PermissionDenied
 from django.shortcuts import render, redirect
 from django.views import generic
 from django.urls import reverse
+
 from audit.forms import UnlockAfterCertificationForm
 from audit.mixins import (
     SingleAuditChecklistAccessRequiredMixin,
@@ -13,6 +14,8 @@ from audit.models import (
 )
 from audit.models.models import STATUS
 from audit.models.viewflow import sac_transition
+from audit.verify_status import verify_status
+
 
 logger = logging.getLogger(__name__)
 
@@ -25,6 +28,7 @@ class UnlockAfterCertificationView(
     READY_FOR_CERTIFICATION.
     """
 
+    @verify_status(STATUS.READY_FOR_CERTIFICATION)
     def get(self, request, *args, **kwargs):
         report_id = kwargs["report_id"]
 
@@ -51,6 +55,7 @@ class UnlockAfterCertificationView(
         except SingleAuditChecklist.DoesNotExist:
             raise PermissionDenied("You do not have access to this audit.")
 
+    @verify_status(STATUS.READY_FOR_CERTIFICATION)
     def post(self, request, *args, **kwargs):
         report_id = kwargs["report_id"]
 

--- a/backend/audit/views/views.py
+++ b/backend/audit/views/views.py
@@ -15,7 +15,6 @@ from django.http import JsonResponse
 
 from audit.fixtures.excel import FORM_SECTIONS, UNKNOWN_WORKBOOK
 
-
 from audit.forms import (
     AuditorCertificationStep1Form,
     AuditorCertificationStep2Form,
@@ -42,6 +41,7 @@ from audit.validators import (
     validate_auditee_certification_json,
     validate_auditor_certification_json,
 )
+from audit.verify_status import verify_status
 from audit.utils import FORM_SECTION_HANDLERS
 
 from dissemination.remove_workbook_artifacts import remove_workbook_artifacts
@@ -59,38 +59,6 @@ logger = logging.getLogger(__name__)
 
 def _friendly_status(status):
     return dict(SingleAuditChecklist.STATUS_CHOICES)[status]
-
-
-def verify_status(status):
-    """
-    Decorator to be applied to view request methods (i.e. get, post) to verify
-    that the submission is in the correct state before allowing the user to
-    proceed. An incorrect status usually happens via direct URL access. If the
-    given status does not match the submission's, it will redirect them back to
-    the submission progress page.
-    """
-
-    def decorator_verify_status(request_method):
-        def verify(view, request, *args, **kwargs):
-            report_id = kwargs["report_id"]
-
-            try:
-                sac = SingleAuditChecklist.objects.get(report_id=report_id)
-            except SingleAuditChecklist.DoesNotExist:
-                raise PermissionDenied("You do not have access to this audit.")
-
-            # Return to checklist, the Audit is not in the correct state.
-            if sac.submission_status != status:
-                logger.warning(
-                    f"Expected submission status {status} but it's currently {sac.submission_status}"
-                )
-                return redirect(f"/audit/submission-progress/{sac.report_id}")
-            else:
-                return request_method(view, request, *args, **kwargs)
-
-        return verify
-
-    return decorator_verify_status
 
 
 class MySubmissions(LoginRequiredMixin, generic.View):

--- a/backend/audit/views/views.py
+++ b/backend/audit/views/views.py
@@ -14,7 +14,6 @@ from django.utils.decorators import method_decorator
 from django.http import JsonResponse
 
 from audit.fixtures.excel import FORM_SECTIONS, UNKNOWN_WORKBOOK
-
 from audit.forms import (
     AuditorCertificationStep1Form,
     AuditorCertificationStep2Form,
@@ -37,12 +36,12 @@ from audit.models import (
 from audit.models.models import STATUS
 from audit.models.viewflow import sac_transition
 from audit.intakelib.exceptions import ExcelExtractionError
+from audit.utils import FORM_SECTION_HANDLERS
 from audit.validators import (
     validate_auditee_certification_json,
     validate_auditor_certification_json,
 )
 from audit.verify_status import verify_status
-from audit.utils import FORM_SECTION_HANDLERS
 
 from dissemination.remove_workbook_artifacts import remove_workbook_artifacts
 from dissemination.file_downloads import get_download_url, get_filename


### PR DESCRIPTION
Closes https://github.com/GSA-TTS/FAC/issues/4597

In this PR:
- Fixing an issue where unlocking an already-unlocked submission caused a 500. It now redirects to the submission status page, the same that's done for other status check failures.
- Moving `verify_status` into its own file, since it's needed in multiple places now

Testing:
- Get an audit to the ready for certification state. An easy way to do this is comment out lines 101-139 in full-submission.js
- Head to the unlock page on two tabs
- Click unlock on one tab, which should unlock as normal, then click unlock on the second
- You should be redirected back to the submission status page instead of seeing a 500

## PR Checklist: Submitter

- [ ]   Link to an issue if possible. If there’s no issue, describe what your branch does. Even if there is an issue, a brief description in the PR is still useful.
- [ ]   List any special steps reviewers have to follow to test the PR. For example, adding a local environment variable, creating a local test file, etc.
- [ ]   For extra credit, submit a screen recording like [this one](https://github.com/GSA-TTS/FAC/pull/1821).
- [ ]   Make sure you’ve merged `main` into your branch shortly before creating the PR. (You should also be merging `main` into your branch regularly during development.)
- [ ]   Make sure you’ve accounted for any migrations. When you’re about to create the PR, bring up the application locally and then run `git status | grep migrations`. If there are any results, you probably need to add them to the branch for the PR. Your PR should have only **one** new migration file for each of the component apps, except in rare circumstances; you may need to delete some and re-run `python manage.py makemigrations` to reduce the number to one. (Also, unless in exceptional circumstances, your PR should not delete any migration files.)
- [ ]   Make sure that whatever feature you’re adding has tests that cover the feature. This includes test coverage to make sure that the previous workflow still works, if applicable.
- [ ]   Make sure the full-submission.cy.js [Cypress test](https://github.com/GSA-TTS/FAC/blob/main/docs/testing.md#end-to-end-testing) passes, if applicable.
- [ ]   Do manual testing locally. Our tests are not good enough yet to allow us to skip this step. If that’s not applicable for some reason, check this box.
- [ ]   Verify that no Git surgery was necessary, or, if it was necessary at any point, repeat the testing after it’s finished.
- [ ]   Once a PR is merged, keep an eye on it until it’s deployed to dev, and do enough testing on dev to verify that it deployed successfully, the feature works as expected, and the happy path for the broad feature area (such as submission) still works.
- [ ]   Ensure that prior to merging, the working branch is up to date with main and the terraform plan is what you expect.

## PR Checklist: Reviewer

- [ ]   Pull the branch to your local environment and run `make docker-clean; make docker-first-run && docker compose up`; then run `docker compose exec web /bin/bash -c "python manage.py test"`
- [ ]   Manually test out the changes locally, or check this box to verify that it wasn’t applicable in this case.
- [ ]   Check that the PR has appropriate tests. Look out for changes in HTML/JS/JSON Schema logic that may need to be captured in Python tests even though the logic isn’t in Python.
- [ ]   Verify that no Git surgery is necessary at any point (such as during a merge party), or, if it was, repeat the testing after it’s finished.

The larger the PR, the stricter we should be about these points.

## Pre Merge Checklist: Merger

- [ ]   Ensure that prior to approving, the terraform plan is what we expect it to be. `-/+ resource "null_resource" "cors_header" ` should be destroying and recreating its self and ` ~ resource "cloudfoundry_app" "clamav_api" ` might be updating its `sha256` for the `fac-file-scanner` and `fac-av-${ENV}` by default.
- [ ]   Ensure that the branch is up to date with `main`.
- [ ]   Ensure that a terraform plan has been recently generated for the pull request.
