### PR TITLE
Updating mixins to account for audits

### DIFF
--- a/backend/audit/mixins.py
+++ b/backend/audit/mixins.py
@@ -1,5 +1,7 @@
 from typing import Any
 
+import newrelic.agent
+
 from audit.exceptions import SessionExpiredException
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -8,7 +10,8 @@ from django.core.exceptions import PermissionDenied
 from django.http.request import HttpRequest
 from django.http.response import HttpResponse
 
-from .models import Access, SingleAuditChecklist
+from .models import Access, SingleAuditChecklist, Audit, ACCESS_ROLES
+from .models.access_roles import AccessRole
 
 User = get_user_model()
 
@@ -30,14 +33,70 @@ def check_authenticated(request):
         raise SessionExpiredException()
 
 
+# TODO: Update Post SOC Launch
 def has_access(sac, user):
     """Does a user have permission to access a submission?"""
     return bool(Access.objects.filter(sac=sac, user=user))
 
 
+def has_access_to_audit(audit, user):
+    """Does a user have permission to access a submission?"""
+    return bool(Access.objects.filter(audit=audit, user=user))
+
+
 def has_role(sac, user, role):
     """Does a user have a specific role on a submission?"""
-    return bool(Access.objects.filter(sac=sac, user=user, role=role))
+    return bool(Access.objects.filter(sac=sac, user=user, role=role)) if role else True
+
+
+def has_role_on_audit(audit, user, role):
+    """Does a user have a specific role on a submission?"""
+    return (
+        bool(Access.objects.filter(audit=audit, user=user, role=role)) if role else True
+    )
+
+
+ACCESS_ROLE_ERROR_MESSAGES = {
+    AccessRole.CERTIFYING_AUDITEE_CONTACT: "Invalid role. User is not the Auditee Certifying Official",
+    AccessRole.CERTIFYING_AUDITOR_CONTACT: "Invalid role. User is not the Auditor Certifying Official",
+}
+
+
+def _validate_access(request, report_id, role=None):
+    audit = Audit.objects.find_audit_or_none(report_id)
+    try:
+        check_authenticated(request)
+
+        sac = SingleAuditChecklist.objects.get(report_id=report_id)
+        audit_has_access = has_access_to_audit(audit, request.user)
+        audit_has_role = has_role_on_audit(audit, request.user, role)
+
+        if not has_access(sac, request.user) and not settings.DISABLE_AUTH:
+            if audit_has_access:
+                newrelic.agent.record_custom_metric("Custom/SOT/AccessMismatch", 1)
+            raise PermissionDenied(PERMISSION_DENIED_MESSAGE)
+
+        if not has_role(sac, request.user, role):
+            eligible_accesses = Access.objects.select_related("user").filter(
+                sac=sac, role=role
+            )
+            eligible_users = [acc.user for acc in eligible_accesses]
+
+            if audit_has_role:
+                newrelic.agent.record_custom_metric("Custom/SOT/AccessMismatch", 1)
+            raise CertificationPermissionDenied(
+                ACCESS_ROLE_ERROR_MESSAGES[role],
+                eligible_users=eligible_users,
+            )
+    except SingleAuditChecklist.DoesNotExist:
+        if audit:
+            newrelic.agent.record_custom_metric("Custom/SOT/AccessMismatch", 1)
+        raise PermissionDenied(PERMISSION_DENIED_MESSAGE)
+
+    if not audit_has_access or not audit_has_role:
+        newrelic.agent.record_custom_metric("Custom/SOT/AccessMismatch", 1)
+    else:
+        newrelic.agent.record_custom_metric("Custom/SOT/AccessMismatch", 0)
 
 
 class SingleAuditChecklistAccessRequiredMixin(LoginRequiredMixin):
