### PR TITLE
Fix for counting of findings to be in-line with previous method

### DIFF
--- a/backend/audit/models/viewflow.py
+++ b/backend/audit/models/viewflow.py
@@ -147,9 +147,6 @@ def sac_transition(request, sac, **kwargs):
         return True
 
     elif target == STATUS.READY_FOR_CERTIFICATION:
-        logger.error(
-            f"JASON ReadyForCert ========> SAC: {sac.submission_status} Audit: {audit.submission_status}"
-        )
         flow.transition_to_ready_for_certification()
         sac.save(
             event_user=user,

--- a/backend/audit/views/submissions.py
+++ b/backend/audit/views/submissions.py
@@ -156,7 +156,7 @@ class SubmissionView(CertifyingAuditeeRequiredMixin, generic.View):
                     request, sac, audit=audit, transition_to=STATUS.SUBMITTED
                 )
                 disseminated = sac.disseminate()
-                audit_indexes = generate_audit_indexes(audit, sac)
+                audit_indexes = generate_audit_indexes(audit)
                 audit.audit.update(audit_indexes)
 
                 # `disseminated` is None if there were no errors.

--- a/backend/dissemination/views/summary.py
+++ b/backend/dissemination/views/summary.py
@@ -157,19 +157,18 @@ class AuditSummaryView(View):
 
     @staticmethod
     def _populate_summary(audit, is_public):
+        notes_count = 0
+
+        # The main notes_to_sefa object counts as 1 note unless there are entries.
+        if audit.audit["notes_to_sefa"]:
+            num_notes_entries = len(audit.audit["notes_to_sefa"].get("notes_to_sefa_entries", []))
+            notes_count = max(1, num_notes_entries)
+
         return {
             "number_of_federal_awards": len(
                 audit.audit["federal_awards"].get("awards", [])
             ),
-            "number_of_notes": (
-                len(
-                    audit.audit.get("notes_to_sefa", {}).get(
-                        "notes_to_sefa_entries", []
-                    )
-                )
-                if is_public
-                else "N/A"
-            ),
+            "number_of_notes": notes_count if is_public else "N/A",
             "number_of_findings": len(audit.audit.get("findings_uniform_guidance", [])),
             "number_of_findings_text": (
                 len(audit.audit.get("findings_text", [])) if is_public else "N/A"

--- a/backend/dissemination/views/summary.py
+++ b/backend/dissemination/views/summary.py
@@ -161,7 +161,9 @@ class AuditSummaryView(View):
 
         # The main notes_to_sefa object counts as 1 note unless there are entries.
         if audit.audit["notes_to_sefa"]:
-            num_notes_entries = len(audit.audit["notes_to_sefa"].get("notes_to_sefa_entries", []))
+            num_notes_entries = len(
+                audit.audit["notes_to_sefa"].get("notes_to_sefa_entries", [])
+            )
             notes_count = max(1, num_notes_entries)
 
         return {
@@ -169,7 +171,9 @@ class AuditSummaryView(View):
                 audit.audit["federal_awards"].get("awards", [])
             ),
             "number_of_notes": notes_count if is_public else "N/A",
-            "number_of_findings": len(audit.audit.get("findings_uniform_guidance", [])),
+            "number_of_findings": audit.audit.get("search_indexes", {}).get(
+                "unique_audit_findings_count", 0
+            ),
             "number_of_findings_text": (
                 len(audit.audit.get("findings_text", [])) if is_public else "N/A"
             ),


### PR DESCRIPTION
## Purpose

The beta summary page and current summary page should show the same data.

## How

Previously, findings were counted based on unique reference numbers. The initial beta page counted all findings regardless of unique reference numbers. Now we pre-compute the unique findings count, and add it to the search indexes.

## Testing Done

End to End Tests, Manual test.

## Notes:

This will require the audit's to be re-migrated from SACs. Until they are re-migrated, the page will show 0 findings.