### PR TITLE
Terraform network provider update

### DIFF
--- a/terraform/shared/modules/env/policies.tf
+++ b/terraform/shared/modules/env/policies.tf
@@ -44,7 +44,6 @@ resource "cloudfoundry_network_policy" "app-network-policy" {
 }
 
 resource "cloudfoundry_network_policy" "scanner-network-policy" {
-
   policies = [
     {
       source_app      = module.fac-file-scanner.app_id

--- a/terraform/shared/modules/env/policies.tf
+++ b/terraform/shared/modules/env/policies.tf
@@ -4,65 +4,70 @@
 # these may continue to be used until the provider adds this functionality, in which case, should be
 # upgraded as soon as possible.
 resource "cloudfoundry_network_policy" "clamav-network-policy" {
-  provider = cloudfoundry-community
-  policy {
-    source_app      = module.clamav.app_id
-    destination_app = module.https-proxy.app_id
-    port            = "61443"
-    protocol        = "tcp"
-  }
-  policy {
-    source_app      = module.file_scanner_clamav.app_id
-    destination_app = module.https-proxy.app_id
-    port            = "61443"
-    protocol        = "tcp"
-  }
+  policies = [
+    {
+      source_app      = module.clamav.app_id
+      destination_app = module.https-proxy.app_id
+      port            = "61443"
+      protocol        = "tcp"
+    },
+    {
+      source_app      = module.file_scanner_clamav.app_id
+      destination_app = module.https-proxy.app_id
+      port            = "61443"
+      protocol        = "tcp"
+    }
+  ]
 }
 
 resource "cloudfoundry_network_policy" "app-network-policy" {
-  provider = cloudfoundry-community
-  policy {
-    source_app      = data.cloudfoundry_app.fac-app.id
-    destination_app = module.clamav.app_id
-    port            = "61443"
-    protocol        = "tcp"
-  }
-  policy {
-    source_app      = data.cloudfoundry_app.fac-app.id
-    destination_app = module.https-proxy.app_id
-    port            = "61443"
-    protocol        = "tcp"
-  }
-  policy {
-    source_app      = data.cloudfoundry_app.fac-file-scanner.id
-    destination_app = module.clamav.app_id
-    port            = "61443"
-    protocol        = "tcp"
-  }
+  policies = [
+    {
+      source_app      = data.cloudfoundry_app.fac-app.id
+      destination_app = module.clamav.app_id
+      port            = "61443"
+      protocol        = "tcp"
+    },
+    {
+      source_app      = data.cloudfoundry_app.fac-app.id
+      destination_app = module.https-proxy.app_id
+      port            = "61443"
+      protocol        = "tcp"
+    },
+    {
+      source_app      = data.cloudfoundry_app.fac-file-scanner.id
+      destination_app = module.clamav.app_id
+      port            = "61443"
+      protocol        = "tcp"
+    }
+  ]
 }
 
 resource "cloudfoundry_network_policy" "scanner-network-policy" {
-  provider = cloudfoundry-community
-  policy {
-    source_app      = module.fac-file-scanner.app_id
-    destination_app = module.https-proxy.app_id
-    port            = "61443"
-    protocol        = "tcp"
-  }
-  policy {
-    source_app      = module.fac-file-scanner.app_id
-    destination_app = module.file_scanner_clamav.app_id
-    port            = "61443"
-    protocol        = "tcp"
-  }
+
+  policies = [
+    {
+      source_app      = module.fac-file-scanner.app_id
+      destination_app = module.https-proxy.app_id
+      port            = "61443"
+      protocol        = "tcp"
+    },
+    {
+      source_app      = module.fac-file-scanner.app_id
+      destination_app = module.file_scanner_clamav.app_id
+      port            = "61443"
+      protocol        = "tcp"
+    }
+  ]
 }
 
 resource "cloudfoundry_network_policy" "logshipper-network-policy" {
-  provider = cloudfoundry-community
-  policy {
-    source_app      = module.cg-logshipper.app_id
-    destination_app = module.https-proxy.app_id
-    port            = "61443"
-    protocol        = "tcp"
-  }
+  policies = [
+    {
+      source_app      = module.cg-logshipper.app_id
+      destination_app = module.https-proxy.app_id
+      port            = "61443"
+      protocol        = "tcp"
+    }
+  ]
 }

--- a/terraform/shared/modules/sandbox/policies.tf
+++ b/terraform/shared/modules/sandbox/policies.tf
@@ -4,61 +4,64 @@
 # these may continue to be used until the provider adds this functionality, in which case, should be
 # upgraded as soon as possible.
 resource "cloudfoundry_network_policy" "app-network-policy" {
-  provider = cloudfoundry-community
-
-  policy {
-    source_app      = module.fac-app.app_id
-    destination_app = module.https-proxy.app_id
-    port            = "61443"
-    protocol        = "tcp"
-  }
-  policy {
-    source_app      = module.fac-app.app_id
-    destination_app = module.clamav.app_id
-    port            = "61443"
-    protocol        = "tcp"
-  }
+  policies = [
+    {
+      source_app      = module.fac-app.app_id
+      destination_app = module.https-proxy.app_id
+      port            = "61443"
+      protocol        = "tcp"
+    },
+    {
+      source_app      = module.fac-app.app_id
+      destination_app = module.clamav.app_id
+      port            = "61443"
+      protocol        = "tcp"
+    }
+  ]
 }
 
 resource "cloudfoundry_network_policy" "clamav-network-policy" {
-  provider = cloudfoundry-community
-  policy {
-    source_app      = module.clamav.app_id
-    destination_app = module.https-proxy.app_id
-    port            = "61443"
-    protocol        = "tcp"
-  }
-
-  policy {
-    source_app      = module.file_scanner_clamav.app_id
-    destination_app = module.https-proxy.app_id
-    port            = "61443"
-    protocol        = "tcp"
-  }
+  policies = [
+    {
+      source_app      = module.clamav.app_id
+      destination_app = module.https-proxy.app_id
+      port            = "61443"
+      protocol        = "tcp"
+    },
+    {
+      source_app      = module.file_scanner_clamav.app_id
+      destination_app = module.https-proxy.app_id
+      port            = "61443"
+      protocol        = "tcp"
+    }
+  ]
 }
 
 resource "cloudfoundry_network_policy" "logshipper-network-policy" {
-  provider = cloudfoundry-community
-  policy {
-    source_app      = module.logshipper.app_id
-    destination_app = module.https-proxy.app_id
-    port            = "61443"
-    protocol        = "tcp"
-  }
+  policies = [
+    {
+      source_app      = module.logshipper.app_id
+      destination_app = module.https-proxy.app_id
+      port            = "61443"
+      protocol        = "tcp"
+    }
+  ]
 }
 
+
 resource "cloudfoundry_network_policy" "scanner-network-policy" {
-  provider = cloudfoundry-community
-  policy {
-    source_app      = module.fac-file-scanner.app_id
-    destination_app = module.https-proxy.app_id
-    port            = "61443"
-    protocol        = "tcp"
-  }
-  policy {
-    source_app      = module.fac-file-scanner.app_id
-    destination_app = module.file_scanner_clamav.app_id
-    port            = "61443"
-    protocol        = "tcp"
-  }
+  policies = [
+    {
+      source_app      = module.fac-file-scanner.app_id
+      destination_app = module.https-proxy.app_id
+      port            = "61443"
+      protocol        = "tcp"
+    },
+    {
+      source_app      = module.fac-file-scanner.app_id
+      destination_app = module.file_scanner_clamav.app_id
+      port            = "61443"
+      protocol        = "tcp"
+    }
+  ]
 }


### PR DESCRIPTION
resolves #4837 

Changes:
Updates the network policies to use provider 1.6.0 code, removing the community provider and using the new format of:
```tf
resource "cloudfoundry_network_policy" "policy" {
  policies = [
    { 1 },
    { 2 },
    { N }
  ]
}
```

No state file changes necessary. Plan only `~updates in place` the existing policies in `policies.tf`
- [x] Clean sandbox deployment
- [x] Clean [preview](https://github.com/GSA-TTS/FAC/actions/runs/15468142275/job/43545182076) deployment