### PR TITLE
Removes all spaces from prior reference numbers

### DIFF
--- a/backend/audit/intakelib/transforms/xform_reformat_prior_references.py
+++ b/backend/audit/intakelib/transforms/xform_reformat_prior_references.py
@@ -8,10 +8,22 @@ import re
 logger = logging.getLogger(__name__)
 
 
+# The prior references field might look like
+# 2023-001
+# or
+# 2023-001,2022-006
+# but people tend to like to insert spaces and other things.
+#
+# Because whitespace should never impact the meaning of this field, especially around the
+# comma, we're going to strip whitespace from within the field.
+#
+# We do this by:
+# 1. Stripping the string (removing leading and trailing whitespace)
+# 2. Removing all whitespace internal to the string.
 def reformat_prior_references(ir):
     references = get_range_by_name(ir, "prior_references")
     new_values = list(
-        map(lambda v: re.sub(r"\s+,", ",", str(v).strip()), references["values"])
+        map(lambda v: re.sub(r"\s+", "", str(v).strip()), references["values"])
     )
     new_ir = replace_range_by_name(ir, "prior_references", new_values)
     return new_ir

--- a/backend/audit/test_xform_reformat_prior_references.py
+++ b/backend/audit/test_xform_reformat_prior_references.py
@@ -23,6 +23,7 @@ EXPECTED = [
 
 class TestFindingReferenceYear(SimpleTestCase):
     def setUp(self):
+        # noqa: W291
         self.ir = [
             {
                 "name": "Form",

--- a/backend/audit/test_xform_reformat_prior_references.py
+++ b/backend/audit/test_xform_reformat_prior_references.py
@@ -23,7 +23,6 @@ EXPECTED = [
 
 class TestFindingReferenceYear(SimpleTestCase):
     def setUp(self):
-        # noqa: W291
         self.ir = [
             {
                 "name": "Form",
@@ -44,6 +43,7 @@ class TestFindingReferenceYear(SimpleTestCase):
                             "2027-007 , 2026-006 , 2025-005 ",
                             " 2028-008 , 2027-007 , 2026-006 ",
                             # Note multiline test case...
+                            # noqa: W291
                             """ 2029-009 ,
                               2028-008 ,
                                 2027-007

--- a/backend/audit/test_xform_reformat_prior_references.py
+++ b/backend/audit/test_xform_reformat_prior_references.py
@@ -1,6 +1,5 @@
 from unittest.mock import Mock
 from django.test import SimpleTestCase
-from django.core.exceptions import ValidationError
 from audit.intakelib.transforms.xform_reformat_prior_references import (
     reformat_prior_references,
 )

--- a/backend/audit/test_xform_reformat_prior_references.py
+++ b/backend/audit/test_xform_reformat_prior_references.py
@@ -46,7 +46,7 @@ class TestFindingReferenceYear(SimpleTestCase):
                             # Note multiline test case...
                             """ 2029-009 ,
                               2028-008 ,
-                                2027-007 
+                                2027-007
 """,
                         ],
                     },

--- a/backend/audit/test_xform_reformat_prior_references.py
+++ b/backend/audit/test_xform_reformat_prior_references.py
@@ -1,0 +1,68 @@
+from unittest.mock import Mock
+from django.test import SimpleTestCase
+from django.core.exceptions import ValidationError
+from audit.intakelib.transforms.xform_reformat_prior_references import (
+    reformat_prior_references,
+)
+from audit.context import set_sac_to_context
+
+
+EXPECTED = [
+    "2022-002",
+    "2022-002,2021-001",
+    "2023-003,2022-002",
+    "2024-004,2023-003",
+    "2025-005,2024-004,2023-003",
+    "2026-006,2025-005,2024-004",
+    "2022-002",
+    "2023-003",
+    "2027-007,2026-006,2025-005",
+    "2028-008,2027-007,2026-006",
+    "2029-009,2028-008,2027-007",
+]
+
+
+class TestFindingReferenceYear(SimpleTestCase):
+    def setUp(self):
+        self.ir = [
+            {
+                "name": "Form",
+                "ranges": [
+                    {
+                        "name": "prior_references",
+                        "start_cell": {"column": "A", "row": "2"},
+                        "end_cell": {"column": "A", "row": "20001"},
+                        "values": [
+                            "2022-002",
+                            "2022-002,2021-001",
+                            "2023-003, 2022-002",
+                            "2024-004 ,2023-003",
+                            "2025-005 , 2024-004, 2023-003",
+                            "2026-006 , 2025-005 , 2024-004",
+                            "2022-002 ",
+                            " 2023-003",
+                            "2027-007 , 2026-006 , 2025-005 ",
+                            " 2028-008 , 2027-007 , 2026-006 ",
+                            # Note multiline test case...
+                            """ 2029-009 ,
+                              2028-008 ,
+                                2027-007 
+""",
+                        ],
+                    },
+                ],
+            }
+        ]
+        self.mock_sac = Mock()
+
+    def test_success(self):
+        """
+        Test that spaces in prior reference years all get removed.
+        """
+        with set_sac_to_context(self.mock_sac):
+            new_ir = reformat_prior_references(self.ir)
+            values = new_ir[0]["ranges"][0]["values"]
+            # We expect all spaces to be removed. So, each value in the
+            # `values` array should match the value in the EXPECTED array.
+            for expected, returned in zip(EXPECTED, values):
+                self.assertEqual(expected, returned)


### PR DESCRIPTION
We found a bug with the handling of prior reference numbers that this change should address.

Specifically, we found that the validation for prior references breaks when there is a space in the references; users were writing things like

`2022-001, 2021-005`

and the space after the comma was a problem. We filter spaces in a transform (`xform_...`) *before* the comma currently, but not *after*.

This fix removes *all* spaces from the prior references string: beginning, end, and any spaces internal to the string. This should not impact the semantics of the field negatively (and should eliminate a class of error for the user).

That is, regardless of whether we have

`2023-001 ,2022-004`

or

`2023-001, 2022-004`

or

`2023-001 , 2022-004`

they should all become

`2023-001,2022-004`

We already `trim()` the strings; this makes sure there are no internal spaces whatsoever.


## PR Checklist: Submitter

- [ ]   Link to an issue if possible. If there’s no issue, describe what your branch does. Even if there is an issue, a brief description in the PR is still useful.
- [ ]   List any special steps reviewers have to follow to test the PR. For example, adding a local environment variable, creating a local test file, etc.
- [ ]   For extra credit, submit a screen recording like [this one](https://github.com/GSA-TTS/FAC/pull/1821).
- [ ]   Make sure you’ve merged `main` into your branch shortly before creating the PR. (You should also be merging `main` into your branch regularly during development.)
- [ ]   Make sure you’ve accounted for any migrations. When you’re about to create the PR, bring up the application locally and then run `git status | grep migrations`. If there are any results, you probably need to add them to the branch for the PR. Your PR should have only **one** new migration file for each of the component apps, except in rare circumstances; you may need to delete some and re-run `python manage.py makemigrations` to reduce the number to one. (Also, unless in exceptional circumstances, your PR should not delete any migration files.)
- [ ]   Make sure that whatever feature you’re adding has tests that cover the feature. This includes test coverage to make sure that the previous workflow still works, if applicable.
- [ ]   Make sure the full-submission.cy.js [Cypress test](https://github.com/GSA-TTS/FAC/blob/main/docs/testing.md#end-to-end-testing) passes, if applicable.
- [ ]   Do manual testing locally. Our tests are not good enough yet to allow us to skip this step. If that’s not applicable for some reason, check this box.
- [ ]   Verify that no Git surgery was necessary, or, if it was necessary at any point, repeat the testing after it’s finished.
- [ ]   Once a PR is merged, keep an eye on it until it’s deployed to dev, and do enough testing on dev to verify that it deployed successfully, the feature works as expected, and the happy path for the broad feature area (such as submission) still works.
- [ ]   Ensure that prior to merging, the working branch is up to date with main and the terraform plan is what you expect.

## PR Checklist: Reviewer

- [ ]   Pull the branch to your local environment and run `make docker-clean; make docker-first-run && docker compose up`; then run `docker compose exec web /bin/bash -c "python manage.py test"`
- [ ]   Manually test out the changes locally, or check this box to verify that it wasn’t applicable in this case.
- [ ]   Check that the PR has appropriate tests. Look out for changes in HTML/JS/JSON Schema logic that may need to be captured in Python tests even though the logic isn’t in Python.
- [ ]   Verify that no Git surgery is necessary at any point (such as during a merge party), or, if it was, repeat the testing after it’s finished.

The larger the PR, the stricter we should be about these points.

## Pre Merge Checklist: Merger

- [ ]   Ensure that prior to approving, the terraform plan is what we expect it to be. `-/+ resource "null_resource" "cors_header" ` should be destroying and recreating its self and ` ~ resource "cloudfoundry_app" "clamav_api" ` might be updating its `sha256` for the `fac-file-scanner` and `fac-av-${ENV}` by default.
- [ ]   Ensure that the branch is up to date with `main`.
- [ ]   Ensure that a terraform plan has been recently generated for the pull request.
