### PR TITLE
Adding --wait to all cf run-task commands

### DIFF
--- a/.github/workflows/deploy-application.yml
+++ b/.github/workflows/deploy-application.yml
@@ -78,6 +78,7 @@ jobs:
           cf_org: gsa-tts-oros-fac
           cf_space: ${{ env.space }}
           command: cf run-task gsa-fac -k 7G -m 3G --name deploy_backup --command "./fac-backup-util.sh v0.1.10 deploy_backup" --wait
+
       - name: Deploy Preview to cloud.gov
         if: ${{ inputs.environment == 'preview' }}
         uses: cloud-gov/cg-cli-tools@main

--- a/.github/workflows/deploy-application.yml
+++ b/.github/workflows/deploy-application.yml
@@ -77,8 +77,7 @@ jobs:
           cf_password: ${{ secrets.CF_PASSWORD }}
           cf_org: gsa-tts-oros-fac
           cf_space: ${{ env.space }}
-          command: cf run-task gsa-fac -k 7G -m 3G --name deploy_backup --command "./fac-backup-util.sh v0.1.10 deploy_backup"
-
+          command: cf run-task gsa-fac -k 7G -m 3G --name deploy_backup --command "./fac-backup-util.sh v0.1.10 deploy_backup" --wait
       - name: Deploy Preview to cloud.gov
         if: ${{ inputs.environment == 'preview' }}
         uses: cloud-gov/cg-cli-tools@main

--- a/.github/workflows/destroy-and-regenerate-dissemination.yml
+++ b/.github/workflows/destroy-and-regenerate-dissemination.yml
@@ -28,4 +28,4 @@ jobs:
           cf_password: ${{ secrets.CF_PASSWORD }}
           cf_org: gsa-tts-oros-fac
           cf_space: ${{ env.space }}
-          command: cf run-task gsa-fac -k 2G -m 2G --name rebuild_dissemination --command "python manage.py delete_and_regenerate_dissemination_from_intake"
+          command: cf run-task gsa-fac -k 2G -m 2G --name rebuild_dissemination --command "python manage.py delete_and_regenerate_dissemination_from_intake" --wait

--- a/.github/workflows/export-data-to-csv.yml
+++ b/.github/workflows/export-data-to-csv.yml
@@ -35,7 +35,7 @@ jobs:
           cf_password: ${{ secrets.CF_PASSWORD }}
           cf_org: gsa-tts-oros-fac
           cf_space: ${{ env.space }}
-          command: cf run-task gsa-fac -k 2G -m 2G --name export_data_to_csv --command "python manage.py export_data"
+          command: cf run-task gsa-fac -k 2G -m 2G --name export_data_to_csv --command "python manage.py export_data" --wait
 
   dispatch-data-export:
     if: ${{ github.event.inputs.environment != '' }}
@@ -52,4 +52,4 @@ jobs:
           cf_password: ${{ secrets.CF_PASSWORD }}
           cf_org: gsa-tts-oros-fac
           cf_space: ${{ env.space }}
-          command: cf run-task gsa-fac -k 2G -m 2G --name export_data_to_csv --command "python manage.py export_data"
+          command: cf run-task gsa-fac -k 2G -m 2G --name export_data_to_csv --command "python manage.py export_data" --wait

--- a/.github/workflows/fac-backup-util-scheduled.yml
+++ b/.github/workflows/fac-backup-util-scheduled.yml
@@ -32,5 +32,5 @@ jobs:
           cf_password: ${{ secrets.CF_PASSWORD }}
           cf_org: gsa-tts-oros-fac
           cf_space: ${{ env.space }}
-          command: cf run-task gsa-fac -k 7G -m 3G --name backup_util_scheduled --command "./fac-backup-util.sh ${{ inputs.util_version }} ${{ inputs.backup_operation }}"
+          command: cf run-task gsa-fac -k 7G -m 3G --name backup_util_scheduled --command "./fac-backup-util.sh ${{ inputs.util_version }} ${{ inputs.backup_operation }}" --wait
 

--- a/.github/workflows/fac-backup-util.yml
+++ b/.github/workflows/fac-backup-util.yml
@@ -41,4 +41,4 @@ jobs:
           cf_password: ${{ secrets.CF_PASSWORD }}
           cf_org: gsa-tts-oros-fac
           cf_space: ${{ env.space }}
-          command: cf run-task gsa-fac -k 7G -m 3G --name deploy_backup_util --command "./fac-backup-util.sh ${{ inputs.util_version }} ${{ inputs.backup_operation }}"
+          command: cf run-task gsa-fac -k 7G -m 3G --name deploy_backup_util --command "./fac-backup-util.sh ${{ inputs.util_version }} ${{ inputs.backup_operation }}" --wait

--- a/.github/workflows/fac-check-tables.yml
+++ b/.github/workflows/fac-check-tables.yml
@@ -51,4 +51,4 @@ jobs:
           cf_password: ${{ secrets.CF_PASSWORD }}
           cf_org: gsa-tts-oros-fac
           cf_space: ${{ env.space }}
