### PR TITLE
menu.bash and README fixes

### DIFF
--- a/backend/util/load_public_dissem_data/menu.bash
+++ b/backend/util/load_public_dissem_data/menu.bash
@@ -5,12 +5,12 @@ USERNAME=postgres
 HOST=localhost
 PORT=5432
 FINISHED_FILENAME=${FINISHED_FILENAME:-data/internal-and-external-20250402.dump}
-RAW_FILENAME=${RAW_FILENAME:-data/sac-user-access-valwaiver-pdf-xlsx-event-data-03-28-25.dump.dump}
+RAW_FILENAME=${RAW_FILENAME:-data/sac-user-access-valwaiver-pdf-xlsx-event-data-03-28-25.dump}
 DATE=$(date '+%Y%m%d')
 
 count_audit_singleauditchecklist=354222
-count_audit_access=1195595 
-count_auth_user=75461 
+count_audit_access=1195595
+count_auth_user=75461
 count_dissemination_additionalein=59251
 count_dissemination_additionaluei=15101
 count_dissemination_captext=116694
@@ -18,7 +18,7 @@ count_dissemination_federalaward=5811960
 count_dissemination_finding=507895
 count_dissemination_findingtext=120290
 count_dissemination_general=343116
-count_dissemination_note=530405
+count_dissemination_note=530407
 count_dissemination_passthrough=4025800
 count_dissemination_secondaryauditor=1803
 count_audit_ueivalidationwaiver=0
@@ -41,7 +41,7 @@ truncate () {
     -v ON_ERROR_STOP=1 \
     <<EOF
 	begin;
-		truncate 
+		truncate
       audit_access,
       audit_singleauditchecklist,
       auth_user,
@@ -247,8 +247,8 @@ check_row_counts () {
 check_all_row_counts () {
   echo "Checking counts"
   check_row_counts "audit_singleauditchecklist" ${count_audit_singleauditchecklist}
-  check_row_counts "audit_access" ${count_audit_access} 
-  check_row_counts "auth_user" ${count_auth_user} 
+  check_row_counts "audit_access" ${count_audit_access}
+  check_row_counts "auth_user" ${count_auth_user}
   check_row_counts "dissemination_additionalein" ${count_dissemination_additionalein}
   check_row_counts "dissemination_additionaluei" ${count_dissemination_additionaluei}
   check_row_counts "dissemination_captext" ${count_dissemination_captext}


### PR DESCRIPTION
In this PR:
- menu.bash
  - RAW_FILENAME extension corrected
  - disseminated_note count corrected
- README
  - Updated with current menu.bash options
  - Including link to internal-and-external*.dump file
  - Raw vs finished explanation
  - VSCode cleaning up endline whitespace 😀

Testing:
- Make sure you have the required "finished" dump file (see README)
- In `backend/util/load_public_dissem_data` run `./menu.bash`
- Run `2) Load finished data`
- Run `6) Check row counts` and it should pass
- Run `1) Truncate tables`
- Make sure you have the required "raw" dump file (see README)
- Run `3) Load raw data` and it should not error

## PR Checklist: Submitter

- [ ]   Link to an issue if possible. If there’s no issue, describe what your branch does. Even if there is an issue, a brief description in the PR is still useful.
- [ ]   List any special steps reviewers have to follow to test the PR. For example, adding a local environment variable, creating a local test file, etc.
- [ ]   For extra credit, submit a screen recording like [this one](https://github.com/GSA-TTS/FAC/pull/1821).
- [ ]   Make sure you’ve merged `main` into your branch shortly before creating the PR. (You should also be merging `main` into your branch regularly during development.)
- [ ]   Make sure you’ve accounted for any migrations. When you’re about to create the PR, bring up the application locally and then run `git status | grep migrations`. If there are any results, you probably need to add them to the branch for the PR. Your PR should have only **one** new migration file for each of the component apps, except in rare circumstances; you may need to delete some and re-run `python manage.py makemigrations` to reduce the number to one. (Also, unless in exceptional circumstances, your PR should not delete any migration files.)
- [ ]   Make sure that whatever feature you’re adding has tests that cover the feature. This includes test coverage to make sure that the previous workflow still works, if applicable.
- [ ]   Make sure the full-submission.cy.js [Cypress test](https://github.com/GSA-TTS/FAC/blob/main/docs/testing.md#end-to-end-testing) passes, if applicable.
- [ ]   Do manual testing locally. Our tests are not good enough yet to allow us to skip this step. If that’s not applicable for some reason, check this box.
- [ ]   Verify that no Git surgery was necessary, or, if it was necessary at any point, repeat the testing after it’s finished.
- [ ]   Once a PR is merged, keep an eye on it until it’s deployed to dev, and do enough testing on dev to verify that it deployed successfully, the feature works as expected, and the happy path for the broad feature area (such as submission) still works.
- [ ]   Ensure that prior to merging, the working branch is up to date with main and the terraform plan is what you expect.

## PR Checklist: Reviewer

- [ ]   Pull the branch to your local environment and run `make docker-clean; make docker-first-run && docker compose up`; then run `docker compose exec web /bin/bash -c "python manage.py test"`
- [ ]   Manually test out the changes locally, or check this box to verify that it wasn’t applicable in this case.
- [ ]   Check that the PR has appropriate tests. Look out for changes in HTML/JS/JSON Schema logic that may need to be captured in Python tests even though the logic isn’t in Python.
- [ ]   Verify that no Git surgery is necessary at any point (such as during a merge party), or, if it was, repeat the testing after it’s finished.

The larger the PR, the stricter we should be about these points.

## Pre Merge Checklist: Merger

- [ ]   Ensure that prior to approving, the terraform plan is what we expect it to be. `-/+ resource "null_resource" "cors_header" ` should be destroying and recreating its self and ` ~ resource "cloudfoundry_app" "clamav_api" ` might be updating its `sha256` for the `fac-file-scanner` and `fac-av-${ENV}` by default.
- [ ]   Ensure that the branch is up to date with `main`.
- [ ]   Ensure that a terraform plan has been recently generated for the pull request.
