### PR TITLE
Uncomments the predeploy backup

### DIFF
--- a/.github/workflows/deploy-application.yml
+++ b/.github/workflows/deploy-application.yml
@@ -69,15 +69,15 @@ jobs:
           cf_space: ${{ env.space }}
           cf_command: update-user-provided-service fac-key-service -p '"{\"SAM_API_KEY\":\"${{ secrets.SAM_API_KEY }}\", \"DJANGO_SECRET_LOGIN_KEY\":\"${{ secrets.DJANGO_SECRET_LOGIN_KEY }}\", \"LOGIN_CLIENT_ID\":\"${{ secrets.LOGIN_CLIENT_ID }}\", \"SECRET_KEY\":\"${{ secrets.SECRET_KEY}}\"}"'
 
-      # - name: Backup the database
-      #   if: startsWith(github.ref, 'refs/tags/v1.')
-      #   uses: cloud-gov/cg-cli-tools@main
-      #   with:
-      #     cf_username: ${{ secrets.CF_USERNAME }}
-      #     cf_password: ${{ secrets.CF_PASSWORD }}
-      #     cf_org: gsa-tts-oros-fac
-      #     cf_space: ${{ env.space }}
-      #     command: cf run-task gsa-fac -k 7G -m 3G --name deploy_backup --command "./fac-backup-util.sh v0.1.11 deploy_backup" --wait
+      - name: Backup the database
+        if: startsWith(github.ref, 'refs/tags/v1.')
+        uses: cloud-gov/cg-cli-tools@main
+        with:
+          cf_username: ${{ secrets.CF_USERNAME }}
+          cf_password: ${{ secrets.CF_PASSWORD }}
+          cf_org: gsa-tts-oros-fac
+          cf_space: ${{ env.space }}
+          command: cf run-task gsa-fac -k 7G -m 3G --name deploy_backup --command "./fac-backup-util.sh v0.1.11 deploy_backup" --wait
 
       - name: Deploy Preview to cloud.gov
         if: ${{ inputs.environment == 'preview' }}


### PR DESCRIPTION
The application cannot do a backup because the application has not changed the `$https_proxy` variable. We commented this out to get a deploy going and get `prod` operational.