### PR TITLE
Allowing more submission states for unlocking

### DIFF
--- a/backend/audit/verify_status.py
+++ b/backend/audit/verify_status.py
@@ -17,10 +17,9 @@ def verify_status(status):
     Decorator to be applied to view request methods (i.e. get, post) to verify
     that the submission is in the correct state before allowing the user to
     proceed. An incorrect status usually happens via direct URL access. If the
-    given status does not match the submission's, it will redirect them back to
-    the submission progress page.
+    given status(es) do(es) not match the submission's, it will redirect them back to
+    the submission progress page. Accepts either a str or a [str].
     """
-
     def decorator_verify_status(request_method):
         def verify(view, request, *args, **kwargs):
             report_id = kwargs["report_id"]
@@ -30,8 +29,10 @@ def verify_status(status):
             except SingleAuditChecklist.DoesNotExist:
                 raise PermissionDenied("You do not have access to this audit.")
 
-            # Return to checklist, the Audit is not in the correct state.
-            if sac.submission_status != status:
+            statuses = status if type(status) == list else [status]
+
+            if sac.submission_status not in statuses:
+                # Return to checklist, the audit is not in the correct state
                 logger.warning(
                     f"Expected submission status {status} but it's currently {sac.submission_status}"
                 )

--- a/backend/audit/verify_status.py
+++ b/backend/audit/verify_status.py
@@ -20,6 +20,7 @@ def verify_status(status):
     given status(es) do(es) not match the submission's, it will redirect them back to
     the submission progress page. Accepts either a str or a [str].
     """
+
     def decorator_verify_status(request_method):
         def verify(view, request, *args, **kwargs):
             report_id = kwargs["report_id"]

--- a/backend/audit/verify_status.py
+++ b/backend/audit/verify_status.py
@@ -30,7 +30,7 @@ def verify_status(status):
             except SingleAuditChecklist.DoesNotExist:
                 raise PermissionDenied("You do not have access to this audit.")
 
-            statuses = status if type(status) == list else [status]
+            statuses = status if isinstance(status, list) else [status]
 
             if sac.submission_status not in statuses:
                 # Return to checklist, the audit is not in the correct state

