### PR TITLE
Updating the previous references validation to use Audit table

### DIFF
--- a/backend/audit/cross_validation/audit_validation_shape.py
+++ b/backend/audit/cross_validation/audit_validation_shape.py
@@ -57,7 +57,7 @@ def audit_validation_shape(audit):
     shape = {
         "sf_sac_sections": {k: get_shaped_section(audit, k) for k in SECTION_NAMES},
         "sf_sac_meta": {
-            "submitted_by": audit.submitted_by,
+            "submitted_by": audit.created_by,  # For SACs submitted by was created_by (and at this point the audit isn't even submitted
             "date_created": audit.created_at,
             "submission_status": audit.submission_status,
             "report_id": audit.report_id,

--- a/backend/audit/cross_validation/check_finding_prior_references.py
+++ b/backend/audit/cross_validation/check_finding_prior_references.py
@@ -1,16 +1,17 @@
+from django.db import connection
 from audit.fixtures.excel import (
     FINDINGS_UNIFORM_TEMPLATE_DEFINITION,
 )
+from dissemination.models import Finding, General
 from .errors import err_prior_ref_not_found
-from dissemination.models import (
-    Finding,
-    General,
-)
 
 from django.conf import settings
 
 from datetime import date
 import json
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def check_finding_prior_references(sac_dict, *_args, **_kwargs):
@@ -48,15 +49,34 @@ def check_finding_prior_references(sac_dict, *_args, **_kwargs):
     if audit_year < 2023:
         return []
 
+    # TODO: Update Post SOC Launch -> Clean-up, the check on Audit can go away
+    # imported locally to avoid circular dependencies.
+    from audit.models import Audit
+
+    report_id = sac_dict.get("sf_sac_meta", {}).get("report_id")
+    use_audit = Audit.objects.find_audit_or_none(report_id=report_id) is not None
+    previous_findings_refs = None
+    if use_audit:
+        previous_findings_refs = _get_previous_findings(report_id, auditee_uei)
+
     # Get the report_ids for previous reports
     previous_report_ids = General.objects.filter(auditee_uei=auditee_uei).values_list(
         "report_id", flat=True
     )
     errors = []
-
+    audit_errors = []
     # Validate all prior reference numbers for each award
     for award_ref, prior_refs_strings in all_prior_refs.items():
         prior_refs = prior_refs_strings.split(",")
+        if use_audit:
+            _validate_prior_refs_audit(
+                prior_refs,
+                award_ref,
+                auditee_uei,
+                previous_findings_refs,
+                audit_errors,
+            )
+
         _validate_prior_refs(
             prior_refs,
             award_ref,
@@ -64,8 +84,25 @@ def check_finding_prior_references(sac_dict, *_args, **_kwargs):
             previous_report_ids,
             errors,
         )
+    if use_audit:
+        _compare_errors(audit_errors, errors)
 
     return errors
+
+
+def _get_previous_findings(report_id, auditee_uei):
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """
+            select distinct (findings->'findings'->'reference_number') as reference_number
+            from audit_audit,
+                 jsonb_array_elements(audit->'findings_uniform_guidance') as findings
+            where auditee_uei = %s and
+                  report_id != %s
+        """,
+            [auditee_uei, report_id],
+        )
+        return set([row[0].replace('"', "") for row in cursor.fetchall()])
 
 
 def _get_prior_refs(findings_uniform_guidance):
@@ -88,6 +125,33 @@ TEMPLATE_DEFINITION_PATH = (
     settings.XLSX_TEMPLATE_JSON_DIR / FINDINGS_UNIFORM_TEMPLATE_DEFINITION
 )
 FINDINGS_TEMPLATE = json.loads(TEMPLATE_DEFINITION_PATH.read_text(encoding="utf-8"))
+
+
+# TODO: Update Post SOC Launch -> only the audit version needs to remain
+def _validate_prior_refs_audit(
+    prior_refs, award_ref, auditee_uei, previous_findings, errors
+):
+    """
+    Performs validation on the given list of prior reference numbers
+    """
+    first_row = FINDINGS_TEMPLATE["title_row"]
+
+    for index, prior_ref in enumerate(prior_refs):
+        current_row = first_row + index + 1
+        prior_ref_year = prior_ref[:4]
+
+        if prior_ref_year.isnumeric() and int(prior_ref_year) < 2022:
+            # Skip validation for pre-UEI prior references
+            continue
+        elif prior_ref not in previous_findings:
+            # Error if we can't find the prior finding in previous
+            errors.append(
+                {
+                    "error": err_prior_ref_not_found(
+                        auditee_uei, prior_ref, award_ref, current_row
+                    ),
+                }
+            )
 
 
 def _validate_prior_refs(
@@ -127,3 +191,10 @@ def _validate_prior_refs(
                     ),
                 }
             )
+
+
+def _compare_errors(audit_errors, errors):
+    if audit_errors != errors:
+        logger.error(
+            f"<SOT ERROR> Finding Prior References Error: {audit_errors} Audit: {errors}"
+        )

--- a/backend/audit/migrations/0018_auditflow_rename_audit_history_event_data_and_more.py
+++ b/backend/audit/migrations/0018_auditflow_rename_audit_history_event_data_and_more.py
@@ -266,4 +266,17 @@ class Migration(migrations.Migration):
                 ),
             ],
         ),
