### PR TITLE
Updating the downloads to use the audit table.

### DIFF
--- a/backend/audit/intakelib/mapping_federal_awards.py
+++ b/backend/audit/intakelib/mapping_federal_awards.py
@@ -85,9 +85,21 @@ def federal_awards_named_ranges(errors):
 
 def federal_awards_audit_view(data):
     awards = data.get("FederalAwards", {}).get("federal_awards", [])
+    pass_objects = []
+    for award in awards:
+        entities = award.get("direct_or_indirect_award", {}).get("entities", [])
+        for entity in entities:
+            passthrough = {
+                "award_reference": award.get("award_reference", ""),
+                "passthrough_id": entity.get("passthrough_identifying_number", ""),
+                "passthrough_name": entity.get("passthrough_name", ""),
+            }
+            pass_objects.append(passthrough)
     total_expended = data.get("FederalAwards", {}).get("total_amount_expended", "")
+
     return {
-        "federal_awards": {"awards": awards, "total_amount_expended": total_expended}
+        "federal_awards": {"awards": awards, "total_amount_expended": total_expended},
+        "passthrough": pass_objects,
     }
 
 

--- a/backend/audit/models/constants.py
+++ b/backend/audit/models/constants.py
@@ -2,6 +2,16 @@ from django.utils.translation import gettext_lazy as _
 from collections import namedtuple as nt
 
 