--- a/backend/audit/views/unlock_after_certification.py
+++ b/backend/audit/views/unlock_after_certification.py
@@ -28,11 +28,13 @@ class UnlockAfterCertificationView(
     READY_FOR_CERTIFICATION.
     """
 
-    @verify_status([
-        STATUS.READY_FOR_CERTIFICATION,
-        STATUS.AUDITOR_CERTIFIED,
-        STATUS.AUDITEE_CERTIFIED,
-    ])
+    @verify_status(
+        [
+            STATUS.READY_FOR_CERTIFICATION,
+            STATUS.AUDITOR_CERTIFIED,
+            STATUS.AUDITEE_CERTIFIED,
+        ]
+    )
     def get(self, request, *args, **kwargs):
         report_id = kwargs["report_id"]
 
@@ -59,11 +61,13 @@ class UnlockAfterCertificationView(
         except SingleAuditChecklist.DoesNotExist:
             raise PermissionDenied("You do not have access to this audit.")
 
-    @verify_status([
-        STATUS.READY_FOR_CERTIFICATION,
-        STATUS.AUDITOR_CERTIFIED,
-        STATUS.AUDITEE_CERTIFIED,
-    ])
+    @verify_status(
+        [
+            STATUS.READY_FOR_CERTIFICATION,
+            STATUS.AUDITOR_CERTIFIED,
+            STATUS.AUDITEE_CERTIFIED,
+        ]
+    )
     def post(self, request, *args, **kwargs):
         report_id = kwargs["report_id"]
 

--- a/backend/audit/views/unlock_after_certification.py
+++ b/backend/audit/views/unlock_after_certification.py
@@ -28,7 +28,11 @@ class UnlockAfterCertificationView(
     READY_FOR_CERTIFICATION.
     """
 
-    @verify_status(STATUS.READY_FOR_CERTIFICATION)
+    @verify_status([
+        STATUS.READY_FOR_CERTIFICATION,
+        STATUS.AUDITOR_CERTIFIED,
+        STATUS.AUDITEE_CERTIFIED,
+    ])
     def get(self, request, *args, **kwargs):
         report_id = kwargs["report_id"]
 
@@ -55,7 +59,11 @@ class UnlockAfterCertificationView(
         except SingleAuditChecklist.DoesNotExist:
             raise PermissionDenied("You do not have access to this audit.")
 
-    @verify_status(STATUS.READY_FOR_CERTIFICATION)
+    @verify_status([
+        STATUS.READY_FOR_CERTIFICATION,
+        STATUS.AUDITOR_CERTIFIED,
+        STATUS.AUDITEE_CERTIFIED,
+    ])
     def post(self, request, *args, **kwargs):
         report_id = kwargs["report_id"]
 


### PR DESCRIPTION
In this PR:
- Currently, audits can only be unlocked when in the ready_for_certification state, meaning it can't be unlocked once any certification has occurred. This change allows the auditor_cerfified and auditee_certified states as well.
- `@verify_state` now accepts either a single state or a list of states

Testing:
- full-submission passes as normal (this includes unlocking from ready_for_certification)
- Get a submission up to and including the auditor certification step. Any easy way to do this is comment out everything in full-submission after line 105. You should still be able to unlock successfully after the certification. You can do the same for auditee_certification (line 122).

## PR Checklist: Submitter

- [ ]   Link to an issue if possible. If there’s no issue, describe what your branch does. Even if there is an issue, a brief description in the PR is still useful.
- [ ]   List any special steps reviewers have to follow to test the PR. For example, adding a local environment variable, creating a local test file, etc.
- [ ]   For extra credit, submit a screen recording like [this one](https://github.com/GSA-TTS/FAC/pull/1821).
- [ ]   Make sure you’ve merged `main` into your branch shortly before creating the PR. (You should also be merging `main` into your branch regularly during development.)
- [ ]   Make sure you’ve accounted for any migrations. When you’re about to create the PR, bring up the application locally and then run `git status | grep migrations`. If there are any results, you probably need to add them to the branch for the PR. Your PR should have only **one** new migration file for each of the component apps, except in rare circumstances; you may need to delete some and re-run `python manage.py makemigrations` to reduce the number to one. (Also, unless in exceptional circumstances, your PR should not delete any migration files.)
- [ ]   Make sure that whatever feature you’re adding has tests that cover the feature. This includes test coverage to make sure that the previous workflow still works, if applicable.
- [ ]   Make sure the full-submission.cy.js [Cypress test](https://github.com/GSA-TTS/FAC/blob/main/docs/testing.md#end-to-end-testing) passes, if applicable.
- [ ]   Do manual testing locally. Our tests are not good enough yet to allow us to skip this step. If that’s not applicable for some reason, check this box.
- [ ]   Verify that no Git surgery was necessary, or, if it was necessary at any point, repeat the testing after it’s finished.
- [ ]   Once a PR is merged, keep an eye on it until it’s deployed to dev, and do enough testing on dev to verify that it deployed successfully, the feature works as expected, and the happy path for the broad feature area (such as submission) still works.
- [ ]   Ensure that prior to merging, the working branch is up to date with main and the terraform plan is what you expect.

## PR Checklist: Reviewer

- [ ]   Pull the branch to your local environment and run `make docker-clean; make docker-first-run && docker compose up`; then run `docker compose exec web /bin/bash -c "python manage.py test"`
- [ ]   Manually test out the changes locally, or check this box to verify that it wasn’t applicable in this case.
- [ ]   Check that the PR has appropriate tests. Look out for changes in HTML/JS/JSON Schema logic that may need to be captured in Python tests even though the logic isn’t in Python.
- [ ]   Verify that no Git surgery is necessary at any point (such as during a merge party), or, if it was, repeat the testing after it’s finished.

The larger the PR, the stricter we should be about these points.

## Pre Merge Checklist: Merger

- [ ]   Ensure that prior to approving, the terraform plan is what we expect it to be. `-/+ resource "null_resource" "cors_header" ` should be destroying and recreating its self and ` ~ resource "cloudfoundry_app" "clamav_api" ` might be updating its `sha256` for the `fac-file-scanner` and `fac-av-${ENV}` by default.
- [ ]   Ensure that the branch is up to date with `main`.
- [ ]   Ensure that a terraform plan has been recently generated for the pull request.
