### PR TITLE
Adding a beta page for Summary View

### DIFF
--- a/backend/dissemination/templates/audit_summary.html
+++ b/backend/dissemination/templates/audit_summary.html
@@ -1,0 +1,279 @@
+{% extends "base.html" %}
+{% load getkey %}
+{% load humanize %}
+{% load sprite_helper %}
+{% load static %}
+{% block content %}
+    <div class="grid-container margin-top-6">
+        <div class="grid-col grid-gap">
+            {% comment %} Title & Header {% endcomment %}
+          {% include "includes/beta_warning.html" %}
+            <div class="grid-row" id="title">
+                <div class="grid-col-12 tablet:grid-col-7">
+                    <h1 class="usa-legend usa-legend--large font-sans-2xl">Single audit summary</h1>
+                    <legend class="usa-legend usa-legend--large text-normal font-sans-xl margin-top-4">
+                        <p class="margin-0 text-bold">{{ header.auditee_name }}</p>
+                        <p class="margin-0 text-semibold">
+                            <strong>UEI:</strong> {{ header.auditee_uei }}
+                        </p>
+                    </legend>
+                    <div class="font-sans-lg">
+                        <p class="margin-bottom-1 margin-top-2">
+                            <strong>Report ID:&nbsp;</strong>{{ header.report_id }}
+                        </p>
+                        <p class="margin-y-1">
+                            <strong>FAC acceptance date:&nbsp;</strong>{{ header.fac_accepted_date }}
+                        </p>
+                        <p class="margin-y-1">
+                            <strong>Fiscal Year:&nbsp;</strong>{{ header.fy_start_date }} to {{ header.fy_end_date }}
+                        </p>
+                    </div>
+                </div>
+                <div class="grid-col-12 tablet:grid-col-5 tablet:display-flex flex-column tablet:flex-justify-end">
+                    <div class="margin-0 flex-align-self-end margin-top-2">
+                        <div class="display-flex flex-row">
+                            <a class="usa-button display-flex flex-fill font-sans-xl margin-bottom-2"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                href="{% url 'dissemination:SummaryReportDownload' report_id=report_id%}"
+                            >
+                                <svg class="usa-icon margin-right-1 flex-align-self-center"
+                                    aria-hidden="true"
+                                    role="img">
+                                    {% uswds_sprite "file_download" %}
+                                </svg>
+                                <p class="margin-0">SF-SAC</p>
+                            </a>
+                        </div>
+
+                        {% if allow_download %}
+                            <a class="usa-button display-flex font-sans-xl"
+                                href="{% url 'dissemination:PdfDownload' report_id=report_id %}"
+                                target="_blank"
+                                rel="noopener noreferrer">
+                                <svg class="usa-icon margin-right-1 flex-align-self-center"
+                                    aria-hidden="true"
+                                    role="img">
+                                    {% uswds_sprite "file_download" %}
+                                </svg>
+                                <p class="margin-0">Single audit report</p>
+                            </a>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    {% comment %} The grey box of doom {% endcomment %}
+    <div class="bg-base-lighter padding-bottom-10 ">
+        <div class="grid-container margin-top-6">
+            <div id="summary-information" class="margin-top-6 padding-y-3">
+                {% comment %} Auditee {% endcomment %}
+                <h2 class="font-sans-2xl text-semibold margin-bottom-2 margin-top-3">Auditee</h2>
+                <table class="usa-table width-full">
+                    <tbody class="grid-row" id="{{ section_key }}-table__body">
+                        <tr class="grid-row grid-col-12">
+                            <td class="grid-col-12 tablet:grid-col tablet:margin-right-2">
+                                <p class="margin-y-1">
+                                    <strong>Contact Name:&nbsp;</strong>{{ auditee_info.auditee_contact_name }}
+                                </p>
+                            </td>
+                            <td class="grid-col-12 margin-top-2 tablet:grid-col tablet:margin-left-2 tablet:margin-top-0">
+                                <p class="margin-y-1">
+                                    <strong>Contact title:&nbsp;</strong>{{ auditee_info.auditee_contact_title }}
+                                </p>
+                            </td>
+                        </tr>
+                        <tr class="grid-row grid-col-12 margin-top-2">
+                            <td class="grid-col-12 tablet:grid-col tablet:margin-right-2">
+                                <p class="margin-y-1">
+                                    <strong>Email:&nbsp;</strong>{{ auditee_info.auditee_email }}
+                                </p>
+                            </td>
+                            <td class="grid-col-12 margin-top-2 tablet:grid-col tablet:margin-left-2 tablet:margin-top-0">
+                                <p class="margin-y-1">
+                                    <strong>Phone:&nbsp;</strong>{{ auditee_info.auditee_phone }}
+                                </p>
+                            </td>
+                        </tr>
+                        <tr class="grid-row grid-col-12 margin-top-2">
+                            <td class="grid-col-12 tablet:grid-col tablet:margin-right-2">
+                                <p class="margin-y-1">
+                                    <strong>Address:&nbsp;</strong>{{ auditee_info.auditee_address_line_1 }}
+                                </p>
+                            </td>
+                            <td class="grid-col-12 margin-top-2 tablet:grid-col tablet:margin-left-2 tablet:margin-top-0">
+                                <p class="margin-y-1">
+                                    <strong>City and state:&nbsp;</strong>{{ auditee_info.auditee_city }}, {{ auditee_info.auditee_state }}
+                                </p>
+                            </td>
+                        </tr>
+                        <tr class="grid-row grid-col-12 margin-top-2">
+                            <td class="grid-col-12 tablet:grid-col tablet:margin-right-2">
+                                <p class="margin-y-1">
+                                    <strong>Zip code:&nbsp;</strong>{{ auditee_info.auditee_zip }}
+                                </p>
+                            </td>
+                            <td class="grid-col-12 margin-top-2 tablet:grid-col tablet:margin-left-2 tablet:margin-top-0">
+                                <p class="margin-y-1">
+                                    <span><strong>Additional UEIs? </strong>{{ auditee_info.additional_ueis }}</span>
+                                </p>
+                            </td>
+                        </tr>
+                        <tr class="grid-row grid-col-12 margin-top-2">
+                            <td class="grid-col-12 tablet:grid-col tablet:margin-right-2">
+                                <p class="margin-y-1">
+                                    <strong>EIN:&nbsp;</strong>{{ auditee_info.ein }}
+                                </p>
+                            </td>
+                            <td class="grid-col-12 margin-top-2 tablet:grid-col tablet:margin-left-2 tablet:margin-top-0">
+                                <p class="margin-y-1">
+                                    <span><strong>Additional EINs? </strong>{{ auditee_info.additional_eins }}</span>
+                                </p>
+                            </td>
+                        </tr>
+                        <tr class="grid-row grid-col-12 margin-top-2">
+                            <td class="grid-col-12 tablet:grid-col tablet:margin-right-2">
+                                <p class="margin-y-1">
+                                    <strong>Certifying name:&nbsp;</strong>{{ auditee_info.auditee_certify_name }}
+                                </p>
+                            </td>
+                            <td class="grid-col-12 margin-top-2 tablet:grid-col tablet:margin-left-2 tablet:margin-top-0">
+                                <p class="margin-y-1">
+                                    <strong>Certifying title:&nbsp;</strong>{{ auditee_info.auditee_certify_title }}
+                                </p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+
+                {% comment %} Auditor {% endcomment %}
+                <h2 class="font-sans-2xl text-semibold margin-bottom-2 margin-top-3">Auditor</h2>
+                <table class="usa-table width-full">
+                    <tbody class="grid-row" id="{{ section_key }}-table__body">
+                        <tr class="grid-row grid-col-12">
+                            <td class="grid-col-12 tablet:grid-col tablet:margin-right-2">
+                                <p class="margin-y-1">
+                                    <strong>Contact Name:&nbsp;</strong>{{ auditor_info.auditor_contact_name }}
+                                </p>
+                            </td>
+                            <td class="grid-col-12 margin-top-2 tablet:grid-col tablet:margin-left-2 tablet:margin-top-0">
+                                <p class="margin-y-1">
+                                    <strong>Contact title:&nbsp;</strong>{{ auditor_info.auditor_contact_title }}
+                                </p>
+                            </td>
+                        </tr>
+                        <tr class="grid-row grid-col-12 margin-top-2">
+                            <td class="grid-col-12 tablet:grid-col tablet:margin-right-2">
+                                <p class="margin-y-1">
+                                    <strong>Email:&nbsp;</strong>{{ auditor_info.auditor_email }}
+                                </p>
+                            </td>
+                            <td class="grid-col-12 margin-top-2 tablet:grid-col tablet:margin-left-2 tablet:margin-top-0">
+                                <p class="margin-y-1">
+                                    <strong>Phone:&nbsp;</strong>{{ auditor_info.auditor_phone }}
+                                </p>
+                            </td>
+                        </tr>
+                        {% if auditor_info.auditor_address_line_1 %}
+                            {% comment %} Domestic auditor {% endcomment %}
+                            <tr class="grid-row grid-col-12 margin-top-2">
+                                <td class="grid-col-12 tablet:grid-col tablet:margin-right-2">
+                                    <p class="margin-y-1">
+                                        <strong>Address:&nbsp;</strong>{{ auditor_info.auditor_address_line_1 }}
+                                    </p>
+                                </td>
+                                <td class="grid-col-12 margin-top-2 tablet:grid-col tablet:margin-left-2 tablet:margin-top-0">
+                                    <p class="margin-y-1">
+                                        <strong>City and state:&nbsp;</strong>{{ auditor_info.auditor_city }}, {{ auditor_info.auditor_state }}
+                                    </p>
+                                </td>
+                            </tr>
+                            <tr class="grid-row grid-col-12 margin-top-2">
+                                <td class="grid-col-12 tablet:grid-col tablet:margin-right-2">
+                                    <p class="margin-y-1">
+                                        <strong>Zip code:&nbsp;</strong>{{ auditor_info.auditor_zip }}
+                                    </p>
+                                </td>
+                                <td class="grid-col-12 margin-top-2 tablet:grid-col tablet:margin-left-2 tablet:margin-top-0">
+                                    <p class="margin-y-1">
+                                        <span><strong>Secondary Auditors? </strong>&nbsp;{{auditor_info.has_secondary_auditors}}
+                                        </span>
+                                    </p>
+                                </td>
+                            </tr>
+                        {% else %}
+                            {% comment %} International auditor {% endcomment %}
+                            <tr class="grid-row grid-col-12 margin-top-2">
+                                <td class="grid-col-12 tablet:grid-col tablet:margin-right-2">
+                                    <p class="margin-y-1">
+                                        <strong>Address:&nbsp;</strong>{{ auditor_info.auditor_foreign_address }}
+                                    </p>
+                                </td>
+                                <td class="grid-col-12 margin-top-2 tablet:grid-col tablet:margin-left-2 tablet:margin-top-0">
+                                    <p class="margin-y-1">
+                                        <span><strong>Secondary Auditors? </strong> {{auditor_info.has_secondary_auditors}}
+                                    </p>
+                                </td>
+                            </tr>
+                        {% endif %}
+                    </tbody>
+                </table>
+
+                {% comment %} Summary {% endcomment %}
+                <h2 class="font-sans-2xl text-semibold margin-bottom-2 margin-top-3">Summary</h2>
+                <table class="usa-table width-full">
+                    <tbody class="grid-row" id="{{ section_key }}-table__body">
+                        <tr class="grid-row grid-col-12">
+                            <td class="grid-col-12 margin-top-2 tablet:grid-col tablet:margin-right-2 tablet:margin-top-0">
+                                <p class="margin-y-1">
+                                    <span><strong>Federal awards:</strong>&nbsp;
+                                        {{ summary.number_of_federal_awards }}
+                                    </span>
+                                </p>
+                            </td>
+                            <td class="grid-col-12 margin-top-2 tablet:grid-col tablet:margin-left-2 tablet:margin-top-0">
+                                <p class="margin-y-1 {% if not summary|getkey:"Notes to SEFA" %}text-gray-40{% endif %}">
+                                    <span><strong>Notes to SEFA:</strong>&nbsp;{{ summary.number_of_notes }}</span>
+                                </p>
+                            </td>
+                        </tr>
+                        <tr class="grid-row grid-col-12 margin-top-2">
+                            <td class="grid-col-12 margin-top-2 tablet:grid-col tablet:margin-right-2 tablet:margin-top-0">
+                                <p class="margin-y-1 {% if not summary|getkey:"Audit Findings" %}text-gray-40{% endif %}">
+                                    <span><strong>Findings:</strong>&nbsp;
+                                        {{ summary.number_of_findings }}
+                                    </span>
+                                </p>
+                            </td>
+                            {% comment %} Findings text - If none, show the gray box with no link. {% endcomment %}
+                            <td class="grid-col-12 margin-top-2 tablet:grid-col tablet:margin-left-2 tablet:margin-top-0">
+                                <p class="margin-y-1 {% if not summary|getkey:"Audit Findings Text" %}text-gray-40{% endif %}">
+                                    <span><strong>Findings text:</strong>&nbsp; {{ summary.number_of_findings_text }}</span>
+                                </p>
+                            </td>
+                        </tr>
+                        {% comment %} CAP - If none, show the gray box with no link. {% endcomment %}
+                        <tr class="grid-row grid-col-12 margin-top-2">
+                            <td class="grid-col-12 tablet:grid-col tablet:margin-right-2 tablet:margin-top-0">
+                                <p class="margin-y-1 {% if not summary|getkey:"Corrective Action Plan" %}text-gray-40{% endif %}">
+                                    <span><strong>CAP:</strong>&nbsp;{{ summary.number_of_caps }}
+                                    </span>
+                                </p>
+                            </td>
+                            <td class="grid-col-12 margin-top-2 tablet:grid-col tablet:margin-left-2 tablet:margin-top-0">
+                                <p class="margin-y-1 display-flex flex-row flex-justify">
+                                    <strong>Total federal expenditure:&nbsp;</strong>
+                                    <span class="margin-0 display-flex">
+                                        ${{ summary.total_amount_expended|intcomma }}
+                                    </span>
+                                </p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+{% endblock content %}

