### PR TITLE
Merging tests into real-time-checking

### DIFF
--- a/backend/audit/models/utils.py
+++ b/backend/audit/models/utils.py
@@ -192,7 +192,7 @@ def validate_audit_consistency(audit_instance):
             {"error": f"No SAC found with report_id {audit_instance.report_id}"}
         ]
 
-    difference = []
+    differences = []
 
     json_fields_to_check = [
         "general_information",
@@ -222,7 +222,7 @@ def validate_audit_consistency(audit_instance):
         audit_value = getattr(audit_instance, field, None)
 
         if sac_value and sac_value != audit_value:
-            difference.append(
+            differences.append(
                 {"field": field, "sac_value": sac_value, "audit_value": audit_value}
             )
 
@@ -231,7 +231,7 @@ def validate_audit_consistency(audit_instance):
         audit_field_data = audit_instance.audit.get(field)
 
         if sac_data is not None and audit_field_data is None:
-            difference.append(
+            differences.append(
                 {
                     "field": field,
                     "error": f"Field is empty in Audit, but not in SAC",
@@ -242,7 +242,7 @@ def validate_audit_consistency(audit_instance):
             continue
 
         if sac_data is None and audit_field_data is not None:
-            difference.append(
+            differences.append(
                 {
                     "field": field,
                     "error": f"Field is empty in SAC, but not in Audit",
@@ -253,38 +253,36 @@ def validate_audit_consistency(audit_instance):
             continue
 
         if sac_data is not None:
-
-            sac_values = flatten_json(sac_data)
+            flat_sac = flatten_json(sac_data)
             flat_audit = flatten_json(audit_instance.audit)
 
-            for path, value in sac_values.items():
-                result = value_exists_in_audit(path, value, flat_audit)
+            for sac_path, sac_value in flat_sac.items(): # change to sac_path, sac_value
+                result = value_exists_in_audit(sac_path, sac_value, flat_audit)
 
                 if result == False:
-                    difference.append(
+                    differences.append(
                         {
                             "field": field,
-                            "path": path,
-                            "value": value,
-                            "error": f"Value from SAC.{field}.{path} not found in Audit",
+                            "sac_path": sac_path,
+                            "sac_value": sac_value,
+                            "error": f"Value from SAC.{field}.{sac_path} not found in Audit",
                         }
                     )
 
                 elif isinstance(result, dict) and result.get(
                     "found_with_different_key"
                 ):
-                    difference.append(
+                    differences.append(
                         {
                             "field": field,
-                            "path": path,
-                            "value": value,
-                            "found_in_path": result["found_in_path"],
-                            "found_value": result["found_value"],
-                            "error": f"Value from SAC.{field}.{path} found in Audit but with different structure/key",
+                            "sac_path": sac_path,
+                            "sac_value": sac_value,
+                            "audit_path": result["audit_path"],
+                            "error": f"Value from SAC.{field}.{sac_path} found in Audit but with different structure/key",
                         }
                     )
 
-    return len(difference) == 0, difference
+    return len(differences) == 0, differences
 
 
 def flatten_json(obj, path="", result=None):
@@ -307,12 +305,12 @@ def flatten_json(obj, path="", result=None):
     return result
 
 
-def value_exists_in_audit(path, value, audit_data):
+def value_exists_in_audit(sac_path, sac_value, audit_data):
     """Check if a value from SAC exists somewhere in audit data with the same key-value"""
-    field_name = path.split(".")[-1] if "." in path else path
-    field_name = field_name.split("[")[0] if "[" in field_name else field_name
+    sac_field = sac_path.split(".")[-1] if "." in sac_path else sac_path
+    sac_field = sac_field.split("[")[0] if "[" in sac_field else sac_field
 
-    norm_field = normalize_key(field_name)
+    sac_norm_field = normalize_key(sac_field)
 
     for audit_path, audit_value in audit_data.items():
         audit_field = audit_path.split(".")[-1] if "." in audit_path else audit_path
@@ -320,23 +318,24 @@ def value_exists_in_audit(path, value, audit_data):
 
         norm_audit_field = normalize_key(audit_field)
 
-        if norm_field == norm_audit_field and (
-            value == audit_value or get_other_formats(value, audit_value)
+        if sac_norm_field == norm_audit_field and (
+            compare_values(sac_value, audit_value)
         ):
             return True
 
     for audit_path, audit_value in audit_data.items():
-        if value == audit_value or get_other_formats(value, audit_value):
+        if compare_values(sac_value, audit_value):
             return {
                 "found_with_different_key": True,
-                "original_field": field_name,
-                "found_in_path": audit_path,
-                "found_value": audit_value,
+                "sac_field": sac_field,
+                "audit_path": audit_path,
+                "value": audit_value,
             }
 
     return False
 
 
+# Do we need this?
 def normalize_key(key):
     """Normalize the keys for comparison"""
     if not isinstance(key, str):
@@ -346,29 +345,43 @@ def normalize_key(key):
     return normalized.lower()
 
 
-def get_other_formats(value1, value2):
+def compare_values(value1, value2):
     """Generate other format types for obj, str, list, dict"""
     if value1 == value2:
         return True
 
     if str(value1) == str(value2):
+        # print("str")
+        # print(value1, value2)
         return True
 
     if isinstance(value1, list) and value2 in value1:
+        # print("list1")
+        # print(value1, value2)
         return True
 
     if isinstance(value2, list) and value1 in value2:
+        # print("list2")
+        # print(value1, value2)
         return True
 
     if isinstance(value1, dict) and value2 in value1.values():
+        # print("dict1")
+        # print(value1, value2)
         return True
     if isinstance(value2, dict) and value1 in value2.values():
+        # print("dict2")
+        # print(value1, value2)
         return True
 
     try:
         if isinstance(value1, (int, float)) and isinstance(value2, str):
+            # print("float1")
+            # print(value1, value2)
             return value1 == float(value2)
         if isinstance(value2, (int, float)) and isinstance(value1, str):
+            # print("float2")
+            # print(value1, value2)
             return value2 == float(value1)
     except (ValueError, TypeError):
         pass

--- a/backend/audit/models/utils.py
+++ b/backend/audit/models/utils.py
@@ -351,37 +351,23 @@ def compare_values(value1, value2):
         return True
 
     if str(value1) == str(value2):
-        # print("str")
-        # print(value1, value2)
         return True
 
     if isinstance(value1, list) and value2 in value1:
-        # print("list1")
-        # print(value1, value2)
         return True
 
     if isinstance(value2, list) and value1 in value2:
-        # print("list2")
-        # print(value1, value2)
         return True
 
     if isinstance(value1, dict) and value2 in value1.values():
-        # print("dict1")
-        # print(value1, value2)
         return True
     if isinstance(value2, dict) and value1 in value2.values():
-        # print("dict2")
-        # print(value1, value2)
         return True
 
     try:
         if isinstance(value1, (int, float)) and isinstance(value2, str):
-            # print("float1")
-            # print(value1, value2)
             return value1 == float(value2)
         if isinstance(value2, (int, float)) and isinstance(value1, str):
-            # print("float2")
-            # print(value1, value2)
             return value2 == float(value1)
     except (ValueError, TypeError):
         pass

--- a/backend/audit/test_validate_audit_consistency.py
+++ b/backend/audit/test_validate_audit_consistency.py
@@ -1,4 +1,3 @@
-
 from django.test import TestCase
 from model_bakery import baker
 
@@ -9,7 +8,6 @@ from audit.models.utils import (
   compare_values,
   validate_audit_consistency,
 )
-from .models import SingleAuditChecklist
 
 
 class TestFlattenJson(TestCase):

--- a/backend/audit/test_validate_audit_consistency.py
+++ b/backend/audit/test_validate_audit_consistency.py
@@ -1,0 +1,244 @@
+
+from django.test import TestCase
+from model_bakery import baker
+
+from audit.models import Audit, SingleAuditChecklist
+from audit.models.utils import (
+  flatten_json,
+  value_exists_in_audit,
+  compare_values,
+  validate_audit_consistency,
+)
+from .models import SingleAuditChecklist
+
+
+class TestFlattenJson(TestCase):
+    """Tests for flatten_json"""
+    def test_empty(self):
+        test_json = {}
+        expected_result = {}
+        result = flatten_json(test_json)
+        self.assertDictEqual(result, expected_result)
+
+    def test_simple(self):
+        test_json = { "a": 1 , "b": 2 }
+        expected_result = { "a": 1 , "b": 2 }
+        result = flatten_json(test_json)
+        self.assertDictEqual(result, expected_result)
+
+    def test_nested(self):
+        test_json = { "a": { "b": 2 }, "c": 3 }
+        expected_result = { "a.b": 2, "c": 3 }
+        result = flatten_json(test_json)
+        self.assertDictEqual(result, expected_result)
+
+    def test_list(self):
+        test_json = { "a": [1, 2] }
+        expected_result = { "a[0]": 1 , "a[1]": 2 }
+        result = flatten_json(test_json)
+        self.assertDictEqual(result, expected_result)
+
+    def test_nested_list(self):
+        test_json = { "a": { "b": [1, 2] } }
+        expected_result = { "a.b[0]": 1 , "a.b[1]": 2 }
+        result = flatten_json(test_json)
+        self.assertDictEqual(result, expected_result)
+
+
+class TestValueExistsInAudit(TestCase):
+    """Tests for value_exists_in_audit"""
+    def test_empty(self):
+        sac_path = "a"
+        sac_value = 1
+        test_json = {}
+        expected_result = False
+        result = value_exists_in_audit(sac_path, sac_value, test_json)
+        self.assertEqual(result, expected_result)
+
+    def test_simple(self):
+        sac_path = "a"
+        sac_value = 1
+        test_json = { "a": 1 }
+        expected_result = True
+        result = value_exists_in_audit(sac_path, sac_value, test_json)
+        self.assertEqual(result, expected_result)
+
+    def test_nested(self):
+        sac_path = "a.b"
+        sac_value = 2
+        test_json = { "c.b": 2 }
+        expected_result = True
+        result = value_exists_in_audit(sac_path, sac_value, test_json)
+        self.assertEqual(result, expected_result)
+
+    def test_list(self):
+        sac_path = "a[0]"
+        sac_value = 1
+        test_json = { "a[0]": 1 }
+        expected_result = True
+        result = value_exists_in_audit(sac_path, sac_value, test_json)
+        self.assertEqual(result, expected_result)
+
+    def test_nested_list(self):
+        sac_path = "a.b[0]"
+        sac_value = 1
+        test_json = { "a.b[0]": 1 }
+        expected_result = True
+        result = value_exists_in_audit(sac_path, sac_value, test_json)
+        self.assertEqual(result, expected_result)
+
+    def test_list_different_index(self):
+        """
+        A value that matches but has a different position in a list should
+        still be found
+        """
+        sac_path = "a[0]"
+        sac_value = 1
+        test_json = { "a[1]": 1 }
+        expected_result = True
+        result = value_exists_in_audit(sac_path, sac_value, test_json)
+        self.assertEqual(result, expected_result)
+
+    def test_different_key(self):
+        """The SAC value is found in the SOT, but uses a different key"""
+        sac_path = "a"
+        sac_value = 1
+        test_json = { "b": 1 }
+        expected_result = {
+            'found_with_different_key': True,
+            'sac_field': 'a',
+            'audit_path': 'b',
+            'value': 1,
+        }
+        result = value_exists_in_audit(sac_path, sac_value, test_json)
+        self.assertDictEqual(result, expected_result)
+
+class TestCompareValues(TestCase):
+    """Tests for compare_values"""
+    def test_simple_true(self):
+        value_1 = 1
+        value_2 = 1
+        result = compare_values(value_1, value_2)
+        self.assertTrue(result)
+
+    def test_simple_false(self):
+        value_1 = 1
+        value_2 = 2
+        result = compare_values(value_1, value_2)
+        self.assertFalse(result)
+
+    def test_float_1(self):
+        value_1 = 1.0
+        value_2 = 1
+        result = compare_values(value_1, value_2)
+        self.assertTrue(result)
+
+    def test_float_2(self):
+        value_1 = 1
+        value_2 = 1.0
+        result = compare_values(value_1, value_2)
+        self.assertTrue(result)
+
+    def test_int_str_1(self):
+        value_1 = 1
+        value_2 = "1"
+        result = compare_values(value_1, value_2)
+        self.assertTrue(result)
+
+    def test_int_str_2(self):
+        value_1 = "1"
+        value_2 = 1
+        result = compare_values(value_1, value_2)
+        self.assertTrue(result)
+
+    # Are these possible, since we're flattening?
+    def test_list_1(self):
+        value_1 = [1, 2]
+        value_2 = 1
+        result = compare_values(value_1, value_2)
+        self.assertTrue(result)
+
+    def test_list_2(self):
+        value_1 = 1
+        value_2 = [1, 2]
+        result = compare_values(value_1, value_2)
+        self.assertTrue(result)
+
+    def test_dict_1(self):
+        value_1 = { "a": 1 }
+        value_2 = 1
+        result = compare_values(value_1, value_2)
+        self.assertTrue(result)
+
+    def test_dict_2(self):
+        value_1 = 1
+        value_2 = { "a": 1 }
+        result = compare_values(value_1, value_2)
+        self.assertTrue(result)
+
+class TestValidateAuditConsistency(TestCase):
+    """Tests for validate_audit_consistency"""
+    def test_simple_valid(self):
+        audit = baker.make(Audit, version=0)
+        baker.make(SingleAuditChecklist, report_id=audit.report_id)
+        result = validate_audit_consistency(audit)
+        self.assertTrue(result[0])
+        self.assertEqual(result[1], [])
+
+    def test_simple_invalid(self):
+        audit = baker.make(Audit, version=0)
+        sac = baker.make(SingleAuditChecklist, report_id=audit.report_id)
+        sac.data_source = "foo"
+        sac.save()
+        result = validate_audit_consistency(audit)
+        self.assertFalse(result[0])
+        self.assertEqual(result[1], [{'field': 'data_source', 'sac_value': 'foo', 'audit_value': 'GSAFAC'}])
+
+    def test_json_valid(self):
+        audit = baker.make(Audit, version=0)
+        audit.audit = { 'general_information': { 'a': 1 } }
+        audit.save()
+        sac = baker.make(SingleAuditChecklist, report_id=audit.report_id)
+        sac.general_information = { 'a': 1 }
+        sac.save()
+        result = validate_audit_consistency(audit)
+        self.assertTrue(result[0])
+        self.assertEqual(result[1], [])
+
+    def test_json_invalid(self):
+        audit = baker.make(Audit, version=0)
+        audit.audit = { 'general_information': { 'a': 1 } }
+        audit.save()
+        sac = baker.make(SingleAuditChecklist, report_id=audit.report_id)
+        sac.general_information = { 'a': 2 }
+        sac.save()
+        result = validate_audit_consistency(audit)
+        self.assertFalse(result[0])
+        self.assertEqual(
+            result[1],
+            [{'field': 'general_information', 'sac_path': 'a', 'sac_value': 2, 'error': 'Value from SAC.general_information.a not found in Audit'}],
+        )
+
+    def test_json_audit_none_invalid(self):
+        audit = baker.make(Audit, version=0)
+        sac = baker.make(SingleAuditChecklist, report_id=audit.report_id)
+        sac.general_information = { 'a': 1 }
+        sac.save()
+        result = validate_audit_consistency(audit)
+        self.assertFalse(result[0])
+        self.assertEqual(
+            result[1],
+            [{'field': 'general_information', 'error': 'Field is empty in Audit, but not in SAC', 'sac_value': {'a': 1}, 'audit_value': None}],
+        )
+
+    def test_json_sac_none_invalid(self):
+        audit = baker.make(Audit, version=0)
+        audit.audit = { 'general_information': { 'a': 1 } }
+        audit.save()
+        baker.make(SingleAuditChecklist, report_id=audit.report_id)
+        result = validate_audit_consistency(audit)
+        self.assertFalse(result[0])
+        self.assertEqual(
+            result[1],
+            [{'field': 'general_information', 'error': 'Field is empty in SAC, but not in Audit', 'sac_value': None, 'audit_value': {'a': 1}}],
+        )

--- a/backend/dissemination/management/commands/source_of_truth.py
+++ b/backend/dissemination/management/commands/source_of_truth.py
@@ -1,0 +1,84 @@
+from django.core.management.base import BaseCommand
+from django.db.models import Q
+
+import logging
+import sys
+
+from audit.models import Audit
+from dissemination.models import General
+from audit.models import SingleAuditChecklist
+from audit.models.utils import validate_audit_consistency
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = """
+        For the given fac_accepted_date range, validate that submission data
+        matches for both the SOT and SAC models.
+        Usage:
+        manage.py source_of_truth
+            --start <YYYYMMDD start fac_accepted_date>
+            --end <YYYYMMDD end fac_accepted_date>
+
+        Alternatively, it can also test on a single report_id:
+        manage.py source_of_truth
+            --report_id 2023-12-GSAFAC-0000000001
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument("--start", type=str, required=False, help="YYYYMMDD start fac_accepted_date")
+        parser.add_argument("--end", type=str, required=False, help="YYYYMMDD end fac_accepted_date")
+        parser.add_argument("--report_id", type=str, required=False, help="A report_id")
+
+    def handle(self, *args, **kwargs):
+        report_id = kwargs.get("report_id", None)
+        if report_id:
+            logger.info(f"Testing on report_id {report_id}")
+            query = Q(report_id=report_id)
+        else:
+            start = kwargs["start"]
+            end = kwargs["end"]
+            logger.info(f"Testing on date range {start}-{end}")
+            query = Q(fac_accepted_date__gte=start) | Q(fac_accepted_date__lte=end)
+
+        sot_audits_query = Audit.objects.filter(query) # also search for dissem status?
+        sot_sorted_report_ids = self._get_sorted_report_ids(sot_audits_query)
+
+        gen_audits_query = General.objects.filter(query)
+        sac_sorted_report_ids = self._get_sorted_report_ids(gen_audits_query)
+
+        logger.info(f"SOT report_ids: {sot_sorted_report_ids}")
+        logger.info(f"SAC report_ids: {sac_sorted_report_ids}")
+
+        if sot_sorted_report_ids != sac_sorted_report_ids:
+            sot_not_sac = [x for x in sot_sorted_report_ids if x not in sac_sorted_report_ids]
+            logger.error(f"report_ids found in SOT but not SAC: {sot_not_sac}")
+            sac_not_sot = [x for x in sac_sorted_report_ids if x not in sot_sorted_report_ids]
+            logger.error(f"report_ids found in SAC but not SOT: {sac_not_sot}")
+        else:
+            logger.info(f"SOT and SAC report_ids match; continuing")
+
+        sot_audits_by_report_id = self._get_audits_by_report_id(sot_audits_query)
+
+        for report_id in sot_sorted_report_ids:
+            is_consistent, discrepancies = validate_audit_consistency(sot_audits_by_report_id[report_id])
+
+            if not is_consistent:
+                logger.error(discrepancies)
+
+    def _get_sorted_report_ids(self, queryset):
+        report_ids = []
+        for audit in queryset:
+            report_ids.append(audit.report_id)
+
+        report_ids.sort()
+
+        return report_ids
+
+    def _get_audits_by_report_id(self, audits_query):
+        result = {}
+        for audit in audits_query:
+            result[audit.report_id] = audit
+
+        return result


### PR DESCRIPTION
In this PR:
- Creating unit tests for the SOT real time checking
- Creating a Django command for testing SAC vs. SOT data for a date range or report_id
- Some tweaks to the real time checking code, mostly name changes to make it clear what is SAC and what is SOT

Testing:
- Use a valid `report_id`/date range for these commands:
  - `docker compose run --rm web python manage.py source_of_truth --report_id 2023-12-GSAFAC-0000000001`
  - `docker compose run --rm web python manage.py source_of_truth --start 20250101 --end 20260101`
- `docker compose run --rm web python manage.py test audit.test_validate_audit_consistency`

## PR Checklist: Submitter

- [ ]   Link to an issue if possible. If there’s no issue, describe what your branch does. Even if there is an issue, a brief description in the PR is still useful.
- [ ]   List any special steps reviewers have to follow to test the PR. For example, adding a local environment variable, creating a local test file, etc.
- [ ]   For extra credit, submit a screen recording like [this one](https://github.com/GSA-TTS/FAC/pull/1821).
- [ ]   Make sure you’ve merged `main` into your branch shortly before creating the PR. (You should also be merging `main` into your branch regularly during development.)
- [ ]   Make sure you’ve accounted for any migrations. When you’re about to create the PR, bring up the application locally and then run `git status | grep migrations`. If there are any results, you probably need to add them to the branch for the PR. Your PR should have only **one** new migration file for each of the component apps, except in rare circumstances; you may need to delete some and re-run `python manage.py makemigrations` to reduce the number to one. (Also, unless in exceptional circumstances, your PR should not delete any migration files.)
- [ ]   Make sure that whatever feature you’re adding has tests that cover the feature. This includes test coverage to make sure that the previous workflow still works, if applicable.
- [ ]   Make sure the full-submission.cy.js [Cypress test](https://github.com/GSA-TTS/FAC/blob/main/docs/testing.md#end-to-end-testing) passes, if applicable.
- [ ]   Do manual testing locally. Our tests are not good enough yet to allow us to skip this step. If that’s not applicable for some reason, check this box.
- [ ]   Verify that no Git surgery was necessary, or, if it was necessary at any point, repeat the testing after it’s finished.
- [ ]   Once a PR is merged, keep an eye on it until it’s deployed to dev, and do enough testing on dev to verify that it deployed successfully, the feature works as expected, and the happy path for the broad feature area (such as submission) still works.
- [ ]   Ensure that prior to merging, the working branch is up to date with main and the terraform plan is what you expect.

## PR Checklist: Reviewer

- [ ]   Pull the branch to your local environment and run `make docker-clean; make docker-first-run && docker compose up`; then run `docker compose exec web /bin/bash -c "python manage.py test"`
- [ ]   Manually test out the changes locally, or check this box to verify that it wasn’t applicable in this case.
- [ ]   Check that the PR has appropriate tests. Look out for changes in HTML/JS/JSON Schema logic that may need to be captured in Python tests even though the logic isn’t in Python.
- [ ]   Verify that no Git surgery is necessary at any point (such as during a merge party), or, if it was, repeat the testing after it’s finished.

The larger the PR, the stricter we should be about these points.

## Pre Merge Checklist: Merger

- [ ]   Ensure that prior to approving, the terraform plan is what we expect it to be. `-/+ resource "null_resource" "cors_header" ` should be destroying and recreating its self and ` ~ resource "cloudfoundry_app" "clamav_api" ` might be updating its `sha256` for the `fac-file-scanner` and `fac-av-${ENV}` by default.
- [ ]   Ensure that the branch is up to date with `main`.
- [ ]   Ensure that a terraform plan has been recently generated for the pull request.
