### PR TITLE
Add file download check + SOT `if` conditional

### DIFF
--- a/backend/cypress/support/full-submission.js
+++ b/backend/cypress/support/full-submission.js
@@ -17,7 +17,8 @@ import {
   testWorkbookCorrectiveActionPlan,
   testWorkbookAdditionalUEIs,
   testWorkbookSecondaryAuditors,
-  testWorkbookAdditionalEINs
+  testWorkbookAdditionalEINs,
+  testWorkbookDownloadLinkExists
 } from './workbook-uploads.js';
 
 const LOGIN_TEST_EMAIL_AUDITEE = Cypress.env('LOGIN_TEST_EMAIL_AUDITEE');
@@ -36,30 +37,38 @@ export function testFullSubmission(isTribal, isPublic) {
   // Upload all the workbooks. Don't intercept the uploads, which means a file will make it into the DB.
   cy.get(".usa-link").contains("Federal Awards").click();
   testWorkbookFederalAwards(false);
+  testWorkbookDownloadLinkExists("Federal Awards")
 
   cy.get(".usa-link").contains("Notes to SEFA").click();
   testWorkbookNotesToSEFA(false);
+  testWorkbookDownloadLinkExists("Notes to SEFA")
 
   cy.get(".usa-link").contains("Audit report PDF").click();
   testPdfAuditReport(false);
 
   cy.get(".usa-link").contains("Federal Awards Audit Findings").click();
   testWorkbookFindingsUniformGuidance(false);
+  testWorkbookDownloadLinkExists("Federal Awards Audit Findings")
 
   cy.get(".usa-link").contains("Federal Awards Audit Findings Text").click();
   testWorkbookFindingsText(false);
+  testWorkbookDownloadLinkExists("Federal Awards Audit Findings Text")
 
   cy.get(".usa-link").contains("Corrective Action Plan").click();
   testWorkbookCorrectiveActionPlan(false);
+  testWorkbookDownloadLinkExists("Corrective Action Plan")
 
   cy.get(".usa-link").contains("Additional UEIs").click();
   testWorkbookAdditionalUEIs(false);
+  testWorkbookDownloadLinkExists("Additional UEIs")
 
   cy.get(".usa-link").contains("Secondary Auditors").click();
   testWorkbookSecondaryAuditors(false);
+  testWorkbookDownloadLinkExists("Secondary Auditors")
 
   cy.get(".usa-link").contains("Additional EINs").click();
   testWorkbookAdditionalEINs(false);
+  testWorkbookDownloadLinkExists("Additional EINs")
 
   if (isTribal) {
     cy.url().then(url => {

--- a/backend/cypress/support/workbook-uploads.js
+++ b/backend/cypress/support/workbook-uploads.js
@@ -26,6 +26,15 @@ function testWorkbookUpload(interceptUrl, uploadSelector, filename, will_interce
   cy.url().should('match', /\/audit\/submission-progress\/[0-9]{4}-[0-9]{2}-GSAFAC-[0-9]{10}/);
 };
 
+export function testWorkbookDownloadLinkExists(workbook_name) {
+  // From the main page, click the edit link
+  cy.get(".usa-link").contains("Edit the " + workbook_name).click();
+  // Then, try and download
+  cy.get(".usa-link").contains("Download current workbook").click();
+  // Return to the main page.
+  cy.get(".usa-button").contains("Cancel").click();
+};
+
 export function testWorkbookFederalAwards(will_intercept = true) {
   testWorkbookUpload(
     '/audit/excel/federal-awards/*',

--- a/backend/report_submission/views/file_views.py
+++ b/backend/report_submission/views/file_views.py
@@ -55,17 +55,29 @@ class UploadPageView(SingleAuditChecklistAccessRequiredMixin, View):
                     sac, additional_context[path_name]["DB_id"]
                 )
 
-                audit = Audit.objects.get(report_id=report_id)
-                shaped_sac = sac_validation_shape(sac)
-                shaped_audit = audit_validation_shape(audit)
+                # DANGER
+                # If this was created before SOT, we could be in a situation where there is a SAC
+                # but no SOT. So, we should *try* and do a `get()`, and if nothing is there,
+                # handle it gracefully.
+                try:
+                    audit = Audit.objects.get(report_id=report_id)
+                except:
+                    audit = None
 
-                _compare_shapes(shaped_sac, shaped_audit)
+                shaped_sac = sac_validation_shape(sac)
+
+                if audit:
+                    shaped_audit = audit_validation_shape(audit)
+                    _compare_shapes(shaped_sac, shaped_audit)
+                else:
+                    logger.debug("A SOT does not yet exist for this SAC.\n")
 
                 completed_metadata = section_completed_metadata(shaped_sac, path_name)
                 completed_audit_audit = section_completed_metadata(
                     shaped_sac, path_name
                 )
 
+                # LESS DANGER
                 _compare_completed_metadata(completed_metadata, completed_audit_audit)
 
                 context["last_uploaded_by"] = completed_metadata[0]


### PR DESCRIPTION
This does two things:

1. Adds some additional Cypress tests to make sure files can be downloaded.
2. Adds some more `if` conditionals around the `audit` table, which might not exist if the audit was created before last week (of which there are 400-ish).

This should allow users to see files and download them in cases where they have a `sac` but not a `sot` object.