### PR TITLE
The walkthrough

### DIFF
--- a/backend/audit/intakelib/checks/runners.py
+++ b/backend/audit/intakelib/checks/runners.py
@@ -54,7 +54,8 @@ from .check_y_or_n__fields import has_invalid_yorn_field
 # Audit findings checks
 from .check_no_repeat_findings import no_repeat_findings
 from .check_findings_grid_validation import findings_grid_validation
-from .check_finding_prior_references_pattern import prior_references_pattern
+
+# from .check_finding_prior_references_pattern import prior_references_pattern
 from .check_finding_reference_pattern import finding_reference_pattern
 from .check_finding_reference_year import finding_reference_year
 from .check_aln_prefix_pattern import aln_agency_prefix
@@ -110,7 +111,11 @@ audit_findings_checks = general_checks + [
     has_all_required_fields(FORM_SECTIONS.FINDINGS_UNIFORM_GUIDANCE),
     has_invalid_yorn_field(FORM_SECTIONS.FINDINGS_UNIFORM_GUIDANCE),
     award_references_pattern,
-    prior_references_pattern,
+    # 20250425 This does not work if an auditee changes their UEI from one
+    # year to the next. At that point, we need a waiver. That fix is not something
+    # that can be done at this exact moment, and so we are turning off this validation
+    # for the time being.
+    # prior_references_pattern,
     finding_reference_pattern,
     finding_reference_year,
     no_repeat_findings,

--- a/backend/audit/intakelib/mapping_util.py
+++ b/backend/audit/intakelib/mapping_util.py
@@ -105,7 +105,12 @@ def _extract_from_field_mapping(path, field_mapping, match=None):
 
 def _extract_error_details(error):
     if not bool(error.path):
-        logger.info("No path found in error object")
+        # Was previously `info`. However, for 18 months, we have
+        # not done anything with that information. Shifting it to a
+        # debug, and perhaps someday we will ask why this mattered.
+        # The calling code pathway happily continues if we return
+        # (None, None, None), so this is acceptable behavior.
+        logger.debug("No path found in error object")
         return None, None, None
 
     row_index = next((item for item in error.path if isinstance(item, int)), None)

--- a/backend/audit/models/models.py
+++ b/backend/audit/models/models.py
@@ -124,14 +124,19 @@ def json_property_mixin_generator(name, fname=None, toplevel=None, classname=Non
     toplevelproperty = toplevel or camel_to_snake(name)
     mixinname = classname or f"{name}Mixin"
 
+    # 20250425 The `debug` statements used to be `warning`. However, this code has
+    # been in production for 22 months. We clearly are not troubled by the
+    # keys not being present; every time we marshal a General Info object into
+    # JSON, we will see this for some keys. So, we're going to make this quieter
+    # in production at this point.
     def _wrapper(key):
         def inner(self):
             try:
                 return getattr(self, toplevelproperty)[key]
             except KeyError:
-                logger.warning("Key %s not found in SAC", key)
+                logger.debug("Key %s not found in SAC", key)
             except TypeError:
-                logger.warning("Type error trying to get %s from SAC %s", key, self)
+                logger.debug("Type error trying to get %s from SAC %s", key, self)
             return None
 
         return inner

--- a/backend/audit/models/viewflow.py
+++ b/backend/audit/models/viewflow.py
@@ -126,6 +126,7 @@ def sac_transition(request, sac, **kwargs):
     """
     audit = kwargs.get("audit", None)
     user = None
+    # SOT TODO: This needs to use `audit`
     flow = SingleAuditChecklistFlow(sac)
     audit_flow = AuditFlow(audit)
 
@@ -285,6 +286,7 @@ def audit_transition(request, audit, **kwargs):
     return True
 
 
+# SOT TODO: This goes away, because we have AuditFlow
 class SingleAuditChecklistFlow(SingleAuditChecklist):
     """
     Handles transitioning of states for an SAC.

--- a/backend/audit/templates/audit/audit_submissions/audit_submissions.html
+++ b/backend/audit/templates/audit/audit_submissions/audit_submissions.html
@@ -25,9 +25,12 @@
                 </button>
             </div>
         </div>
-        {% if is_beta %}
-          {% include "includes/beta_warning.html" %}
-        {% endif %}
+        {% comment %}
+          <!-- SOT TODO: enable for testing with SOT inclusion -->
+          {% if is_beta %}
+            {% include "includes/beta_warning.html" %}
+          {% endif %}
+        {% endcomment %}
         {% if data.in_progress_audits|length == 0 and data.completed_audits|length == 0 %}
             <p class="margin-bottom-4">No submissions associated with your email address were found.</p>
             {% include "./alert_find_report.html" %}

--- a/backend/audit/views/audit_info_form_view.py
+++ b/backend/audit/views/audit_info_form_view.py
@@ -24,6 +24,7 @@ class AuditInfoFormView(SingleAuditChecklistAccessRequiredMixin, generic.View):
     def get(self, request, *args, **kwargs):
         report_id = kwargs["report_id"]
         try:
+            # SOT TODO: Switch to audit
             sac = SingleAuditChecklist.objects.get(report_id=report_id)
             current_info = {}
             if sac.audit_information:
@@ -77,6 +78,7 @@ class AuditInfoFormView(SingleAuditChecklistAccessRequiredMixin, generic.View):
         report_id = kwargs["report_id"]
 
         try:
+            # SOT TODO: Switch to `audit`
             sac = SingleAuditChecklist.objects.get(report_id=report_id)
             form = AuditInfoForm(request.POST)
 
@@ -114,16 +116,20 @@ class AuditInfoFormView(SingleAuditChecklistAccessRequiredMixin, generic.View):
             else:
                 for field, errors in form.errors.items():
                     for error in errors:
-                        logger.warn(f"ERROR in field {field} : {error}")
+                        logger.warning(f"ERROR in field {field} : {error}")
 
                 form.clean_booleans()
+                # TODO: Update Post SOC Launch
                 context = self._get_context(sac, form)
                 return render(request, "audit/audit-info-form.html", context)
 
         except SingleAuditChecklist.DoesNotExist:
             raise PermissionDenied("You do not have access to this audit.")
         except Exception as e:
-            logger.info("Enexpected error in AuditInfoFormView post.\n%s", e)
+            # SOT TODO: This generic exception is rarely/never triggered. However,
+            # we think it would be better to not just throw back a BadRequest at the user.
+            # A more refined approach is warranted.
+            logger.error("Unexpected error in AuditInfoFormView post.\n%s", e)
             raise BadRequest()
 
     def _get_context(self, sac, form):
@@ -138,7 +144,7 @@ class AuditInfoFormView(SingleAuditChecklistAccessRequiredMixin, generic.View):
             "sp_framework_opinions": SP_FRAMEWORK_OPINIONS,
         }
         for field, value in context.items():
-            logger.warn(f"{field}:{value}")
+            logger.warning(f"{field}:{value}")
         context.update(
             {
                 "form": form,

--- a/backend/audit/views/auditee_certification.py
+++ b/backend/audit/views/auditee_certification.py
@@ -34,6 +34,7 @@ class AuditeeCertificationStep1View(CertifyingAuditeeRequiredMixin, generic.View
         report_id = kwargs["report_id"]
 
         try:
+            # SOT TODO: Switch to audit
             sac = SingleAuditChecklist.objects.get(report_id=report_id)
             initial = {
                 "AuditeeCertificationStep1Session": request.session.get(
@@ -59,6 +60,7 @@ class AuditeeCertificationStep1View(CertifyingAuditeeRequiredMixin, generic.View
         report_id = kwargs["report_id"]
 
         try:
+            # SOT TODO: Switch to audit
             sac = SingleAuditChecklist.objects.get(report_id=report_id)
             initial = {
                 "AuditeeCertificationStep1Session": request.session.get(
@@ -93,6 +95,7 @@ class AuditeeCertificationStep2View(CertifyingAuditeeRequiredMixin, generic.View
         report_id = kwargs["report_id"]
 
         try:
+            # SOT TODO: Switch to audit
             sac = SingleAuditChecklist.objects.get(report_id=report_id)
             initial = {
                 "AuditeeCertificationStep2Session": request.session.get(
@@ -127,6 +130,7 @@ class AuditeeCertificationStep2View(CertifyingAuditeeRequiredMixin, generic.View
         report_id = kwargs["report_id"]
 
         try:
+            # SOT TODO: Switch to audit
             sac = SingleAuditChecklist.objects.get(report_id=report_id)
             form1_cleaned = request.session.get(
                 "AuditeeCertificationStep1Session", None

--- a/backend/audit/views/auditor_certification.py
+++ b/backend/audit/views/auditor_certification.py
@@ -36,6 +36,7 @@ class AuditorCertificationStep1View(CertifyingAuditorRequiredMixin, generic.View
         report_id = kwargs["report_id"]
 
         try:
+            # SOT TODO: Switch to audit
             sac = SingleAuditChecklist.objects.get(report_id=report_id)
             initial = {
                 "AuditorCertificationStep1Session": request.session.get(
@@ -65,6 +66,7 @@ class AuditorCertificationStep1View(CertifyingAuditorRequiredMixin, generic.View
         report_id = kwargs["report_id"]
 
         try:
+            # SOT TODO: Switch to audit
             sac = SingleAuditChecklist.objects.get(report_id=report_id)
             initial = {
                 "AuditorCertificationStep1Session": request.session.get(
@@ -103,6 +105,7 @@ class AuditorCertificationStep2View(CertifyingAuditorRequiredMixin, generic.View
         report_id = kwargs["report_id"]
 
         try:
+            # SOT TODO: Switch to audit
             sac = SingleAuditChecklist.objects.get(report_id=report_id)
             initial = {
                 "AuditorCertificationStep2Session": request.session.get(
@@ -141,6 +144,7 @@ class AuditorCertificationStep2View(CertifyingAuditorRequiredMixin, generic.View
         report_id = kwargs["report_id"]
 
         try:
+            # SOT TODO: Switch to audit
             sac = SingleAuditChecklist.objects.get(report_id=report_id)
             form1_cleaned = request.session.get(
                 "AuditorCertificationStep1Session", None

--- a/backend/audit/views/certification.py
+++ b/backend/audit/views/certification.py
@@ -50,9 +50,11 @@ class ReadyForCertificationView(SingleAuditChecklistAccessRequiredMixin, generic
             # TODO: Update Post SOC Launch
             audit = Audit.objects.find_audit_or_none(report_id=report_id)
             errors = sac.validate_full()
-            audit_errors = audit.validate() if audit else None
 
-            _compare_errors(errors, audit_errors)
+            if audit:
+                audit_errors = audit.validate()
+                _compare_errors(errors, audit_errors)
+
             if not errors:
                 sac_transition(
                     request,

--- a/backend/audit/views/cross_validation.py
+++ b/backend/audit/views/cross_validation.py
@@ -26,6 +26,7 @@ class CrossValidationView(SingleAuditChecklistAccessRequiredMixin, generic.View)
         report_id = kwargs["report_id"]
 
         try:
+            # SOT TODO: Switch to `audit`
             sac = SingleAuditChecklist.objects.get(report_id=report_id)
 
             context = {
@@ -43,12 +44,15 @@ class CrossValidationView(SingleAuditChecklistAccessRequiredMixin, generic.View)
         report_id = kwargs["report_id"]
 
         try:
+            # SOT TODO: Switch to `audit`
             sac = SingleAuditChecklist.objects.get(report_id=report_id)
-            audit = Audit.objects.find_audit_or_none(report_id=report_id)
             errors = sac.validate_full()
-            audit_errors = audit.validate() if audit else None
 
-            _compare_errors(errors, audit_errors)
+            audit = Audit.objects.find_audit_or_none(report_id=report_id)
+            if audit:
+                audit_errors = audit.validate()
+                _compare_errors(errors, audit_errors)
+
             context = {"report_id": report_id, "errors": errors}
 
             return render(

--- a/backend/audit/views/excel_file_handler.py
+++ b/backend/audit/views/excel_file_handler.py
@@ -74,11 +74,10 @@ class ExcelFileHandlerView(SingleAuditChecklistAccessRequiredMixin, generic.View
             setattr(sac, handler_info["field_name"], audit_data)
             sac.save()
 
-            # TODO: Update Post SOC Launch
-            # TODO Audit Rework
-            # remove try/except once we are ready to deprecate SAC.
-            try:
-                audit = Audit.objects.get(report_id=sac.report_id)
+            # SOT TODO: Update Post SOC Launch
+            # SOT TODO Audit Rework
+            audit = Audit.objects.find_audit_or_none(report_id=sac.report_id)
+            if audit:
                 audit_update = FORM_SECTION_HANDLERS.get(form_section)["audit_object"](
                     audit_data
                 )
@@ -87,8 +86,6 @@ class ExcelFileHandlerView(SingleAuditChecklistAccessRequiredMixin, generic.View
                     event_user=user,
                     event_type=self._event_type(form_section),
                 )
-            except Audit.DoesNotExist:
-                pass
 
     @method_decorator(csrf_exempt)
     def dispatch(self, *args, **kwargs):
@@ -120,6 +117,7 @@ class ExcelFileHandlerView(SingleAuditChecklistAccessRequiredMixin, generic.View
 
             form_section = kwargs["form_section"]
 
+            # SOT TODO: Need to use `audit`
             sac = SingleAuditChecklist.objects.get(report_id=report_id)
 
             file = request.FILES["FILES"]

--- a/backend/audit/views/manage_submission.py
+++ b/backend/audit/views/manage_submission.py
@@ -59,6 +59,7 @@ class ManageSubmissionView(SingleAuditChecklistAccessRequiredMixin, generic.View
             return reverse(f"audit:{viewname}", **kwargs)
 
         report_id = kwargs["report_id"]
+        # SOT TODO: Switch to audit
         sac = SingleAuditChecklist.objects.get(report_id=report_id)
         accesses = Access.objects.filter(sac=sac).order_by("role")
         base_entries = list(map(_user_entry, accesses))

--- a/backend/audit/views/manage_submission_access.py
+++ b/backend/audit/views/manage_submission_access.py
@@ -17,6 +17,8 @@ from audit.models import (
     Audit,
 )
 
+from audit.models.access_roles import AccessRole
+
 logger = logging.getLogger(__name__)
 
 
@@ -125,16 +127,8 @@ class ChangeOrAddRoleView(SingleAuditChecklistAccessRequiredMixin, generic.View)
             context = {
                 "role": self.role,
                 "friendly_role": _get_friendly_role(self.role),
-                "auditee_uei": (
-                    audit.audit.get("general_information", {}).get("auditee_uei", None)
-                    if audit
-                    else sac.general_information["auditee_uei"]
-                ),
-                "auditee_name": (
-                    audit.audit.get("general_information", {}).get("auditee_name", None)
-                    if audit
-                    else sac.general_information.get("auditee_name")
-                ),
+                "auditee_uei": sac.general_information["auditee_uei"],
+                "auditee_name": sac.general_information.get("auditee_name"),
                 "certifier_name": access.fullname,
                 "email": access.email,
                 "report_id": report_id,
@@ -142,6 +136,15 @@ class ChangeOrAddRoleView(SingleAuditChecklistAccessRequiredMixin, generic.View)
                     "email": "Cannot use the same email address for both certifying officials."
                 },
             }
+
+            # SOT TODO: When we switch to audit, we should only use these values.
+            # For now, do not use parts of both SAC and SOT.
+            # if audit:
+            #     context = context | {
+            #         "auditee_uei": audit.audit.get("general_information", {}).get("auditee_uei", None),
+            #         "auditee_name": audit.audit.get("general_information", {}).get("auditee_name", None),
+            #     }
+
             return render(request, self.template, context, status=400)
 
         # Only Access, and not SimpleNamespace, has .delete:
@@ -305,8 +308,8 @@ class ChangeAuditorCertifyingOfficialView(ChangeOrAddRoleView):
     View for changing the auditor certifying official
     """
 
-    role = "certifying_auditor_contact"
-    other_role = "certifying_auditee_contact"
+    role = AccessRole.CERTIFYING_AUDITOR_CONTACT
+    other_role = AccessRole.CERTIFYING_AUDITEE_CONTACT
 
 
 class ChangeAuditeeCertifyingOfficialView(ChangeOrAddRoleView):
@@ -314,5 +317,5 @@ class ChangeAuditeeCertifyingOfficialView(ChangeOrAddRoleView):
     View for changing the auditee certifying official
     """
 
-    role = "certifying_auditee_contact"
-    other_role = "certifying_auditor_contact"
+    role = AccessRole.CERTIFYING_AUDITEE_CONTACT
+    other_role = AccessRole.CERTIFYING_AUDITOR_CONTACT

--- a/backend/audit/views/pre_dissemination_download_view.py
+++ b/backend/audit/views/pre_dissemination_download_view.py
@@ -32,7 +32,9 @@ class PredisseminationSummaryReportDownloadView(
     def get(self, request, report_id):
         sac = get_object_or_404(SingleAuditChecklist, report_id=report_id)
 
-        use_audit = request.GET.get("beta", "N") == "Y"
+        # TODO SOT: Enable for testing
+        # use_audit = request.GET.get("beta", "N") == "Y"
+        use_audit = False
         if use_audit:
             get_object_or_404(Audit, report_id=report_id)
 

--- a/backend/audit/views/remove_submission_in_progress.py
+++ b/backend/audit/views/remove_submission_in_progress.py
@@ -41,6 +41,8 @@ class RemoveSubmissionView(SingleAuditChecklistAccessRequiredMixin, generic.View
         Show the audit to be removed and confirmation form.
         """
         report_id = kwargs["report_id"]
+
+        # SOT TODO: Switch to audit
         sac = SingleAuditChecklist.objects.get(report_id=report_id)
         role_values = [role[0] for role in ACCESS_ROLES]
         if not Access.objects.filter(
@@ -73,6 +75,8 @@ class RemoveSubmissionView(SingleAuditChecklistAccessRequiredMixin, generic.View
         Remove the audit and redirect to the audits list.
         """
         report_id = kwargs["report_id"]
+
+        # SOT TODO: Switch to audit
         sac = SingleAuditChecklist.objects.get(report_id=report_id)
         role_values = [role[0] for role in ACCESS_ROLES]
         if not Access.objects.filter(

--- a/backend/audit/views/single_audit_report_file_handler.py
+++ b/backend/audit/views/single_audit_report_file_handler.py
@@ -50,5 +50,5 @@ class SingleAuditReportFileHandlerView(
             return redirect("/")
 
         except MultiValueDictKeyError:
-            logger.warn("No file found in request")
+            logger.warning("No file found in request")
             raise BadRequest()

--- a/backend/audit/views/submission_progress_view.py
+++ b/backend/audit/views/submission_progress_view.py
@@ -134,15 +134,16 @@ class SubmissionProgressView(SingleAuditChecklistAccessRequiredMixin, generic.Vi
                 sar = None
 
             shaped_sac = sac_validation_shape(sac)
-
-            shaped_audit = audit_validation_shape(audit) if audit else None
-
             subcheck = submission_progress_check(shaped_sac, sar, crossval=False)
-            audit_subcheck = (
-                submission_progress_check(shaped_audit, sar, crossval=False)
-                if shaped_audit
-                else None
-            )
+
+            if audit:
+                shaped_audit = audit_validation_shape(audit)
+                audit_subcheck = submission_progress_check(
+                    shaped_audit, sar, crossval=False
+                )
+            else:
+                shaped_audit = None
+                audit_subcheck = None
 
             _compare_progress_check(subcheck, audit_subcheck)
             # Update with the view-specific info from SECTIONS_BASE:

--- a/backend/audit/views/submissions.py
+++ b/backend/audit/views/submissions.py
@@ -38,7 +38,9 @@ class MySubmissions(LoginRequiredMixin, generic.View):
         template_name = "audit/audit_submissions/audit_submissions.html"
         new_link = "report_submission"
         edit_link = "audit:EditSubmission"
-        use_audit = request.GET.get("beta", "N") == "Y"
+        # TODO SOT: Enable for testing
+        # use_audit = request.GET.get("beta", "N") == "Y"
+        use_audit = False
         submissions = MySubmissions.fetch_my_submissions(request.user, use_audit)
 
         data = {"completed_audits": [], "in_progress_audits": []}
@@ -129,13 +131,13 @@ class SubmissionView(CertifyingAuditeeRequiredMixin, generic.View):
         report_id = kwargs["report_id"]
         try:
             sac = SingleAuditChecklist.objects.get(report_id=report_id)
-            # TODO: Update Post SOC Launch
-            # remove try/except once we are ready to deprecate SAC.
-            audit = Audit.objects.find_audit_or_none(report_id=report_id)
-            audit_errors = audit.validate() if audit else None
             errors = sac.validate_full()
 
-            _compare_errors(errors, audit_errors)
+            # TODO: Update Post SOC Launch
+            audit = Audit.objects.find_audit_or_none(report_id=report_id)
+            if audit:
+                audit_errors = audit.validate()
+                _compare_errors(errors, audit_errors)
 
             if errors:
                 context = {"report_id": report_id, "errors": errors}

--- a/backend/audit/views/tribal_data_consent.py
+++ b/backend/audit/views/tribal_data_consent.py
@@ -20,6 +20,8 @@ class TribalDataConsent(SingleAuditChecklistAccessRequiredMixin, generic.View):
         report_id = kwargs["report_id"]
 
         try:
+            # SOT TODO: This does not yet use `audit` at all, and
+            # will need to be updated.
             sac = SingleAuditChecklist.objects.get(report_id=report_id)
             tribal_audit_consent = sac.tribal_data_consent or {}
 
@@ -41,6 +43,8 @@ class TribalDataConsent(SingleAuditChecklistAccessRequiredMixin, generic.View):
         report_id = kwargs["report_id"]
 
         try:
+            # SOT TODO: This does not yet use `audit` at all, and
+            # will need to be updated.
             sac = SingleAuditChecklist.objects.get(report_id=report_id)
             form = TribalAuditConsentForm(request.POST or None)
 
@@ -56,16 +60,14 @@ class TribalDataConsent(SingleAuditChecklistAccessRequiredMixin, generic.View):
                 logger.info("Tribal data consent saved.", tribal_data_consent)
 
                 # TODO: Update Post SOC Launch
-                # remove try/except once we are ready to deprecate SAC.
-                try:
-                    audit = Audit.objects.get(report_id=report_id)
+                audit = Audit.objects.find_audit_or_none(report_id=report_id)
+                if audit:
+                    # audit = Audit.objects.get(report_id=report_id)
                     audit.audit.update({"tribal_data_consent": tribal_data_consent})
                     audit.save(
                         event_user=request.user,
                         event_type=SubmissionEvent.EventType.TRIBAL_CONSENT_UPDATED,
                     )
-                except Audit.DoesNotExist:
-                    pass
 
                 return redirect(reverse("audit:SubmissionProgress", args=[report_id]))
 

--- a/backend/audit/views/unlock_after_certification.py
+++ b/backend/audit/views/unlock_after_certification.py
@@ -40,6 +40,7 @@ class UnlockAfterCertificationView(
         report_id = kwargs["report_id"]
 
         try:
+            # SOT TODO: Needs to use `audit`
             sac = SingleAuditChecklist.objects.get(report_id=report_id)
             target_statuses = [
                 STATUS.READY_FOR_CERTIFICATION,
@@ -73,13 +74,16 @@ class UnlockAfterCertificationView(
         report_id = kwargs["report_id"]
 
         try:
+            # SOT TODO: Needs to use `audit`
             sac = SingleAuditChecklist.objects.get(report_id=report_id)
+            audit = Audit.objects.find_audit_or_none(report_id=report_id)
+
             form = UnlockAfterCertificationForm(request.POST or None)
             acceptable = ("True", True)
             should_go_to_in_progress = (
                 form.data.get("unlock_after_certification") in acceptable
             )
-            audit = Audit.objects.find_audit_or_none(report_id=report_id)
+
             if form.is_valid() and should_go_to_in_progress:
                 if sac_transition(
                     request, sac, audit=audit, transition_to=STATUS.IN_PROGRESS

--- a/backend/dissemination/urls.py
+++ b/backend/dissemination/urls.py
@@ -41,5 +41,6 @@ urlpatterns = [
     path("search/", views.Search.as_view(), name="Search"),
     path("search/advanced/", views.AdvancedSearch.as_view(), name="AdvancedSearch"),
     path("summary/<str:report_id>", views.AuditSummaryView.as_view(), name="Summary"),
-    path("search/beta/", views.AuditSearch.as_view(), name="BetaSearch"),
+    # TODO SOT: Enable for testing
+    # path("search/beta/", views.AuditSearch.as_view(), name="BetaSearch"),
 ]

--- a/backend/dissemination/views/download.py
+++ b/backend/dissemination/views/download.py
@@ -43,7 +43,10 @@ class PdfDownloadView(ReportAccessRequiredMixin, View):
         # TODO: Update Post SOC Launch
         get_object_or_404(General, report_id=report_id)
 
-        use_audit = request.GET.get("beta", "N") == "Y"
+        # TODO SOT: Enable for testing
+        # use_audit = request.GET.get("beta", "N") == "Y"
+        use_audit = False
+
         if use_audit:
             get_object_or_404(
                 Audit, report_id=report_id, submission_status=STATUS.DISSEMINATED
@@ -69,7 +72,10 @@ class XlsxDownloadView(ReportAccessRequiredMixin, View):
         # get_object_or_404(Audit, report_id=report_id, submission_status=STATUS.DISSEMINATED)
         get_object_or_404(General, report_id=report_id)
 
-        use_audit = request.GET.get("beta", "N") == "Y"
+        # TODO SOT: Enable for testing
+        # use_audit = request.GET.get("beta", "N") == "Y"
+        use_audit = False
+
         if use_audit:
             get_object_or_404(
                 Audit, report_id=report_id, submission_status=STATUS.DISSEMINATED
@@ -122,7 +128,10 @@ class OneTimeAccessDownloadView(View):
             ota = OneTimeAccess.objects.get(uuid=uuid)
 
             # get the filename for the SingleAuditReport for this SAC
-            use_audit = request.GET.get("beta", "N") == "Y"
+            # TODO SOT: Enable for testing
+            # use_audit = request.GET.get("beta", "N") == "Y"
+            use_audit = False
+
             filename = (
                 get_filename_from_audit(ota.report_id, "report")
                 if use_audit
@@ -143,12 +152,16 @@ class OneTimeAccessDownloadView(View):
 
 
 class SingleSummaryReportDownloadView(View):
+
     def get(self, request, report_id):
         """
         Given a report_id in the URL, generate the summary report in S3 and
         redirect to its download link.
         """
-        use_audit = request.GET.get("beta", "N") == "Y"
+        # TODO SOT: Enable for testing
+        # use_audit = request.GET.get("beta", "N") == "Y"
+        use_audit = False
+
         if use_audit:
             get_object_or_404(Audit, report_id=report_id)
         else:
@@ -180,7 +193,10 @@ class MultipleSummaryReportDownloadView(View):
         4. Redirect to the download url of this new report
         """
         form = AdvancedSearchForm(request.POST)
-        use_audit = request.GET.get("beta", "N") == "Y"
+        # TODO SOT: Enable for testing
+        # use_audit = request.GET.get("beta", "N") == "Y"
+        use_audit = False
+
         try:
             if form.is_valid():
                 form_data = form.cleaned_data

--- a/backend/report_submission/templates/report_submission/upload-page.html
+++ b/backend/report_submission/templates/report_submission/upload-page.html
@@ -3,9 +3,12 @@
 {% block content %}
     <div class="grid-container margin-top-6">
         <div class="grid-row">
+            {% comment %}
             {% if is_beta %}
+              <!-- # TODO SOT: Enable for testing -->
               {% include "includes/beta_warning.html" %}
             {% endif %}
+            {% endcomment %}
             {% comment %} {% include "../sidenav.html" %} {% endcomment %}
             <form class="tablet:grid-col-8 tablet:grid-offset-2"
                   id="{{ view_id }}"

--- a/backend/report_submission/views/file_views.py
+++ b/backend/report_submission/views/file_views.py
@@ -28,14 +28,16 @@ class UploadPageView(SingleAuditChecklistAccessRequiredMixin, View):
     def get(self, request, *args, **kwargs):
         report_id = kwargs["report_id"]
 
-        if request.GET.get("beta", "N") == "Y":
-            return _handle_sot_beta_upload_get(request, *args, **kwargs)
+        # SOT TODO: Enable for testing
+        # if request.GET.get("beta", "N") == "Y":
+        #     return _handle_sot_beta_upload_get(request, *args, **kwargs)
 
         # Organized by URL name, page specific constants are defined here
         # Data can then be accessed by checking the current URL
         additional_context = create_upload_context(report_id)
 
         try:
+            # TODO SOT: Update for `audit`
             sac = SingleAuditChecklist.objects.get(report_id=report_id)
 
             # Context for every upload page
@@ -55,33 +57,30 @@ class UploadPageView(SingleAuditChecklistAccessRequiredMixin, View):
                     sac, additional_context[path_name]["DB_id"]
                 )
 
-                # DANGER
-                # If this was created before SOT, we could be in a situation where there is a SAC
-                # but no SOT. So, we should *try* and do a `get()`, and if nothing is there,
-                # handle it gracefully.
-                try:
-                    audit = Audit.objects.get(report_id=report_id)
-                except Audit.DoesNotExist:
-                    audit = None
-
                 shaped_sac = sac_validation_shape(sac)
 
+                audit = Audit.objects.find_audit_or_none(report_id=report_id)
                 if audit:
                     shaped_audit = audit_validation_shape(audit)
                     _compare_shapes(shaped_sac, shaped_audit)
                 else:
                     logger.debug("A SOT does not yet exist for this SAC.\n")
 
-                completed_metadata = section_completed_metadata(shaped_sac, path_name)
-                completed_audit_audit = section_completed_metadata(
+                # This tuple can come back as None, None, which is fine.
+                uploaded_by, uploaded_at = section_completed_metadata(
                     shaped_sac, path_name
                 )
 
-                # LESS DANGER
-                _compare_completed_metadata(completed_metadata, completed_audit_audit)
+                # SOT TODO: This needs to be changed/improved
+                # for the migration to SOT. I think it wants to operate on the
+                # shaped_audit, but we don't need it now/here.
+                # completed_audit_audit = section_completed_metadata(
+                #     shaped_sac, path_name
+                # )
+                # _compare_completed_metadata(completed_metadata, completed_audit_audit)
 
-                context["last_uploaded_by"] = completed_metadata[0]
-                context["last_uploaded_at"] = completed_metadata[1]
+                context["last_uploaded_by"] = uploaded_by
+                context["last_uploaded_at"] = uploaded_at
             except Exception:
                 context["already_submitted"] = None
 
@@ -96,10 +95,13 @@ class UploadPageView(SingleAuditChecklistAccessRequiredMixin, View):
             return Util.validate_redirect_url(
                 "/audit/submission-progress/{report_id}".format(report_id=report_id)
             )
-
         except Exception as e:
-            logger.info("Unexpected error in UploadPageView post.\n", e)
+            logger.error("Unexpected error in UploadPageView post.\n", e)
 
+        # FIXME: This feels like a fragile control pathway.
+        # At the moment, you should ALWAYS return OR throw an exception.
+        # But, the future could change this. Therefore, what happens outside of
+        # the `except` could matter.
         raise BadRequest()
 
 
@@ -131,15 +133,16 @@ class DeleteFileView(SingleAuditChecklistAccessRequiredMixin, View):
             raise PermissionDenied("You do not have access to this audit.")
 
     def post(self, request, *args, **kwargs):
-        # TODO: Post SOT Launch -> Remove SAC / SubmissionEvent
+        # SOT TODO: Post SOT Launch -> Remove SAC / SubmissionEvent
         report_id = kwargs["report_id"]
         path_name = request.path.split("/")[2]
         section = self.additional_context[path_name]
         redirect_uri = f"/report_submission/{section['view_id']}/{report_id}"
         try:
-            audit = Audit.objects.find_audit_or_none(report_id=report_id)
             sac = SingleAuditChecklist.objects.get(report_id=report_id)
             accesses = Access.objects.filter(sac=sac, user=request.user)
+
+            audit = Audit.objects.find_audit_or_none(report_id=report_id)
             # accesses = Access.objects.filter(audit=audit, user=request.user)
 
             if not accesses:
@@ -162,18 +165,24 @@ class DeleteFileView(SingleAuditChecklistAccessRequiredMixin, View):
                         event_type=section["event_type"],
                         event_user=request.user,
                     )
-
             except ExcelFile.DoesNotExist:
                 messages.error(request, "File not found.")
                 return Util.validate_redirect_url(redirect_uri)
 
+            # SOT TODO: Switch to `audit`. Also, this should generate a
+            # History event, as opposed to a SubmissionEvent
             SubmissionEvent.objects.create(
                 sac_id=sac.id,
+                # SOT TODO: audit MUST exist at this point, but we're not
+                # connecting it up *yet* because we have never tested adding in
+                # this relationship. In theory, it is safe. Or, perhaps it is
+                # not needed, because we won't be keeping SubmissionEvents post-SOT.
+                # audit_id=audit.id if audit else None,
                 user=request.user,
                 event=section["event_type"],
             )
 
-            logger.info("The file has been successfully deleted.")
+            logger.info("The file(s) has been successfully deleted.")
             return Util.validate_redirect_url(
                 f"/audit/submission-progress/{sac.report_id}"
             )


### PR DESCRIPTION
We are setting up the PR and bringing this through to `main` in order to see it test/auto-deploy to `staging`.

It covers a few major/minor changes:

1. We go through every code pathway and make sure that the SOT/`audit` table is not being missed/incorrectly referenced. We had two cases in the past two weeks, and we do not think we found any more.
2. We nested `_compare_errors()` for validation against SOT and SAC, because there were many cases where we were logging errors when the `audit` did not exist.
3. Disable the cross-validation check for prior reference numbers. This is because we have some cases where an entity may have a new UEI, and we do not have a way to connect the new UEI to the old. Or, we would need a new waiver. We are working under time constraints that make either of these solutions difficult/impossible at this time. The better path is *probably* a waiver.
4. Many logging changes from `warn` to `error` (in the case of unhandled/unlikely exceptions), and a number of downgrades to `debug` for `info` messages that have been running for 18+ months (and clearly are not problematic or info-worthy.)
5. Changed several strings to constants, mostly using `AccessRoles`.
6. Disabled the `/beta` pathways until we are ready to bring in SOT2 and test more.

The end result should be:

1. Quieter/more appropriate logs.
2. No additional errors in referencing `audit` until we are ready.
3. Eliminating a blocker for some submitters (the cross-val)
