### PR TITLE
Bump setup-node versions to 23

### DIFF
--- a/.github/workflows/cypress-testing-from-container.yml
+++ b/.github/workflows/cypress-testing-from-container.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 23
 
       - name: Install Node dependencies
         working-directory: ./backend

--- a/.github/workflows/testing-from-build.yml
+++ b/.github/workflows/testing-from-build.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 23
 
       - name: Create .env
         working-directory: ./backend
@@ -81,7 +81,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 23
 
       - name: Install Node dependencies
         working-directory: ./backend

--- a/.github/workflows/testing-from-ghcr.yml
+++ b/.github/workflows/testing-from-ghcr.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 23
 
       - name: Create .env file
         working-directory: ./backend
@@ -83,7 +83,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 23
 
       - name: Install Node dependencies
         working-directory: ./backend

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -54,7 +54,7 @@ RUN set -ex && \
 FROM pip AS node
 WORKDIR /src/
 
-RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+RUN curl -fsSL https://deb.nodesource.com/setup_23.x | bash - && \
     apt-get install -y nodejs
 COPY package*.json /src/
 RUN npm ci && \

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -38,7 +38,7 @@
         "stylelint-config-standard-scss": "^14.0.0"
       },
       "engines": {
-        "node": ">=18.0.0 <21.0.0",
+        "node": ">=18.0.0 <=23.6.1",
         "npm": ">=9.0.0"
       }
     },

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "engines": {
     "npm": ">=9.0.0",
-    "node": ">=18.0.0 <21.0.0"
+    "node": ">=18.0.0 <=23.6.1"
   },
   "scripts": {
     "build": "run-p build:*",


### PR DESCRIPTION
Follow on from addition to cypress to PR checks, we are running 2 different versions of node on the setup steps in the actions, and we would like to test to see if v23 will cause our actions to break.

To Test:
Pull down the branch, `cd backend` & `npm install`. Rebuild the container with `make docker-first-run`, then `docker compose -f docker-compose.yml up`. In a new terminal, `npx cypress open` and run `full-submission.cy.js` spec.
![image](https://github.com/user-attachments/assets/19d523e2-88af-4e7e-99b0-b51df4e423e1)

Alternatively, Cypress tests on the PR should pass.