-          command: cf run-task gsa-fac -k 2G -m 3G --name check_tables --command "./fac-backup-util.sh ${{ inputs.util_version }} ${{ inputs.backup_operation }}"
+          command: cf run-task gsa-fac -k 2G -m 3G --name check_tables --command "./fac-backup-util.sh ${{ inputs.util_version }} ${{ inputs.backup_operation }}" --wait

--- a/.github/workflows/failed-data-migration-reprocessor.yml
+++ b/.github/workflows/failed-data-migration-reprocessor.yml
@@ -47,4 +47,4 @@ jobs:
           cf_password: ${{ secrets.CF_PASSWORD }}
           cf_org: gsa-tts-oros-fac
           cf_space: ${{ env.space }}
-          command: cf run-task gsa-fac -k 1G -m 1G --name failed_data_migration_reprocessor --command "python manage.py reprocess_failed_migration --year ${{ inputs.year }} --page_size ${{ inputs.page_size }} --pages ${{ inputs.pages }} --error_tag ${{ inputs.error_tag }}"
+          command: cf run-task gsa-fac -k 1G -m 1G --name failed_data_migration_reprocessor --command "python manage.py reprocess_failed_migration --year ${{ inputs.year }} --page_size ${{ inputs.page_size }} --pages ${{ inputs.pages }} --error_tag ${{ inputs.error_tag }}" --wait

--- a/.github/workflows/historic-data-migrator-with-pagination.yml
+++ b/.github/workflows/historic-data-migrator-with-pagination.yml
@@ -43,4 +43,4 @@ jobs:
           cf_password: ${{ secrets.CF_PASSWORD }}
           cf_org: gsa-tts-oros-fac
           cf_space: ${{ env.space }}
-          command: cf run-task gsa-fac -k 1G -m 1G --name historic_data_migrator_with_pagination --command "python manage.py run_paginated_migration --year ${{ inputs.year }} --page_size ${{ inputs.page_size }} --pages ${{ inputs.pages }}"
+          command: cf run-task gsa-fac -k 1G -m 1G --name historic_data_migrator_with_pagination --command "python manage.py run_paginated_migration --year ${{ inputs.year }} --page_size ${{ inputs.page_size }} --pages ${{ inputs.pages }}" --wait

--- a/.github/workflows/historic-data-migrator.yml
+++ b/.github/workflows/historic-data-migrator.yml
@@ -39,4 +39,4 @@ jobs:
           cf_password: ${{ secrets.CF_PASSWORD }}
           cf_org: gsa-tts-oros-fac
           cf_space: ${{ env.space }}
-          command: cf run-task gsa-fac -k 2G -m 2G --name historic_data_migrator --command "python manage.py historic_data_migrator --dbkeys ${{ inputs.dbkeys }} --years ${{ inputs.years }}"
+          command: cf run-task gsa-fac -k 2G -m 2G --name historic_data_migrator --command "python manage.py historic_data_migrator --dbkeys ${{ inputs.dbkeys }} --years ${{ inputs.years }}" --wait

--- a/.github/workflows/materialized-views.yml
+++ b/.github/workflows/materialized-views.yml
@@ -35,7 +35,7 @@ jobs:
           cf_password: ${{ secrets.CF_PASSWORD }}
           cf_org: gsa-tts-oros-fac
           cf_space: ${{ env.space }}
-          command: cf run-task gsa-fac -k 2G -m 2G --name scheduled_create_materialized_views --command "python manage.py materialized_views --create"
+          command: cf run-task gsa-fac -k 2G -m 2G --name scheduled_create_materialized_views --command "python manage.py materialized_views --create" --wait
 
   dispatch-materialized-views:
     if: ${{ github.event.inputs.environment != '' }}
@@ -52,4 +52,4 @@ jobs:
           cf_password: ${{ secrets.CF_PASSWORD }}
           cf_org: gsa-tts-oros-fac
           cf_space: ${{ env.space }}
-          command: cf run-task gsa-fac -k 2G -m 2G --name dispatch_create_materialized_views --command "python manage.py materialized_views --create"
+          command: cf run-task gsa-fac -k 2G -m 2G --name dispatch_create_materialized_views --command "python manage.py materialized_views --create" --wait


### PR DESCRIPTION
## Purpose

We recently found out that backup tasks were failing silently. Backup tasks are kicked off by github actions through a cloud foundry run-task command. By default this task is run asynchronously, and therefore the github action sees a success message when the task is started successfully. The purpose of this code change is ensure we can see the errors in the github workflow.

## How  

The cloud foundry run-task command accepts a --wait flag which will wait until the task is finished. If the task fails, the github workflow will fail.

## Testing

I created a temporary script which always fails. (Since removed from the commit). I tested it using the deploy to preview workflow. You can see that here: https://github.com/GSA-TTS/FAC/actions/runs/12913210660/job/36010804577