### PR TITLE
Update versions for backup util to match v0.1.10

### DIFF
--- a/.github/workflows/deploy-application.yml
+++ b/.github/workflows/deploy-application.yml
@@ -70,6 +70,7 @@ jobs:
           cf_command: update-user-provided-service fac-key-service -p '"{\"SAM_API_KEY\":\"${{ secrets.SAM_API_KEY }}\", \"DJANGO_SECRET_LOGIN_KEY\":\"${{ secrets.DJANGO_SECRET_LOGIN_KEY }}\", \"LOGIN_CLIENT_ID\":\"${{ secrets.LOGIN_CLIENT_ID }}\", \"SECRET_KEY\":\"${{ secrets.SECRET_KEY}}\"}"'
 
       - name: Backup the database
+        if: startsWith(github.ref, 'refs/tags/v1.')
         uses: cloud-gov/cg-cli-tools@main
         with:
           cf_username: ${{ secrets.CF_USERNAME }}

--- a/.github/workflows/deploy-application.yml
+++ b/.github/workflows/deploy-application.yml
@@ -76,7 +76,7 @@ jobs:
           cf_password: ${{ secrets.CF_PASSWORD }}
           cf_org: gsa-tts-oros-fac
           cf_space: ${{ env.space }}
-          command: cf run-task gsa-fac -k 7G -m 3G --name deploy_backup --command "./fac-backup-util.sh v0.1.5 deploy_backup"
+          command: cf run-task gsa-fac -k 7G -m 3G --name deploy_backup --command "./fac-backup-util.sh v0.1.10 deploy_backup"
 
       - name: Deploy Preview to cloud.gov
         if: ${{ inputs.environment == 'preview' }}

--- a/.github/workflows/fac-backup-util-scheduled.yml
+++ b/.github/workflows/fac-backup-util-scheduled.yml
@@ -1,8 +1,8 @@
 ---
 name: Backup the database with fac-backup-utility
 ### Common Commands:
-# ./fac-backup-util.sh v0.1.8 scheduled_backup
-# ./fac-backup-util.sh v0.1.8 daily_backup
+# ./fac-backup-util.sh v0.1.10 scheduled_backup
+# ./fac-backup-util.sh v0.1.10 daily_backup
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/fac-backup-util.yml
+++ b/.github/workflows/fac-backup-util.yml
@@ -1,8 +1,8 @@
 ---
 name: Backup the database with fac-backup-utility
 ### Common Commands:
-# ./fac-backup-util.sh v0.1.8 initial_backup
-# ./fac-backup-util.sh v0.1.8 deploy_backup
+# ./fac-backup-util.sh v0.1.10 initial_backup
+# ./fac-backup-util.sh v0.1.10 deploy_backup
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/fac-check-tables.yml
+++ b/.github/workflows/fac-check-tables.yml
@@ -1,7 +1,7 @@
 ---
 name: Check existing tables in an environment
 ### Common Commands:
-# ./fac-backup-util.sh v0.1.8 check_tables
+# ./fac-backup-util.sh v0.1.10 check_tables
 on:
   workflow_dispatch:
     inputs:

--- a/docs/backups_and_restores.md
+++ b/docs/backups_and_restores.md
@@ -34,7 +34,7 @@ Information regarding the fac-backup-utility can be found [at the repository](ht
 Database backups occur in the following ways:
 1. An initial backup, where a backup has not been run in the target environment. This input of `initial_backup` is important, as when it does a the `db_to_db` command, it will not truncate the target table, as the table does not exist in the destination database.
 ```bash
-./fac-backup-util.sh v0.1.5 initial_backup
+./fac-backup-util.sh v0.1.10 initial_backup
 # Curl the utility
 # Install AWS
 # DB to S3 table dump (backups)
@@ -44,7 +44,7 @@ Database backups occur in the following ways:
 
 2. A deploy backup, where the `db_to_db` function is not called. This is a standard backup strategy before the application deploys, to ensure the s3 contents of the primary s3 are sync'd to the backups bucket, and a table dump is stored in the backups bucket.
 ```bash
-./fac-backup-util.sh v0.1.5 deploy_backup
+./fac-backup-util.sh v0.1.10 deploy_backup
 # Curl the utility
 # Install AWS
 # DB to S3 table dump (backups)
@@ -53,7 +53,7 @@ Database backups occur in the following ways:
 
 3. A scheduled backup is run every two hours, across each environment, ensuring that we have a clean backup in s3, rds, and the bucket contents are in sync.
 ```bash
-./fac-backup-util.sh v0.1.5 scheduled_backup
+./fac-backup-util.sh v0.1.10 scheduled_backup
 # Curl the utility
 # Install AWS
 # DB to S3 table dump (fac-db -> backups)
@@ -66,7 +66,7 @@ Restoring from backups can be run via workflow, from designated individuals. The
 
 1. S3 Restore takes a `operation-mm-DD-HH` input (ex `scheduled-06-04-10`), and is required for the backups to be restored. The utility looks in `s3://${bucket}/backups/operation-mm-DD-HH/` for its table dumps, and without supplying the target backups, it will not restore. Once it does a `--data-only` restoration, it will then sync the files from the backups bucket to the application bucket. We do this to ensure the contents of the application bucket are up to date, relative to the data in the database. We know that if we use the latest folder in `/backups/` then the contents of the s3 are the latest available, from the prior backup.
 ```bash
-./fac-restore-util.sh v0.1.5 s3_restore scheduled-06-04-10
+./fac-restore-util.sh v0.1.10 s3_restore scheduled-06-04-10
 # Curl the utility
 # Install AWS
 # DB to S3 table dump (backups -> fac-db) [Truncate target table before --data-only pg_restore]
@@ -81,7 +81,7 @@ daily-mm-dd
 
 2. Database to database restoration also can occur as well, using `psql` to dump the tables from the cold store database to the live database.
 ```bash
-./fac-restore-util.sh v0.1.5 db_restore
+./fac-restore-util.sh v0.1.10 db_restore
 # Curl the utility
 # Install AWS
 # DB to DB table dump (fac-snapshot-db -> fac-db) [Truncate target table before dump]


### PR DESCRIPTION
Follow on PR for #4601 
This brings some of the stray versions in sync with the latest backup util version of `v0.1.10` and adds back a conditional clause for backups. We don't want to backup every env before deployment, just prod