--- a/backend/dissemination/views/summary.py
+++ b/backend/dissemination/views/summary.py
@@ -1,4 +1,7 @@
 import logging
+
+from audit.models import Audit
+from audit.models.constants import STATUS
 from dissemination.models import (
     AdditionalEin,
     AdditionalUei,
@@ -16,7 +19,7 @@ from django.http import Http404
 from django.shortcuts import render
 from django.views.generic import View
 
-from dissemination.views.utils import include_private_results
+from dissemination.views.utils import include_private_results, to_date
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +33,9 @@ class AuditSummaryView(View):
         3.  Wrap the data into a context object for display.
         """
         # Viewable audits __MUST__ be public.
+        if request.GET.get("beta", "N") == "Y":
+            return self._handle_sot(request, report_id)
+
         general = General.objects.filter(report_id=report_id)
         if not general.exists():
             raise Http404(
@@ -40,7 +46,7 @@ class AuditSummaryView(View):
 
         include_private = include_private_results(request)
         include_private_and_public = include_private or general_data["is_public"]
-        data = self.get_audit_content(report_id, include_private_and_public)
+        data = self._get_audit_content(report_id, include_private_and_public)
         is_sf_sac_downloadable = DisseminationCombined.objects.filter(
             report_id=report_id
         ).exists()
@@ -58,7 +64,128 @@ class AuditSummaryView(View):
 
         return render(request, "summary.html", context)
 
-    def get_audit_content(self, report_id, include_private_and_public):
+    def _handle_sot(self, request, report_id):
+        # TODO: Update Post SOC Launch
+        audit = Audit.objects.find_audit_or_none(report_id=report_id)
+        if not audit and audit.submission_status != STATUS.DISSEMINATED:
+            raise Http404(f"The report with ID: {report_id} does not exist.")
+
+        include_private = include_private_results(request)
+        include_private_and_public = include_private or audit.is_public
+        context = {
+            "report_id": report_id,
+            "header": self._populate_header(audit),
+            "auditee_info": self._populate_auditee(audit),
+            "auditor_info": self._populate_auditor(audit),
+            "summary": self._populate_summary(audit, include_private_and_public),
+            "all_download": include_private_and_public,
+            "is_beta": True,
+            "non_beta_url": "dissemination:Summary",
+        }
+        return render(request, "audit_summary.html", context)
+
+    @staticmethod
+    def _populate_header(audit):
+        return {
+            "auditee_name": audit.auditee_name,
+            "auditee_uei": audit.auditee_uei,
+            "fac_accepted_date": to_date(audit.fac_accepted_date),
+            "report_id": audit.report_id,
+            "fy_start_date": to_date(
+                audit.audit["general_information"]["auditee_fiscal_period_start"]
+            ),
+            "fy_end_date": to_date(
+                audit.audit["general_information"]["auditee_fiscal_period_end"]
+            ),
+        }
+
+    @staticmethod
+    def _populate_auditee(audit):
+        auditee_signature = audit.audit["auditee_certification"]["auditee_signature"]
+        auditee_general_keys = {
+            "auditee_contact_name",
+            "auditee_contact_title",
+            "auditee_email",
+            "auditee_phone",
+            "auditee_address_line_1",
+            "auditee_city",
+            "auditee_state",
+            "auditee_zip",
+            "ein",
+        }
+        auditee_info = {
+            key: audit.audit["general_information"].get(key, "")
+            for key in auditee_general_keys
+        }
+
+        return {
+            "additional_eins": "Y" if audit.audit.get("additional_eins", []) else "N",
+            "additional_ueis": "Y" if audit.audit.get("additional_ueis", []) else "N",
+            "auditee_certify_name": auditee_signature["auditee_name"],
+            "auditee_certify_title": auditee_signature["auditee_title"],
+            **auditee_info,
+        }
+
+    @staticmethod
+    def _populate_auditor(audit):
+        auditor_general_keys = {
+            "auditor_contact_name",
+            "auditor_contact_title",
+            "auditor_email",
+            "auditor_phone",
+            "auditor_address_line_1",
+            "auditor_city",
+            "auditor_state",
+            "auditor_zip",
+            "auditor_foreign_address",
+        }
+        # secondary auditors
+        auditor_info = {
+            key: audit.audit["general_information"].get(key, "")
+            for key in auditor_general_keys
+        }
+        return {
+            "has_secondary_auditors": (
+                "Y"
+                if audit.audit["general_information"].get(
+                    "secondary_auditors_exist", False
+                )
+                else "N"
+            ),
+            **auditor_info,
+        }
+
+    @staticmethod
+    def _populate_summary(audit, is_public):
+        return {
+            "number_of_federal_awards": len(
+                audit.audit["federal_awards"].get("awards", [])
+            ),
+            "number_of_notes": (
+                len(
+                    audit.audit.get("notes_to_sefa", {}).get(
+                        "notes_to_sefa_entries", []
+                    )
+                )
+                if is_public
+                else "N/A"
+            ),
+            "number_of_findings": len(audit.audit.get("findings_uniform_guidance", [])),
+            "number_of_findings_text": (
+                len(audit.audit.get("findings_text", [])) if is_public else "N/A"
+            ),
+            "number_of_caps": (
+                len(audit.audit.get("corrective_action_plan", []))
+                if is_public
+                else "N/A"
+            ),
+            "total_amount_expended": audit.audit["federal_awards"][
+                "total_amount_expended"
+            ],
+        }
+
+    @staticmethod
+    def _get_audit_content(report_id, include_private_and_public):
         """
         Grab everything relevant from the dissemination tables.
         Wrap that data into a dict, and return it.

--- a/backend/dissemination/views/utils.py
+++ b/backend/dissemination/views/utils.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from users.permissions import can_read_tribal
 
 
@@ -12,3 +14,10 @@ def include_private_results(request):
         return False
 
     return True
+
+
+def to_date(date_string):
+    """
+    Helper method to convert a string in the format YYYY-MM-DD to a date object.
+    """
+    return datetime.strptime(date_string, "%Y-%m-%d").date()

--- a/backend/templates/includes/beta_warning.html
+++ b/backend/templates/includes/beta_warning.html
@@ -9,7 +9,11 @@ Alert component, provides resources on what to do/where to go when an expected r
         <p class="usa-alert__text padding-bottom-2">
             If this page does not look like you expect please click
             <a class="usa-link"
+               {% if report_id %}
+                href="{% url non_beta_url report_id=report_id%}"
+               {% else %}
                 href="{% url non_beta_url %}"
+               {% endif %}
                 target="_blank"
                 rel="noopener noreferrer">here</a>
             to view the original version of this page.


### PR DESCRIPTION
## Purpose

The Summary view page should use the new audit table.

## How

Created a new beta end point which loads the summary page from the audit table. It's accessible similar to this:

http://localhost:8000/dissemination/summary/2023-12-GSAFAC-0000000001?**beta=Y**

## Testing Completed

Linting, Unit Tests, End to End, Manual Testing.