+        migrations.AlterField(
+            model_name="audit",
+            name="audit_type",
+            field=models.CharField(
+                blank=True,
+                choices=[
+                    ("single-audit", "Single Audit"),
+                    ("program-specific", "Program-Specific Audit"),
+                ],
+                max_length=20,
+                null=True,
+            ),
+        ),
     ]

--- a/backend/audit/models/constants.py
+++ b/backend/audit/models/constants.py
@@ -138,8 +138,8 @@ EVENT_TYPES = (
 
 
 class AuditType:
-    SINGLE_AUDIT = "single_audit"
-    PROGRAM_SPECIFIC = "program_specific"
+    SINGLE_AUDIT = "single-audit"
+    PROGRAM_SPECIFIC = "program-specific"
 
 
 AUDIT_TYPE_CODES = (

--- a/backend/audit/test_views.py
+++ b/backend/audit/test_views.py
@@ -2366,7 +2366,7 @@ class CrossValidationViewTests(TestCase):
     @patch("audit.models.SingleAuditChecklist.validate_full")
     def test_post_view_renders_results_template(self, mock_validate_full):
         """Test that POST with validation errors renders template with errors"""
-        mock_validate_full.return_value = ["Error 1", "Error 2"]
+        mock_validate_full.return_value = {"errors": ["Error 1", "Error 2"], "data": {}}
 
         response = self.client.post(self.url)
 
@@ -2375,7 +2375,7 @@ class CrossValidationViewTests(TestCase):
             response, "audit/cross-validation/cross-validation-results.html"
         )
         self.assertEqual(response.context["report_id"], self.sac.report_id)
-        self.assertEqual(response.context["errors"], ["Error 1", "Error 2"])
+        self.assertEqual(response.context["errors"]["errors"], ["Error 1", "Error 2"])
         mock_validate_full.assert_called_once()
 
     def test_post_view_permission_denied(self):

--- a/backend/audit/views/certification.py
+++ b/backend/audit/views/certification.py
@@ -106,11 +106,22 @@ class CertificationView(CertifyingAuditeeRequiredMixin, generic.View):
 
 # TODO: Post SOT Launch: Delete
 def _compare_errors(sac_errors, audit_errors):
-    if (
-        (sac_errors and not audit_errors)
-        or (audit_errors and not sac_errors)
-        or (sac_errors) != set(audit_errors)
-    ):
+    sac = sac_errors.copy() if sac_errors else dict({"data": {}})
+    audit = audit_errors.copy() if audit_errors else dict({"data": {}})
+
+    sac_metadata = sac.get("data", {}).get("sf_sac_meta", {})
+    audit_metadata = audit.get("data", {}).get("sf_sac_meta", {})
+
+    remove_fields = ("date_created", "transition_name", "transition_date")
+    for field in remove_fields:
+        if field in sac_metadata:
+            del sac_metadata[field]
+        if field in audit_metadata:
+            del audit_metadata[field]
+
+    sac["data"]["sf_sac_meta"] = sac_metadata
+    audit["data"]["sf_sac_meta"] = audit_metadata
+    if (sac and not audit) or (audit and not sac) or (sac != audit):
         logger.error(
-            f"<SOT ERROR> Cross Validation Errors do not match: SAC {sac_errors}, Audit {audit_errors}"
+            f"<SOT ERROR> Certification Errors do not match: SAC {sac_errors}, Audit {audit_errors}"
         )

--- a/backend/audit/views/submission_progress_view.py
+++ b/backend/audit/views/submission_progress_view.py
@@ -207,5 +207,5 @@ class SubmissionProgressView(SingleAuditChecklistAccessRequiredMixin, generic.Vi
 def _compare_progress_check(sac_result, audit_result):
     if sac_result != audit_result:
         logger.error(
-            f"<SOT ERROR> Submission check failure SAC: {sac_result} Audit: {audit_result}"
+            f"<SOT ERROR> Submission check progress failure SAC: {sac_result} Audit: {audit_result}"
         )

--- a/backend/audit/views/submissions.py
+++ b/backend/audit/views/submissions.py
@@ -217,5 +217,5 @@ def _friendly_status(status):
 def _compare_errors(sac_errors, audit_errors):
     if (sac_errors and audit_errors) and set(sac_errors) != set(audit_errors):
         logger.error(
-            f"<SOT ERROR> Cross Validation Errors do not match: SAC {sac_errors}, Audit {audit_errors}"
+            f"<SOT ERROR> Submission Errors do not match: SAC {sac_errors}, Audit {audit_errors}"
         )

--- a/backend/dissemination/management/commands/migrate_audits.py
+++ b/backend/dissemination/management/commands/migrate_audits.py
@@ -144,7 +144,7 @@ class Command(BaseCommand):
                 History.objects.create(
                     event=event.event,
                     report_id=sac.report_id,
-                    audit=audit.audit,
+                    event_data=audit.audit,
                     version=0,
                     updated_at=event.timestamp,
                     updated_by=event.user,


### PR DESCRIPTION
## Purpose

The cross validation step for findings prior references was not using the Audit table.

## How

During the launch of SOT, if there is an audit with the report_id, we'll also check the audit table and compare any errors but continue to use the dissemination tables for SAC validation.

Post SOT launch, this logic can be removed and solely utilize the SOT.

## Testing Completed

Linting, Unit Tests, E2E, Manual.