### PR TITLE
Minor tweak to the migration script

### DIFF
--- a/backend/dissemination/management/commands/migrate_audits.py
+++ b/backend/dissemination/management/commands/migrate_audits.py
@@ -130,7 +130,8 @@ class Command(BaseCommand):
             )
 
             # convert additional fields.
-            audit.audit.update(generate_audit_indexes(audit))
+            if sac.submission_status == STATUS.DISSEMINATED:
+                audit.audit.update(generate_audit_indexes(audit))
             audit.save()
 
             # copy SubmissionEvents into History records.


### PR DESCRIPTION
Only disseminated records _need_ to have the search indexing step performed. Doing this too early causes errors when trying to calculate cog/over.

I ran the full script against the most recent data dump, and it worked.