### PR TITLE
Adding request_file_access to v1.1.0, v1.2.0

### DIFF
--- a/backend/dissemination/api/api_v1_1_0/create_functions.sql
+++ b/backend/dissemination/api/api_v1_1_0/create_functions.sql
@@ -32,28 +32,74 @@ begin
 end;
 $gaku$ LANGUAGE plpgsql;
 
-create or replace function api_v1_1_0_functions.has_tribal_data_access() 
+create or replace function api_v1_1_0_functions.has_tribal_data_access()
 returns boolean
 as $has_tribal_data_access$
-DECLARE 
+DECLARE
     uuid_header UUID;
     key_exists boolean;
 BEGIN
 
     SELECT api_v1_1_0_functions.get_api_key_uuid() INTO uuid_header;
-    SELECT 
+    SELECT
         CASE WHEN EXISTS (
-            SELECT key_id 
+            SELECT key_id
             FROM public.dissemination_TribalApiAccessKeyIds taaki
             WHERE taaki.key_id = uuid_header::TEXT)
             THEN 1::BOOLEAN
             ELSE 0::BOOLEAN
-            END 
+            END
         INTO key_exists;
     RAISE INFO 'api_v1_1_0 has_tribal % %', uuid_header, key_exists;
     RETURN key_exists;
 END;
 $has_tribal_data_access$ LANGUAGE plpgsql;
 