+class ORGANIZATION_TYPE:
+    STATE = "state"
+    LOCAL = "local"
+    TRIBAL = "tribal"
+    HIGHER_ED = "higher-ed"
+    NON_PROFIT = "non-profit"
+    UNKNOWN = "unknown"
+    NONE = "none"
+
+
 class STATUS:
     """
     The possible states of a submission.

--- a/backend/audit/utils.py
+++ b/backend/audit/utils.py
@@ -92,6 +92,10 @@ class Util:
         else:
             return redirect("/")
 
+    @staticmethod
+    def format_date(date):
+        return date.strftime("%Y-%m-%d")
+
 
 class ExcelExtractionError(Exception):
     def __init__(

--- a/backend/audit/views/excel_file_handler.py
+++ b/backend/audit/views/excel_file_handler.py
@@ -16,11 +16,11 @@ from audit.models import (
     ExcelFile,
     LateChangeError,
     SingleAuditChecklist,
-    SubmissionEvent,
     Audit,
 )
 
 from audit.intakelib.exceptions import ExcelExtractionError
+from audit.models.constants import EventType
 from audit.utils import FORM_SECTION_HANDLERS
 
 from audit.context import set_sac_to_context
@@ -47,14 +47,14 @@ class ExcelFileHandlerView(SingleAuditChecklistAccessRequiredMixin, generic.View
 
     def _event_type(self, form_section):
         return {
-            FORM_SECTIONS.ADDITIONAL_EINS: SubmissionEvent.EventType.ADDITIONAL_EINS_UPDATED,
-            FORM_SECTIONS.ADDITIONAL_UEIS: SubmissionEvent.EventType.ADDITIONAL_UEIS_UPDATED,
-            FORM_SECTIONS.CORRECTIVE_ACTION_PLAN: SubmissionEvent.EventType.CORRECTIVE_ACTION_PLAN_UPDATED,
-            FORM_SECTIONS.FEDERAL_AWARDS: SubmissionEvent.EventType.FEDERAL_AWARDS_UPDATED,
-            FORM_SECTIONS.FINDINGS_TEXT: SubmissionEvent.EventType.FEDERAL_AWARDS_AUDIT_FINDINGS_TEXT_UPDATED,
-            FORM_SECTIONS.FINDINGS_UNIFORM_GUIDANCE: SubmissionEvent.EventType.FINDINGS_UNIFORM_GUIDANCE_UPDATED,
-            FORM_SECTIONS.NOTES_TO_SEFA: SubmissionEvent.EventType.NOTES_TO_SEFA_UPDATED,
-            FORM_SECTIONS.SECONDARY_AUDITORS: SubmissionEvent.EventType.SECONDARY_AUDITORS_UPDATED,
+            FORM_SECTIONS.ADDITIONAL_EINS: EventType.ADDITIONAL_EINS_UPDATED,
+            FORM_SECTIONS.ADDITIONAL_UEIS: EventType.ADDITIONAL_UEIS_UPDATED,
+            FORM_SECTIONS.CORRECTIVE_ACTION_PLAN: EventType.CORRECTIVE_ACTION_PLAN_UPDATED,
+            FORM_SECTIONS.FEDERAL_AWARDS: EventType.FEDERAL_AWARDS_UPDATED,
+            FORM_SECTIONS.FINDINGS_TEXT: EventType.FEDERAL_AWARDS_AUDIT_FINDINGS_TEXT_UPDATED,
+            FORM_SECTIONS.FINDINGS_UNIFORM_GUIDANCE: EventType.FINDINGS_UNIFORM_GUIDANCE_UPDATED,
+            FORM_SECTIONS.NOTES_TO_SEFA: EventType.NOTES_TO_SEFA_UPDATED,
+            FORM_SECTIONS.SECONDARY_AUDITORS: EventType.SECONDARY_AUDITORS_UPDATED,
         }[form_section]
 
     def _extract_and_validate_data(self, form_section, excel_file, auditee_uei):

--- a/backend/dissemination/file_downloads.py
+++ b/backend/dissemination/file_downloads.py
@@ -7,6 +7,7 @@ from boto3 import client as boto3_client
 from botocore.client import ClientError, Config
 
 from audit.models import ExcelFile, SingleAuditReportFile, SingleAuditChecklist, Audit
+from audit.models.constants import STATUS
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +44,9 @@ def get_filename_from_audit(report_id, file_type):
     """
     Basically a copy of above. Used for "SOT Beta" pages. Post launch this method should replace get_filename above.
     """
-    audit = Audit.objects.filter(report_id=report_id).first()
+    audit = Audit.objects.filter(
+        report_id=report_id, submission_status=STATUS.DISSEMINATED
+    ).first()
     if file_type == "report":
         try:
             if audit:

--- a/backend/dissemination/management/commands/migrate_audits.py
+++ b/backend/dissemination/management/commands/migrate_audits.py
@@ -227,7 +227,7 @@ def _convert_passthrough(sac: SingleAuditChecklist):
             entities = award.get("direct_or_indirect_award", {}).get("entities", [])
             for entity in entities:
                 passthrough = {
-                    "award_reference": entity.get("award_reference", ""),
+                    "award_reference": award.get("award_reference", ""),
                     "passthrough_id": entity.get("passthrough_identifying_number", ""),
                     "passthrough_name": entity.get("passthrough_name", ""),
                 }

--- a/backend/dissemination/report_generation/audit_summary_reports.py
+++ b/backend/dissemination/report_generation/audit_summary_reports.py
@@ -1,0 +1,114 @@
+import datetime
+import io
+import logging
+import time
+
+from audit.models import Audit
+from audit.models.constants import ORGANIZATION_TYPE
+from dissemination.report_generation.excel.coversheets import (
+    insert_dissemination_coversheet,
+)
+from dissemination.report_generation.excel.utils import REPORT_FORMAT, create_workbook
+from dissemination.summary_reports import insert_precert_coversheet
+
+logger = logging.getLogger(__name__)
+
+restricted_model_names = ("captext", "findingtext", "note")
+
+
+def generate_audit_summary_report(
+    report_ids, include_private=False, pre_submission=False
+):
+    t0 = time.time()
+    (data, tgad) = _gather_audit_data(report_ids, include_private)
+    (workbook, tcw) = create_workbook(data)
+
+    tht = 0
+    if pre_submission:
+        insert_precert_coversheet(workbook)
+    else:
+        (has_tribal, tht) = _contains_private_tribal(report_ids)
+        insert_dissemination_coversheet(workbook, has_tribal, include_private)
+
+    (filename, workbook_bytes, tpw) = _prepare_workbook_for_download(workbook)
+    t1 = time.time()
+    logger.info(
+        f"SUMMARY_REPORTS generate_summary_report\n\ttotal: {t1 - t0} has_tribal: {tht} audit_data: {tgad} create_workbook: {tcw} prepare_workbook: {tpw}"
+    )
+    return filename, workbook_bytes
+
+
+def _prepare_workbook_for_download(workbook):
+
+    t0 = time.time()
+    now = datetime.datetime.now(datetime.UTC).strftime("%Y%m%d%H%M%S")
+    filename = f"audit-fac-summary-report-{now}.xlsx"
+
+    # Save the workbook directly to a BytesIO object
+    workbook_bytes = io.BytesIO()
+    workbook.save(workbook_bytes)
+    workbook_bytes.seek(0)
+
+    t1 = time.time()
+    return filename, workbook_bytes, t1 - t0
+
+
+def _gather_audit_data(report_ids, include_private):
+    """
+    Given a set of report IDs, fetch the disseminated data for each and assemble into a dictionary with the following shape:
+
+    {
+        general: {
+            field_names: [],
+            entries: [],
+        },
+        federal_award: {
+            field_names: [],
+            entries: [],
+        },
+        ...
+    }
+    """
+    t0 = time.time()
+    report_ids = set(report_ids)
+    data = _initialize_data()
+
+    audits = Audit.objects.filter(report_id__in=report_ids)
+    for audit in audits:
+        _add_entries_from_audit(audit, data, include_private)
+
+    return data, time.time() - t0
+
+
+def _initialize_data():
+    data = {}
+    for mapping in REPORT_FORMAT:
+        data[mapping.sheet_name] = {
+            "field_names": mapping.column_names,
+            "entries": [],
+        }
+    return data
+
+
+def _add_entries_from_audit(audit, data, include_private):
+    for mapping in REPORT_FORMAT:
+        if not include_private and mapping.sheet_name in restricted_model_names:
+            continue
+
+        entries = mapping.parse_audit_to_entries(audit)
+        if entries:
+            data[mapping.sheet_name]["entries"].extend(entries)
+
+
+def _contains_private_tribal(report_ids):
+    t0 = time.time()
+    has_tribal = (
+        Audit.objects.filter(
+            report_id__in=report_ids,
+            organization_type=ORGANIZATION_TYPE.TRIBAL,
+            is_public=False,
+        ).count()
+        > 0
+    )
+    t1 = time.time()
+    return has_tribal, t1 - t0

--- a/backend/dissemination/report_generation/excel/additional_ein_excel_sheet.py
+++ b/backend/dissemination/report_generation/excel/additional_ein_excel_sheet.py
@@ -1,0 +1,22 @@
+from dissemination.report_generation.excel.excel_sheet import ExcelSheet
+
+
+def _get_entries(audit):
+    entries = []
+    if not audit or not audit.audit:
+        return [[]]
+    additional_eins = audit.audit.get("additional_eins", [])
+    if not additional_eins:
+        return [[]]
+
+    for ein in additional_eins:
+        entries.append([audit.report_id, ein])
+
+    return entries
+
+
+additional_ein_excel_sheet = ExcelSheet(
+    sheet_name="additionalein",
+    column_names=["report_id", "additional_ein"],
+    parse_audit_to_entries=_get_entries,
+)

--- a/backend/dissemination/report_generation/excel/additional_uei_excel_sheet.py
+++ b/backend/dissemination/report_generation/excel/additional_uei_excel_sheet.py
@@ -1,0 +1,22 @@
+from dissemination.report_generation.excel.excel_sheet import ExcelSheet
+
+
+def _get_entries(audit):
+    entries = []
+    if not audit or not audit.audit:
+        return [[]]
+    additional_ueis = audit.audit.get("additional_ueis", [])
+    if not additional_ueis:
+        return [[]]
+
+    for uei in additional_ueis:
+        entries.append([audit.report_id, uei])
+
+    return entries
+
+
+additional_uei_excel_sheet = ExcelSheet(
+    sheet_name="additionaluei",
+    column_names=["report_id", "additional_uei"],
+    parse_audit_to_entries=_get_entries,
+)

--- a/backend/dissemination/report_generation/excel/cap_text_excel_sheet.py
+++ b/backend/dissemination/report_generation/excel/cap_text_excel_sheet.py
@@ -1,0 +1,34 @@
+from dissemination.report_generation.excel.excel_sheet import ExcelSheet
+
+
+def _get_entries(audit):
+    if not audit or not audit.audit:
+        return [[]]
+    captexts = audit.audit.get("corrective_action_plan", [])
+    if not captexts:
+        return [[]]
+
+    entries = []
+    for text in captexts:
+        entries.append(
+            [
+                audit.report_id,
+                text.get("reference_number"),  # finding_ref_number
+                text.get("planned_action"),
+                text.get("contains_chart_or_table"),
+            ]
+        )
+
+    return entries
+
+
+captext_excel_sheet = ExcelSheet(
+    sheet_name="captext",
+    column_names=[
+        "report_id",
+        "finding_ref_number",
+        "planned_action",
+        "contains_chart_or_table",
+    ],
+    parse_audit_to_entries=_get_entries,
+)

--- a/backend/dissemination/report_generation/excel/coversheets.py
+++ b/backend/dissemination/report_generation/excel/coversheets.py
@@ -1,0 +1,77 @@
+from datetime import datetime
+from dissemination.summary_reports import set_column_widths, protect_sheet
+from dissemination.report_generation.excel.excel_sheet import ExcelSheet
+from django.conf import settings
+
+limit_disclaimer = f"This spreadsheet contains the first {settings.SUMMARY_REPORT_DOWNLOAD_LIMIT} results of your search. If you need to download more than {settings.SUMMARY_REPORT_DOWNLOAD_LIMIT} submissions, try limiting your search parameters to download in batches."
+can_read_tribal_disclaimer = "This document includes one or more Tribal entities that have chosen to keep their data private per 2 CFR 200.512(b)(2). Because your account has access to these submissions, this document includes their audit findings text, corrective action plan, and notes to SEFA. Don't share this data outside your agency."
+cannot_read_tribal_disclaimer = "This document includes one or more Tribal entities that have chosen to keep their data private per 2 CFR 200.512(b)(2). It doesn't include their audit findings text, corrective action plan, or notes to SEFA."
+
+
+def insert_precert_coversheet(workbook):
+    sheet = workbook.create_sheet("Coversheet", 0)
+    sheet.append(["Time created", datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")])
+    sheet.append(["Note", "This file is for review only and can't be edited."])
+    set_column_widths(sheet)
+    protect_sheet(sheet)
+
+
+def insert_dissemination_coversheet(workbook, contains_tribal, include_private):
+    sheet = workbook.create_sheet("Coversheet", 0)
+    sheet.append(["Time created", datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")])
+    sheet.append(
+        [
+            "Note",
+            limit_disclaimer,
+        ]
+    )
+
+    if contains_tribal:
+        if include_private:
+            sheet.append(
+                [
+                    "Note",
+                    can_read_tribal_disclaimer,
+                ]
+            )
+        else:
+            sheet.append(
+                [
+                    "Note",
+                    cannot_read_tribal_disclaimer,
+                ]
+            )
+
+    # Uncomment if we want to link to the FAC API for larger data dumps.
+    # sheet.cell(row=3, column=2).value = "FAC API Link"
+    # sheet.cell(row=3, column=2).hyperlink = f"{settings.STATIC_SITE_URL}/developers/"
+    set_column_widths(sheet)
+
+
+def _get_entries(audit):
+    if not audit or not audit.audit:
+        return [[]]
+    notes = audit.audit.get("notes_to_sefa", {})
+    if not notes:
+        return [[]]
+
+    return [
+        [
+            audit.report_id,
+            notes["accounting_policies"],
+            notes["rate_explained"],
+            notes["is_minimis_rate_used"],
+        ]
+    ]
+
+
+note_coversheet_excel_sheet = ExcelSheet(
+    sheet_name="note_coversheet",
+    column_names=[
+        "report_id",
+        "accounting_policies",
+        "rate_explained",
+        "is_minimis_rate_used",
+    ],
+    parse_audit_to_entries=_get_entries,
+)

--- a/backend/dissemination/report_generation/excel/excel_sheet.py
+++ b/backend/dissemination/report_generation/excel/excel_sheet.py
@@ -1,0 +1,3 @@
+from collections import namedtuple as NT
+
+ExcelSheet = NT("ExcelSheet", ["sheet_name", "column_names", "parse_audit_to_entries"])

--- a/backend/dissemination/report_generation/excel/federal_awards_excel_sheet.py
+++ b/backend/dissemination/report_generation/excel/federal_awards_excel_sheet.py
@@ -1,0 +1,74 @@
+from dissemination.report_generation.excel.excel_sheet import ExcelSheet
+
+
+def _get_entries(audit):
+    if not audit or not audit.audit:
+        return [[]]
+    awards = audit.audit.get("federal_awards", {}).get("awards", [])
+    if not awards:
+        return [[]]
+
+    entries = []
+    for award in awards:
+        program = award.get("program", {})
+        loan = award.get("loan_or_loan_guarantee", {})
+        entries.append(
+            [
+                audit.report_id,
+                award.get("award_reference"),
+                program.get("federal_agency_prefix"),
+                program.get("three_digit_extension"),  # federal_award_extension
+                f"{program.get("federal_agency_prefix")}.{program.get("three_digit_extension")}",  # aln,
+                award.get("program").get("number_of_audit_findings"),  # findings_count
+                program.get("additional_award_identification"),
+                program.get("program_name"),  # federal_program_name
+                program.get("amount_expended"),
+                program.get("federal_program_total"),
+                award.get("cluster").get("cluster_name"),
+                award.get("cluster").get("state_cluster_name"),
+                award.get("cluster").get("other_cluster_name"),
+                award.get("cluster").get("cluster_total"),
+                award.get("direct_or_indirect_award").get("is_direct"),
+                award.get("subrecipients", {}).get(
+                    "is_passed", "N"
+                ),  # "is_passthrough_award"
+                award.get("subrecipients", {}).get(
+                    "subrecipient_amount"
+                ),  # "passthrough_amount"
+                program.get("is_major"),
+                program.get("audit_report_type"),
+                loan.get("is_guaranteed", "N"),  # is_loan"
+                loan.get("loan_balance_at_audit_period_end", ""),  # "loan_balance"
+            ]
+        )
+
+    return entries
+
+
+federal_awards_excel = ExcelSheet(
+    sheet_name="federalaward",
+    column_names=[
+        "report_id",
+        "award_reference",
+        "federal_agency_prefix",
+        "federal_award_extension",
+        "aln",
+        "findings_count",
+        "additional_award_identification",
+        "federal_program_name",
+        "amount_expended",
+        "federal_program_total",
+        "cluster_name",
+        "state_cluster_name",
+        "other_cluster_name",
+        "cluster_total",
+        "is_direct",
+        "is_passthrough_award",
+        "passthrough_amount",
+        "is_major",
+        "audit_report_type",
+        "is_loan",
+        "loan_balance",
+    ],
+    parse_audit_to_entries=_get_entries,
+)

--- a/backend/dissemination/report_generation/excel/findings_excel_sheet.py
+++ b/backend/dissemination/report_generation/excel/findings_excel_sheet.py
@@ -1,0 +1,65 @@
+from dissemination.report_generation.excel.excel_sheet import ExcelSheet
+
+
+def _get_entries(audit):
+    if not audit or not audit.audit:
+        return [[]]
+    findings = audit.audit.get("findings_uniform_guidance", [])
+    if not findings:
+        return [[]]
+
+    awards = audit.audit.get("federal_awards", {}).get("awards", [])
+    awards_dict = {award.get("award_reference"): award for award in awards}
+
+    entries = []
+    for finding in findings:
+        award = awards_dict.get(finding.get("program", {}).get("award_reference"))
+        award_program = award.get("program", {})
+        entries.append(
+            [
+                audit.report_id,
+                award_program.get("federal_agency_prefix"),
+                award_program.get("three_digit_extension"),  # federal_award_extension
+                f"{award_program.get("federal_agency_prefix")}.{award_program.get("three_digit_extension")}",  # aln,
+                finding.get("program", {}).get("award_reference"),
+                finding.get("findings", {}).get("reference_number"),
+                finding.get("program", {}).get(
+                    "compliance_requirement"
+                ),  # type_requirement
+                finding.get("modified_opinion"),  # is_modified_opinion
+                finding.get("other_findings"),  # is_other_findings
+                finding.get("material_weakness"),  # is_material_weakness
+                finding.get("significant_deficiency"),  # is_significant_deficiency
+                finding.get("other_matters"),  # is_other_matters
+                finding.get("questioned_costs"),  # is_questioned_costs
+                finding.get("findings", {}).get(
+                    "repeat_prior_reference"
+                ),  # is_repeat_finding",
+                finding.get("findings", {}).get(
+                    "prior_references"
+                ),  # prior_finding_ref_numbers",
+            ]
+        )
+
+
+findings_excel_sheet = ExcelSheet(
+    sheet_name="finding",
+    column_names=[
+        "report_id",
+        "federal_agency_prefix",
+        "federal_award_extension",
+        "aln",
+        "award_reference",
+        "reference_number",
+        "type_requirement",
+        "is_modified_opinion",
+        "is_other_findings",
+        "is_material_weakness",
+        "is_significant_deficiency",
+        "is_other_matters",
+        "is_questioned_costs",
+        "is_repeat_finding",
+        "prior_finding_ref_numbers",
+    ],
+    parse_audit_to_entries=_get_entries,
+)

--- a/backend/dissemination/report_generation/excel/findings_text_excel_sheet.py
+++ b/backend/dissemination/report_generation/excel/findings_text_excel_sheet.py
@@ -1,0 +1,35 @@
+from dissemination.report_generation.excel.excel_sheet import ExcelSheet
+
+
+def _get_entries(audit):
+    if not audit or not audit.audit:
+        return [[]]
+    findings_text = audit.audit.get("findings_text", [])
+    if not findings_text:
+        return [[]]
+
+    entries = []
+    for finding in findings_text:
+        entries.append(
+            [
+                "id",  # TODO
+                audit.report_id,
+                finding.get("reference_number"),  # finding_ref_number
+                finding.get("contains_chart_or_table"),
+                finding.get("finding_text"),  # finding_text
+            ]
+        )
+    return entries
+
+
+findings_text_excel_sheet = ExcelSheet(
+    sheet_name="findingtext",
+    column_names=[
+        "id",
+        "report_id",
+        "finding_ref_number",
+        "contains_chart_or_table",
+        "finding_text",
+    ],
+    parse_audit_to_entries=_get_entries,
+)

--- a/backend/dissemination/report_generation/excel/general_excel_sheet.py
+++ b/backend/dissemination/report_generation/excel/general_excel_sheet.py
@@ -1,0 +1,195 @@
+from audit.models import History
+from audit.models.constants import EventType
+from audit.utils import Util
+from dissemination.report_generation.excel.excel_sheet import ExcelSheet
+
+
+def _get_entry(audit):
+    if not audit or not audit.audit:
+        return [[]]
+    general_information = audit.audit.get("general_information", None)
+    if not general_information:
+        return [[]]
+
+    auditee_certification = audit.audit.get("auditee_certification", {})
+    auditor_certification = audit.audit.get("auditor_certification", {})
+    audit_information = audit.audit.get("audit_information", {})
+
+    events = (
+        EventType.AUDITEE_CERTIFICATION_COMPLETED,
+        EventType.AUDITOR_CERTIFICATION_COMPLETED,
+        EventType.LOCKED_FOR_CERTIFICATION,
+        EventType.SUBMITTED,
+    )
+
+    audit_history = History.objects.filter(
+        report_id=audit.report_id, event__in=events
+    ).order_by("updated_at")
+    history_dict = {
+        history.event: Util.format_date(history.updated_at) for history in audit_history
+    }
+
+    return [
+        [
+            audit.report_id,
+            audit.audit_year,
+            audit.audit.get("federal_awards").get("total_amount_expended"),
+            general_information.get("user_provided_organization_type"),  # entity_type
+            general_information.get("auditee_fiscal_period_start"),  # fy_start_date
+            general_information.get("auditee_fiscal_period_end"),  # fy_start_date
+            general_information.get("audit_type"),
+            general_information.get("audit_period_covered"),
+            general_information.get("audit_period_other_months"),  # number_months
+            general_information.get("auditee_uei"),
+            general_information.get("ein"),  # auditee_ein
+            general_information.get("auditee_name"),
+            general_information.get("auditee_address_line_1"),
+            general_information.get("auditee_city"),
+            general_information.get("auditee_state"),
+            general_information.get("auditee_zip"),
+            general_information.get("auditee_contact_name"),
+            general_information.get("auditee_contact_title"),
+            general_information.get("auditee_phone"),
+            general_information.get("auditee_email"),
+            history_dict.get(
+                EventType.AUDITEE_CERTIFICATION_COMPLETED
+            ),  # auditee_certified_date
+            auditee_certification.get("auditee_signature", {}).get(
+                "auditee_name"
+            ),  # auditee_certify_name
+            auditee_certification.get("auditee_signature", {}).get(
+                "auditee_title"
+            ),  # auditee_certify_title
+            general_information.get("auditor_ein"),
+            general_information.get("auditor_firm_name"),
+            general_information.get("auditor_address_line_1"),
+            general_information.get("auditor_city"),
+            general_information.get("auditor_state"),
+            general_information.get("auditor_zip"),
+            general_information.get("auditor_country"),
+            general_information.get("auditor_contact_name"),
+            general_information.get("auditor_contact_title"),
+            general_information.get("auditor_phone"),
+            general_information.get("auditor_email"),
+            general_information.get(
+                "auditor_international_address"
+            ),  # auditor_foreign_address
+            history_dict.get(
+                EventType.AUDITOR_CERTIFICATION_COMPLETED
+            ),  # auditor_certified_date
+            auditor_certification.get("auditor_signature", {}).get(
+                "auditor_name"
+            ),  # auditor_certify_name
+            auditor_certification.get("auditor_signature", {}).get(
+                "auditor_title"
+            ),  # auditor_certify_title
+            audit.cognizant_agency,
+            audit.oversight_agency,
+            "UG",  # type_audit_code
+            Util.json_array_to_str(audit_information.get("sp_framework_basis", [])),
+            Util.optional_bool(audit_information.get("is_sp_framework_required", None)),
+            Util.bool_to_yes_no(
+                audit_information.get("is_going_concern_included", False)
+            ),
+            Util.bool_to_yes_no(
+                audit_information.get("is_internal_control_deficiency_disclosed", False)
+            ),
+            Util.bool_to_yes_no(
+                audit_information.get(
+                    "is_internal_control_material_weakness_disclosed", False
+                )
+            ),
+            Util.bool_to_yes_no(
+                audit_information.get("is_material_noncompliance_disclosed", False)
+            ),
+            Util.json_array_to_str(audit_information.get("gaap_results", [])),
+            Util.bool_to_yes_no(
+                audit_information.get("is_aicpa_audit_guide_included", False)
+            ),
+            Util.json_array_to_str(audit_information.get("sp_framework_opinions", [])),
+            Util.json_array_to_str(
+                audit_information.get("agencies", [])
+            ),  # agencies_with_prior_findings,
+            audit_information.get("dollar_threshold"),
+            Util.bool_to_yes_no(audit_information.get("is_low_risk_auditee", False)),
+            Util.bool_to_yes_no(
+                general_information.get("multiple_ueis_covered", False)
+            ),  # "is_additional_ueis",
+            Util.format_date(audit.created_at),  # date_created
+            audit.fac_accepted_date,
+            history_dict.get(
+                EventType.LOCKED_FOR_CERTIFICATION
+            ),  # ready_for_certification_date
+            history_dict.get(EventType.SUBMITTED),  # submitted_date
+            audit.data_source,
+            audit.is_public,
+        ]
+    ]
+
+
+general_information_excel = ExcelSheet(
+    sheet_name="general",
+    column_names=[
+        "report_id",
+        "audit_year",
+        "total_amount_expended",
+        "entity_type",
+        "fy_start_date",
+        "fy_end_date",
+        "audit_type",
+        "audit_period_covered",
+        "number_months",
+        "auditee_uei",
+        "auditee_ein",
+        "auditee_name",
+        "auditee_address_line_1",
+        "auditee_city",
+        "auditee_state",
+        "auditee_zip",
+        "auditee_contact_name",
+        "auditee_contact_title",
+        "auditee_phone",
+        "auditee_email",
+        "auditee_certified_date",
+        "auditee_certify_name",
+        "auditee_certify_title",
+        "auditor_ein",
+        "auditor_firm_name",
+        "auditor_address_line_1",
+        "auditor_city",
+        "auditor_state",
+        "auditor_zip",
+        "auditor_country",
+        "auditor_contact_name",
+        "auditor_contact_title",
+        "auditor_phone",
+        "auditor_email",
+        "auditor_foreign_address",
+        "auditor_certified_date",
+        "auditor_certify_name",
+        "auditor_certify_title",
+        "cognizant_agency",
+        "oversight_agency",
+        "type_audit_code",
+        "sp_framework_basis",
+        "is_sp_framework_required",
+        "is_going_concern_included",
+        "is_internal_control_deficiency_disclosed",
+        "is_internal_control_material_weakness_disclosed",
+        "is_material_noncompliance_disclosed",
+        "gaap_results",
+        "is_aicpa_audit_guide_included",
+        "sp_framework_opinions",
+        "agencies_with_prior_findings",
+        "dollar_threshold",
+        "is_low_risk_auditee",
+        "is_additional_ueis",
+        "date_created",
+        "fac_accepted_date",
+        "ready_for_certification_date",
+        "submitted_date",
+        "data_source",
+        "is_public",
+    ],
+    parse_audit_to_entries=_get_entry,
+)

--- a/backend/dissemination/report_generation/excel/notes_excel_sheet.py
+++ b/backend/dissemination/report_generation/excel/notes_excel_sheet.py
@@ -1,0 +1,43 @@
+from dissemination.report_generation.excel.excel_sheet import ExcelSheet
+
+
+def _get_entries(audit):
+    if not audit or not audit.audit:
+        return [[]]
+    notes = audit.audit.get("notes_to_sefa", {})
+    if not notes:
+        return [[]]
+    note_entries = notes.get("notes_to_sefa_entries", [])
+    if not note_entries:
+        return [[]]
+
+    entries = []
+    for note_entry in note_entries:
+        entries.append(
+            [
+                note_entry.get("seq_number"),  # id
+                audit.report_id,
+                note_entry.get("note_title"),
+                notes.get("accounting_policies"),
+                notes.get("rate_explained"),
+                notes.get("is_minimis_rate_used"),
+                note_entry.get("note_content"),  # content
+                note_entry.get("contains_chart_or_table"),
+            ]
+        )
+
+
+notes_to_sefa_excel_sheet = ExcelSheet(
+    sheet_name="note",
+    column_names=[
+        "id",
+        "report_id",
+        "note_title",
+        "accounting_policies",
+        "rate_explained",
+        "is_minimis_rate_used",
+        "content",
+        "contains_chart_or_table",
+    ],
+    parse_audit_to_entries=_get_entries,
+)

--- a/backend/dissemination/report_generation/excel/passthrough_excel_sheet.py
+++ b/backend/dissemination/report_generation/excel/passthrough_excel_sheet.py
@@ -1,0 +1,33 @@
+from dissemination.report_generation.excel.excel_sheet import ExcelSheet
+
+
+def _get_entries(audit):
+    if not audit or not audit.audit:
+        return [[]]
+    passthrough_items = audit.audit.get("passthrough", [])
+    if not passthrough_items:
+        return [[]]
+
+    entries = []
+    for passthrough in passthrough_items:
+        entries.append(
+            [
+                audit.report_id,
+                passthrough.get("award_reference"),
+                passthrough.get("passthrough_name"),
+                passthrough.get("passthrough_id"),
+            ]
+        )
+    return entries
+
+
+passthrough_excel_sheet = ExcelSheet(
+    sheet_name="passthrough",
+    column_names=[
+        "report_id",
+        "award_reference",
+        "passthrough_name",
+        "passthrough_id",
+    ],
+    parse_audit_to_entries=_get_entries,
+)

--- a/backend/dissemination/report_generation/excel/secondary_auditor_excel_sheet.py
+++ b/backend/dissemination/report_generation/excel/secondary_auditor_excel_sheet.py
@@ -1,0 +1,46 @@
+from dissemination.report_generation.excel.excel_sheet import ExcelSheet
+
+
+def _get_entries(audit):
+    if not audit or not audit.audit:
+        return [[]]
+    secondary_auditors = audit.audit.get("secondary_auditors", [])
+    if not secondary_auditors:
+        return [[]]
+
+    entries = []
+    for sa in secondary_auditors:
+        entries.append(
+            [
+                audit.report_id,
+                sa.get("secondary_auditor_name"),
+                sa.get("secondary_auditor_ein"),
+                sa.get("secondary_auditor_address_street"),
+                sa.get("secondary_auditor_address_city"),
+                sa.get("secondary_auditor_address_state"),
+                sa.get("secondary_auditor_address_zipcode"),
+                sa.get("secondary_auditor_contact_name"),
+                sa.get("secondary_auditor_contact_title"),
+                sa.get("secondary_auditor_contact_email"),
+                sa.get("secondary_auditor_contact_phone"),
+            ]
+        )
+
+
+secondary_auditor_excel_sheet = ExcelSheet(
+    sheet_name="secondaryauditor",
+    column_names=[
+        "report_id",
+        "auditor_name",
+        "auditor_ein",
+        "address_street",
+        "address_city",
+        "address_state",
+        "address_zipcode",
+        "contact_name",
+        "contact_title",
+        "contact_email",
+        "contact_phone",
+    ],
+    parse_audit_to_entries=_get_entries,
+)

--- a/backend/dissemination/report_generation/excel/utils.py
+++ b/backend/dissemination/report_generation/excel/utils.py
@@ -1,0 +1,110 @@
+import string
+import uuid
+import time
+import openpyxl as pyxl
+
+from openpyxl.workbook.defined_name import DefinedName
+from openpyxl.utils import quote_sheetname
+
+from dissemination.report_generation.excel.coversheets import (
+    note_coversheet_excel_sheet,
+)
+from dissemination.report_generation.excel.findings_excel_sheet import (
+    findings_excel_sheet,
+)
+from dissemination.report_generation.excel.additional_ein_excel_sheet import (
+    additional_ein_excel_sheet,
+)
+from dissemination.report_generation.excel.additional_uei_excel_sheet import (
+    additional_uei_excel_sheet,
+)
+from dissemination.report_generation.excel.cap_text_excel_sheet import (
+    captext_excel_sheet,
+)
+from dissemination.report_generation.excel.federal_awards_excel_sheet import (
+    federal_awards_excel,
+)
+from dissemination.report_generation.excel.findings_text_excel_sheet import (
+    findings_text_excel_sheet,
+)
+from dissemination.report_generation.excel.general_excel_sheet import (
+    general_information_excel,
+)
+from dissemination.report_generation.excel.notes_excel_sheet import (
+    notes_to_sefa_excel_sheet,
+)
+from dissemination.report_generation.excel.passthrough_excel_sheet import (
+    passthrough_excel_sheet,
+)
+from dissemination.report_generation.excel.secondary_auditor_excel_sheet import (
+    secondary_auditor_excel_sheet,
+)
+
+REPORT_FORMAT = [
+    additional_ein_excel_sheet,
+    additional_uei_excel_sheet,
+    captext_excel_sheet,
+    federal_awards_excel,
+    findings_excel_sheet,
+    findings_text_excel_sheet,
+    federal_awards_excel,
+    general_information_excel,
+    notes_to_sefa_excel_sheet,
+    note_coversheet_excel_sheet,
+    passthrough_excel_sheet,
+    secondary_auditor_excel_sheet,
+]
+
+columns = list(string.ascii_uppercase)
+columns += ["A" + ch for ch in string.ascii_uppercase]
+columns += ["B" + ch for ch in "ABCDEFGHIJ"]
+
+
+def create_workbook(data, protect_sheets=False):
+    t0 = time.time()
+    workbook = pyxl.Workbook()
+    # remove sheet that is created during workbook construction
+    default_sheet = workbook.active
+    workbook.remove(default_sheet)
+    for sheet_name in sorted(data.keys()):
+        sheet = workbook.create_sheet(sheet_name)
+
+        # create a header row with the field names
+        sheet.append(data[sheet_name]["field_names"])
+
+        # append a new row for each entry in the dataset
+        for entry in data[sheet_name]["entries"]:
+            sheet.append(entry)
+
+        # add named ranges for the columns, now that the data is loaded.
+        for index, field_name in enumerate(data[sheet_name]["field_names"]):
+            coordinate = f"${columns[index]}$2:${columns[index]}${2 + len(data[sheet_name]['entries'])}"
+            ref = f"{quote_sheetname(sheet.title)}!{coordinate}"
+            named_range = DefinedName(f"{sheet_name}_{field_name}", attr_text=ref)
+            workbook.defined_names.add(named_range)
+
+        set_column_widths(sheet)
+        if protect_sheets:
+            protect_sheet(sheet)
+
+    t1 = time.time()
+    return (workbook, t1 - t0)
+
+
+def set_column_widths(worksheet):
+    dims = {}
+    for row in worksheet.rows:
+        for cell in row:
+            if cell.value:
+                dims[cell.column] = max(
+                    (dims.get(cell.column, 0), len(str(cell.value)))
+                )
+    for col, value in dims.items():
+        # Pad the column by a bit, so things are not cramped.
+        worksheet.column_dimensions[columns[col - 1]].width = int(value * 1.2)
+
+
+def protect_sheet(sheet):
+    sheet.protection.sheet = True
+    sheet.protection.password = str(uuid.uuid4())
+    sheet.protection.enable()

--- a/backend/dissemination/summary_reports.py
+++ b/backend/dissemination/summary_reports.py
@@ -24,6 +24,7 @@ from dissemination.models import (
     DisseminationCombined,
 )
 
+# TODO: Update Post SOC Launch -> This whole file can be deleted
 logger = logging.getLogger(__name__)
 
 models = [

--- a/backend/dissemination/templates/audit_summary.html
+++ b/backend/dissemination/templates/audit_summary.html
@@ -35,7 +35,7 @@
                             <a class="usa-button display-flex flex-fill font-sans-xl margin-bottom-2"
                                 target="_blank"
                                 rel="noopener noreferrer"
-                                href="{% url 'dissemination:SummaryReportDownload' report_id=report_id%}"
+                                href="{% url 'dissemination:SummaryReportDownload' report_id=report_id%}?beta=Y"
                             >
                                 <svg class="usa-icon margin-right-1 flex-align-self-center"
                                     aria-hidden="true"
@@ -48,7 +48,7 @@
 
                         {% if allow_download %}
                             <a class="usa-button display-flex font-sans-xl"
-                                href="{% url 'dissemination:PdfDownload' report_id=report_id %}"
+                                href="{% url 'dissemination:PdfDownload' report_id=report_id %}?beta=Y"
                                 target="_blank"
                                 rel="noopener noreferrer">
                                 <svg class="usa-icon margin-right-1 flex-align-self-center"

--- a/backend/dissemination/templates/search-audit.html
+++ b/backend/dissemination/templates/search-audit.html
@@ -96,7 +96,7 @@
                         </p>
                         {% if results_count <= summary_report_download_limit %}
                             <button class="usa-button display-flex"
-                                    formaction="{% url 'dissemination:MultipleSummaryReportDownload' %}"
+                                    formaction="{% url 'dissemination:MultipleSummaryReportDownload' %}?beta=Y"
                                     form="audit-search-form">
                                 <svg class="usa-icon margin-right-1 flex-align-self-center"
                                     aria-hidden="true"
@@ -147,7 +147,7 @@
                                         </td>
                                         <td>
                                             <a class="usa-link display-flex flex-column flex-align-center"
-                                               href="{% url 'dissemination:Summary' report_id=result.report_id %}"
+                                               href="{% url 'dissemination:Summary' report_id=result.report_id %}?beta=Y"
                                                target="_blank">
                                                 <svg class="usa-icon usa-icon--size-4"
                                                      aria-hidden="true"
@@ -160,7 +160,7 @@
                                         <td>
                                             {% if result.is_public or include_private %}
                                                 <a class="usa-link display-flex flex-column flex-align-center"
-                                                href="{% url 'dissemination:PdfDownload' report_id=result.report_id %}"
+                                                href="{% url 'dissemination:PdfDownload' report_id=result.report_id %}?beta=Y"
                                                 target="_blank">
                                                     <svg class="usa-icon usa-icon--size-4"
                                                         aria-hidden="true"


### PR DESCRIPTION
## Purpose

Source of truth should use the audit table for all download file flows.

## How

Large refactoring of downloading using the audit table. Using a beta flag to trigger usage of audit table.

This also fixes a bug related to the pasthrough object in the audit.

## Notes

There are a lot of new mapping type classes here, they are rather straight forward. I have noticed we have a few of these type of mappings of section to <do something>. I will create a follow-up task post SOT to go through all these mappings and identify improvements.

## Testing completed:

Linting (Note: I am now getting some errors on existing code I haven't touched, once merged into jr/sot/main I can see if those still continue and what I can do to fix it.
Unit Tests: All Pass
End to End Tests: Full submission passes.
Manual Testing: append `beta=Y` to summary page (ie: http://localhost:8000/dissemination/summary/2024-06-GSAFAC-0000351980?beta=Y) or visit the beta search: http://localhost:8000/dissemination/search/beta/

Any other download can be triggered by finding the URL, and appending beta=Y.

Additional testing will need to be done around dates (ie submitted date) due to my local database missing submission events.

Will update this PR once I do additional testing (unless testing doesn't identify anything new)

