### PR TITLE
Fix for auditee_ein

### DIFF
--- a/backend/audit/migrations/0018_auditflow_rename_audit_history_event_data_and_more.py
+++ b/backend/audit/migrations/0018_auditflow_rename_audit_history_event_data_and_more.py
@@ -130,4 +130,19 @@ class Migration(migrations.Migration):
                 ]
             ),
         ),
+        migrations.RemoveField(model_name="audit", name="auditee_ein"),
+        migrations.AddField(
+            model_name="audit",
+            name="auditee_ein",
+            field=models.GeneratedField(
+                db_persist=True,
+                expression=django.db.models.fields.json.KeyTextTransform(
+                    "ein",
+                    django.db.models.fields.json.KeyTextTransform(
+                        "general_information", "audit"
+                    ),
+                ),
+                output_field=models.CharField(),
+            ),
+        ),
     ]

--- a/backend/audit/models/audit.py
+++ b/backend/audit/models/audit.py
@@ -226,7 +226,7 @@ class Audit(CreatedMixin, UpdatedMixin):
 
     auditee_ein = GeneratedField(
         expression=KeyTextTransform(
-            "auditee_ein", KeyTextTransform("general_information", "audit")
+            "ein", KeyTextTransform("general_information", "audit")
         ),
         output_field=models.CharField(),
         db_persist=True,


### PR DESCRIPTION
## Purpose

auditee_ein field was not populating correctly. It should be.

## How

Updated the generated field to use the correct object in the general information blob

## Testing done

E2E Tests: The E2E tests were failing due to login issues unrelated to this change. The tests were still creating the audits in the audit table, so I verified the auditee_ein was populating. I'll continue testing, but wanted to get this out quickly

## Notes

You will need to do a full rebuild of your database since I added the migration to the existing migration file.