### PR TITLE
Updates the script to handle additional utilities

### DIFF
--- a/backend/util/load_public_dissem_data/README.md
+++ b/backend/util/load_public_dissem_data/README.md
@@ -69,14 +69,15 @@ Use the menu script in this folder.
 ./menu.bash
 ```
 
-This will give you three options:
+This will give you several options:
 
-```
-1) Truncate tables
-2) Load data
-3) Check row counts
-3) Quit
-```
+1. Truncate tables
+1. Load data
+1. Check row counts
+1. Reset migrated_to_audit
+1. Truncate audit_audit
+1. Quit
+
 
 ## truncate tables
 
@@ -110,6 +111,8 @@ This will reload:
 * auth_user
 * dissemination_*
 
+This also runs `reset_migrated_to_audit`, so that the data is ready for migration to SOT.
+
 ## check counts
 
 This verifies the row counts in every table we loaded. 
@@ -135,6 +138,16 @@ Checking counts
 [PASS] dissemination_passthrough has 4025800 rows
 [PASS] dissemination_secondaryauditor has 1803 rows
 ```
+
+## reset migrated_to_audit
+
+This option will set `migrated_to_audit` to `false` for all rows in the `singleauditchecklist`.
+
+This is run after data load, but is included in the menu as an option.
+
+## truncate audit_audit
+
+This truncates the audit_audit table with `CASCADE`, and then runs the `migrated_to_audit` reset.
 
 ## overriding the data filename
 

--- a/backend/util/load_public_dissem_data/menu.bash
+++ b/backend/util/load_public_dissem_data/menu.bash
@@ -6,6 +6,20 @@ HOST=localhost
 PORT=5432
 FILENAME=${FILENAME:-data/internal-and-external-20250320.dump}
 
+count_audit_singleauditchecklist=354222
+count_audit_access=1195595 
+count_auth_user=75461 
+count_dissemination_additionalein=59251
+count_dissemination_additionaluei=15101
+count_dissemination_captext=116694
+count_dissemination_federalaward=5811948
+count_dissemination_finding=507895
+count_dissemination_findingtext=120290
+count_dissemination_general=343114
+count_dissemination_note=530405
+count_dissemination_passthrough=4025800
+count_dissemination_secondaryauditor=1803
+
 truncate () {
   echo "Truncating test data tables."
   psql \
@@ -39,6 +53,68 @@ EOF
   fi
 }
 
+
+reset_migrated_to_audit () {
+
+  echo "Setting migrated_to_audit to false"
+
+  psql \
+		-d ${DATABASE} \
+		-U ${USERNAME} \
+		-p ${PORT} \
+		-h ${HOST} \
+    -t \
+    -v ON_ERROR_STOP=1 \
+		-w -c "UPDATE audit_singleauditchecklist SET migrated_to_audit = false"
+
+  if [ $? = 0 ]; then
+    echo "Done"
+  else
+    echo "Failed to reset migrated_to_audit"
+  fi
+
+    psql \
+		-d ${DATABASE} \
+		-U ${USERNAME} \
+		-p ${PORT} \
+		-h ${HOST} \
+    -t \
+		-w -c "SELECT COUNT(*) FROM audit_singleauditchecklist WHERE migrated_to_audit = false" > count.tmp
+
+  local VALUE=$(head -n 1 count.tmp)
+
+  if [ $VALUE -ge 0 ]; then
+      if [ $VALUE -eq ${count_audit_singleauditchecklist} ]; then
+        echo "[PASS] audit_singleauditchecklist has ${count_audit_singleauditchecklist} rows with migrated_to_audit = false"
+      else
+        echo "[FAIL] reset of audit_singleauditchecklist failed"
+      fi
+  fi
+  rm -f count.tmp
+}
+
+truncate_sourceoftruth () {
+  echo "Truncating audit_audit"
+  psql \
+		-d ${DATABASE} \
+		-U ${USERNAME} \
+		-p ${PORT} \
+		-h ${HOST} \
+		-w \
+    -v ON_ERROR_STOP=1 \
+    <<EOF
+	begin;
+		truncate audit_audit cascade;
+	commit;
+EOF
+
+  if [ $? = 0 ]; then
+    echo "Truncate completed successfully."
+  fi
+
+  reset_migrated_to_audit
+}
+
 # The dump may contain pg_dump parameters that are inappropriate
 # for our local stack. Remove those lines.
 load_data () {
@@ -56,6 +132,8 @@ load_data () {
   if [ $? = 0 ]; then
     echo "Data loaded successfully."
   fi
+
+  reset_migrated_to_audit
 }
 
 check_row_counts () {
@@ -85,23 +163,23 @@ check_row_counts () {
 
 check_all_row_counts () {
   echo "Checking counts"
-  check_row_counts "audit_singleauditchecklist" 354222
-  check_row_counts "audit_access" 1195595 
-  check_row_counts "auth_user" 75461 
-  check_row_counts "dissemination_additionalein" 59251
-  check_row_counts "dissemination_additionaluei" 15101
-  check_row_counts "dissemination_captext" 116694
-  check_row_counts "dissemination_federalaward" 5811948
-  check_row_counts "dissemination_finding" 507895
-  check_row_counts "dissemination_findingtext" 120290
-  check_row_counts "dissemination_general" 343114
-  check_row_counts "dissemination_note" 530405
-  check_row_counts "dissemination_passthrough" 4025800
-  check_row_counts "dissemination_secondaryauditor" 1803
+  check_row_counts "audit_singleauditchecklist" ${count_audit_singleauditchecklist}
+  check_row_counts "audit_access" ${count_audit_access} 
+  check_row_counts "auth_user" ${count_auth_user} 
+  check_row_counts "dissemination_additionalein" ${count_dissemination_additionalein}
+  check_row_counts "dissemination_additionaluei" ${count_dissemination_additionaluei}
+  check_row_counts "dissemination_captext" ${count_dissemination_captext}
+  check_row_counts "dissemination_federalaward" ${count_dissemination_federalaward}
+  check_row_counts "dissemination_finding" ${count_dissemination_finding}
+  check_row_counts "dissemination_findingtext" ${count_dissemination_findingtext}
+  check_row_counts "dissemination_general" ${count_dissemination_general}
+  check_row_counts "dissemination_note" ${count_dissemination_note}
+  check_row_counts "dissemination_passthrough" ${count_dissemination_passthrough}
+  check_row_counts "dissemination_secondaryauditor" ${count_dissemination_secondaryauditor}
 }
 
 PS3='Please enter your choice: '
-options=("Truncate tables" "Load data" "Check row counts" "Quit")
+options=("Truncate tables" "Load data" "Check row counts" "Reset migrated_to_audit" "Truncate audit_audit" "Quit")
 select opt in "${options[@]}"
 do
     case $opt in
@@ -113,6 +191,12 @@ do
             ;;
         "Check row counts")
             check_all_row_counts
+            ;;
+        "Reset migrated_to_audit")
+            reset_migrated_to_audit
+            ;;
+        "Truncate audit_audit")
+            truncate_sourceoftruth
             ;;
         "Quit")
             break


### PR DESCRIPTION
Resets the `migrated_to_audit` field after data load.

Allows for truncating the `audit_audit` table during testing.