@@ -46,16 +105,7 @@ class SingleAuditChecklistAccessRequiredMixin(LoginRequiredMixin):
     """
 
     def dispatch(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
-        try:
-            check_authenticated(request)
-
-            sac = SingleAuditChecklist.objects.get(report_id=kwargs["report_id"])
-
-            if not has_access(sac, request.user) and not settings.DISABLE_AUTH:
-                raise PermissionDenied(PERMISSION_DENIED_MESSAGE)
-        except SingleAuditChecklist.DoesNotExist:
-            raise PermissionDenied(PERMISSION_DENIED_MESSAGE)
-
+        _validate_access(request=request, report_id=kwargs.get("report_id"))
         return super().dispatch(request, *args, **kwargs)
 
 
@@ -66,28 +116,11 @@ class CertifyingAuditeeRequiredMixin(LoginRequiredMixin):
     """
 
     def dispatch(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
-        role = "certifying_auditee_contact"
-        try:
-            check_authenticated(request)
-
-            sac = SingleAuditChecklist.objects.get(report_id=kwargs["report_id"])
-
-            if not has_access(sac, request.user):
-                raise PermissionDenied(PERMISSION_DENIED_MESSAGE)
-
-            if not has_role(sac, request.user, role):
-                eligible_accesses = Access.objects.select_related("user").filter(
-                    sac=sac, role=role
-                )
-                eligible_users = [acc.user for acc in eligible_accesses]
-
-                raise CertificationPermissionDenied(
-                    "Invalid role. User is not the Auditee Certifying Official.",
-                    eligible_users=eligible_users,
-                )
-        except SingleAuditChecklist.DoesNotExist:
-            raise PermissionDenied(PERMISSION_DENIED_MESSAGE)
-
+        _validate_access(
+            request=request,
+            report_id=kwargs.get("report_id"),
+            role=AccessRole.CERTIFYING_AUDITEE_CONTACT,
+        )
         return super().dispatch(request, *args, **kwargs)
 
 
@@ -98,26 +131,9 @@ class CertifyingAuditorRequiredMixin(LoginRequiredMixin):
     """
 
     def dispatch(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
-        role = "certifying_auditor_contact"
-        try:
-
-            check_authenticated(request)
-
-            sac = SingleAuditChecklist.objects.get(report_id=kwargs["report_id"])
-
-            if not has_access(sac, request.user):
-                raise PermissionDenied(PERMISSION_DENIED_MESSAGE)
-
-            if not has_role(sac, request.user, role):
-                eligible_accesses = Access.objects.select_related("user").filter(
-                    sac=sac, role=role
-                )
-                eligible_users = [acc.user for acc in eligible_accesses]
-                raise CertificationPermissionDenied(
-                    "Invalid role. User is not the Auditor Certifying Official.",
-                    eligible_users=eligible_users,
-                )
-        except SingleAuditChecklist.DoesNotExist:
-            raise PermissionDenied(PERMISSION_DENIED_MESSAGE)
-
+        _validate_access(
+            request=request,
+            report_id=kwargs.get("report_id"),
+            role=AccessRole.CERTIFYING_AUDITOR_CONTACT,
+        )
         return super().dispatch(request, *args, **kwargs)

--- a/backend/audit/models/access_roles.py
+++ b/backend/audit/models/access_roles.py
@@ -4,9 +4,17 @@ DeletedAccess without running into circular import problems.
 """
 
 from django.utils.translation import gettext_lazy as _
+from collections import namedtuple as NT
+
+
+class AccessRole:
+    CERTIFYING_AUDITEE_CONTACT = "certifying_auditee_contact"
+    CERTIFYING_AUDITOR_CONTACT = "certifying_auditor_contact"
+    EDITOR = "editor"
+
 
 ACCESS_ROLES = (
-    ("certifying_auditee_contact", _("Auditee Certifying Official")),
-    ("certifying_auditor_contact", _("Auditor Certifying Official")),
-    ("editor", _("Audit Editor")),
+    (AccessRole.CERTIFYING_AUDITEE_CONTACT, _("Auditee Certifying Official")),
+    (AccessRole.CERTIFYING_AUDITOR_CONTACT, _("Auditor Certifying Official")),
+    (AccessRole.EDITOR, _("Audit Editor")),
 )

--- a/backend/audit/test_mixins.py
+++ b/backend/audit/test_mixins.py
@@ -30,7 +30,7 @@ class SingleAuditChecklistAccessRequiredMixinTests(TestCase):
 
         view = self.ViewStub()
 
-        self.assertRaises(KeyError, view.dispatch, request)
+        self.assertRaises(PermissionDenied, view.dispatch, request)
 
     def test_nonexistent_sac_raises(self):
         user = baker.make(User)
@@ -96,7 +96,7 @@ class CertifyingAuditeeRequiredMixinTests(TestCase):
 
         view = self.ViewStub()
 
-        self.assertRaises(KeyError, view.dispatch, request)
+        self.assertRaises(PermissionDenied, view.dispatch, request)
 
     def test_nonexistent_sac_raises(self):
         user = baker.make(User)
@@ -191,7 +191,7 @@ class CertifyingAuditorRequiredMixinTests(TestCase):
 
         view = self.ViewStub()
 
-        self.assertRaises(KeyError, view.dispatch, request)
+        self.assertRaises(PermissionDenied, view.dispatch, request)
 
     def test_nonexistent_sac_raises(self):
         user = baker.make(User)


### PR DESCRIPTION
## Purpose

To ensure everywhere we are currently using SAC, we also use Audit.

## How

New helper method that checks the audit as well, but relies solely on the SAC for all logic. Logs metrics to new relic if there is a mismatch.

## Testing Completed

I preformed the following locally: linting, unit tests, and full-submission end to end test.