+CREATE OR REPLACE FUNCTION api_v1_1_0.request_file_access(
+    report_id TEXT
+) RETURNS JSON LANGUAGE plpgsql AS
+$$
+DECLARE
+    v_uuid_header TEXT;
+    v_access_uuid VARCHAR(200);
+    v_key_exists BOOLEAN;
+    v_key_added_date DATE;
+BEGIN
+
+    SELECT api_v1_1_0_functions.get_api_key_uuid() INTO v_uuid_header;
+
+    -- Check if the provided API key exists in public.dissemination_TribalApiAccessKeyIds
+    SELECT
+        EXISTS(
+            SELECT 1
+            FROM public.dissemination_TribalApiAccessKeyIds
+            WHERE key_id = v_uuid_header
+        ) INTO v_key_exists;
+
+
+    -- Get the added date of the key from public.dissemination_TribalApiAccessKeyIds
+    SELECT date_added
+    INTO v_key_added_date
+    FROM public.dissemination_TribalApiAccessKeyIds
+    WHERE key_id = v_uuid_header;
+
+
+    -- Check if the key is less than 6 months old
+    IF v_uuid_header IS NOT NULL AND v_key_exists AND v_key_added_date >= CURRENT_DATE - INTERVAL '6 months' THEN
+        -- Generate UUID (using PostgreSQL's gen_random_uuid function)
+        SELECT gen_random_uuid() INTO v_access_uuid;
+
+        -- Inserting data into the one_time_access table
+        INSERT INTO public.dissemination_onetimeaccess (uuid, api_key_id, timestamp, report_id)
+        VALUES (v_access_uuid::UUID, v_uuid_header, CURRENT_TIMESTAMP, report_id);
+
+        -- Return the UUID to the user
+        RETURN json_build_object('access_uuid', v_access_uuid);
+    ELSE
+        -- Return an error for unauthorized access
+        RETURN json_build_object('error', 'Unauthorized access or key older than 6 months')::JSON;
+    END IF;
+END;
+$$;
 
 NOTIFY pgrst, 'reload schema';

--- a/backend/dissemination/api/api_v1_2_0/create_functions.sql
+++ b/backend/dissemination/api/api_v1_2_0/create_functions.sql
@@ -32,28 +32,74 @@ begin
 end;
 $gaku$ LANGUAGE plpgsql;
 
-create or replace function api_v1_2_0_functions.has_tribal_data_access() 
+create or replace function api_v1_2_0_functions.has_tribal_data_access()
 returns boolean
 as $has_tribal_data_access$
-DECLARE 
+DECLARE
     uuid_header UUID;
     key_exists boolean;
 BEGIN
 
     SELECT api_v1_2_0_functions.get_api_key_uuid() INTO uuid_header;
-    SELECT 
+    SELECT
         CASE WHEN EXISTS (
-            SELECT key_id 
+            SELECT key_id
             FROM public.dissemination_TribalApiAccessKeyIds taaki
             WHERE taaki.key_id = uuid_header::TEXT)
             THEN 1::BOOLEAN
             ELSE 0::BOOLEAN
-            END 
+            END
         INTO key_exists;
     RAISE INFO 'api_v1_2_0 has_tribal % %', uuid_header, key_exists;
     RETURN key_exists;
 END;
 $has_tribal_data_access$ LANGUAGE plpgsql;
 
+CREATE OR REPLACE FUNCTION api_v1_2_0.request_file_access(
+    report_id TEXT
+) RETURNS JSON LANGUAGE plpgsql AS
+$$
+DECLARE
+    v_uuid_header TEXT;
+    v_access_uuid VARCHAR(200);
+    v_key_exists BOOLEAN;
+    v_key_added_date DATE;
+BEGIN
+
+    SELECT api_v1_2_0_functions.get_api_key_uuid() INTO v_uuid_header;
+
+    -- Check if the provided API key exists in public.dissemination_TribalApiAccessKeyIds
+    SELECT
+        EXISTS(
+            SELECT 1
+            FROM public.dissemination_TribalApiAccessKeyIds
+            WHERE key_id = v_uuid_header
+        ) INTO v_key_exists;
+
+
+    -- Get the added date of the key from public.dissemination_TribalApiAccessKeyIds
+    SELECT date_added
+    INTO v_key_added_date
+    FROM public.dissemination_TribalApiAccessKeyIds
+    WHERE key_id = v_uuid_header;
+
+
+    -- Check if the key is less than 6 months old
+    IF v_uuid_header IS NOT NULL AND v_key_exists AND v_key_added_date >= CURRENT_DATE - INTERVAL '6 months' THEN
+        -- Generate UUID (using PostgreSQL's gen_random_uuid function)
+        SELECT gen_random_uuid() INTO v_access_uuid;
+
+        -- Inserting data into the one_time_access table
+        INSERT INTO public.dissemination_onetimeaccess (uuid, api_key_id, timestamp, report_id)
+        VALUES (v_access_uuid::UUID, v_uuid_header, CURRENT_TIMESTAMP, report_id);
+
+        -- Return the UUID to the user
+        RETURN json_build_object('access_uuid', v_access_uuid);
+    ELSE
+        -- Return an error for unauthorized access
+        RETURN json_build_object('error', 'Unauthorized access or key older than 6 months')::JSON;
+    END IF;
+END;
+$$;
 
 NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
Closes https://github.com/GSA-TTS/FAC/issues/5060

In this PR:
- Adding the `request_file_access` function to API v1.1.0 and v1.2.0. It already exists on v1.1.1, but that version is inactive.

Testing:
- On this branch, `make docker-first-run && docker compose up`
- Make yourself a super user
  - `docker compose exec web /bin/bash`
  - `python manage.py make_super fac-gov-test-users+pdominguez@gsa.gov`
- In Django admin, create a tribal api access key. You're gonna need a user UUID to test with. You can use your own, or use the UUID/email `CYPRESS_API_GOV_USER_ID` from [here](https://docs.google.com/spreadsheets/d/1byrBp16jufbiEY_GP5MyR0Uqf6WvB_5tubSXN_mYyJY/edit?gid=0#gid=0)
- Testing in Postman
  - Make a POST request to http://localhost:3000/rpc/request_file_access
  - Headers
    - `Authorization`: Use whatever `CYPRESS_API_GOV_JWT` value you normally use for Cypress tests. This value should look like `Bearer blahblahblah`.
    - `X-Api-User-Id`: This is the user UUID from before
    - `Content-Type`: `application/json`
    - `Content-Profile`: Try out both `api_v1_1_0` and `api_v1_2_0` for this
  - Body: `{"report_id": "FOO-REPORT-ID"}`
    - There don't appear to be checks for legit `report_id`s 🤷‍♂️ 
  - Response: `{"access_uuid": "<A new access UUID>"}`
- Testing in Python
  - Adding this here because we are trying to fix the instructions found in `tribal.md` so they actually work
  - Output should be the same as the `Response` above
```python
import json
import requests

def request_file_access(report_id, api_key):
    url = 'http://localhost:3000/rpc/request_file_access'
    headers = {
        'Authorization': 'Bearer <Your JWT>'
        'X-Api-User-Id':<Your user UIUD>,
        'Content-Type': 'application/json',
        'Content-Profile': '<api_v1_1_0 or api_v1_2_0>',
    }
    payload = json.dumps({ "report_id": report_id })

    response = requests.post(url, headers=headers, data=payload)
    if response.status_code == 200:
        return response.json()
    else:
        print("Error requesting file access:", response.status_code, response.text)
        return None

if __name__ == "__main__":
    print(request_file_access("FOO-REPORT-ID", "<Your UUID>"))
```

## PR Checklist: Submitter

- [ ]   Link to an issue if possible. If there’s no issue, describe what your branch does. Even if there is an issue, a brief description in the PR is still useful.
- [ ]   List any special steps reviewers have to follow to test the PR. For example, adding a local environment variable, creating a local test file, etc.
- [ ]   For extra credit, submit a screen recording like [this one](https://github.com/GSA-TTS/FAC/pull/1821).
- [ ]   Make sure you’ve merged `main` into your branch shortly before creating the PR. (You should also be merging `main` into your branch regularly during development.)
- [ ]   Make sure you’ve accounted for any migrations. When you’re about to create the PR, bring up the application locally and then run `git status | grep migrations`. If there are any results, you probably need to add them to the branch for the PR. Your PR should have only **one** new migration file for each of the component apps, except in rare circumstances; you may need to delete some and re-run `python manage.py makemigrations` to reduce the number to one. (Also, unless in exceptional circumstances, your PR should not delete any migration files.)
- [ ]   Make sure that whatever feature you’re adding has tests that cover the feature. This includes test coverage to make sure that the previous workflow still works, if applicable.
- [ ]   Make sure the full-submission.cy.js [Cypress test](https://github.com/GSA-TTS/FAC/blob/main/docs/testing.md#end-to-end-testing) passes, if applicable.
- [ ]   Do manual testing locally. Our tests are not good enough yet to allow us to skip this step. If that’s not applicable for some reason, check this box.
- [ ]   Verify that no Git surgery was necessary, or, if it was necessary at any point, repeat the testing after it’s finished.
- [ ]   Once a PR is merged, keep an eye on it until it’s deployed to dev, and do enough testing on dev to verify that it deployed successfully, the feature works as expected, and the happy path for the broad feature area (such as submission) still works.
- [ ]   Ensure that prior to merging, the working branch is up to date with main and the terraform plan is what you expect.

## PR Checklist: Reviewer

- [ ]   Pull the branch to your local environment and run `make docker-clean; make docker-first-run && docker compose up`; then run `docker compose exec web /bin/bash -c "python manage.py test"`
- [ ]   Manually test out the changes locally, or check this box to verify that it wasn’t applicable in this case.
- [ ]   Check that the PR has appropriate tests. Look out for changes in HTML/JS/JSON Schema logic that may need to be captured in Python tests even though the logic isn’t in Python.
- [ ]   Verify that no Git surgery is necessary at any point (such as during a merge party), or, if it was, repeat the testing after it’s finished.

The larger the PR, the stricter we should be about these points.

## Pre Merge Checklist: Merger

- [ ]   Ensure that prior to approving, the terraform plan is what we expect it to be. `-/+ resource "null_resource" "cors_header" ` should be destroying and recreating its self and ` ~ resource "cloudfoundry_app" "clamav_api" ` might be updating its `sha256` for the `fac-file-scanner` and `fac-av-${ENV}` by default.
- [ ]   Ensure that the branch is up to date with `main`.
- [ ]   Ensure that a terraform plan has been recently generated for the pull request.
