### PR TITLE
Pushing postgREST logs to New Relic

### DIFF
--- a/terraform/shared/modules/env/postgrest.tf
+++ b/terraform/shared/modules/env/postgrest.tf
@@ -37,4 +37,8 @@ resource "cloudfoundry_app" "postgrest" {
     PGRST_JWT_SECRET : var.pgrst_jwt_secret
     PGRST_DB_MAX_ROWS : 20000
   }
+
+  service_binding {
+    service_instance = module.cg-logshipper.logdrain_service_id
+  }
 }


### PR DESCRIPTION
## Purpose

We would like to get more insights into how our API is being used.

## How

By connecting the postgREST service logs into new relic, we can create monitoring, and graphs on how they are used.

## Testing

Deployed to preview, created a parsing rule in new relic to parse out some interesting datapoints, queried the Log table in new relic.

## Next Steps

Configure dashboards and appropriate monitors for the API. Investigate adding the manually created Log Parser into terraform.