### PR TITLE
Update proxy allow list

### DIFF
--- a/terraform/shared/modules/env/https-proxy.tf
+++ b/terraform/shared/modules/env/https-proxy.tf
@@ -14,10 +14,11 @@ module "https-proxy" {
     "${var.cf_org_name}-${var.cf_space.name}-egress-https-proxy.apps.internal",
     "idp.int.identitysandbox.gov:443",
     "secure.login.gov:443",
-    "*.github.com:443",
-    "objects.githubusercontent.com:443",
     "awscli.amazonaws.com:443",
-    "database.clamav.net:443"
+    "database.clamav.net:443",
+    "*.github.com:443",
+    "release-assets.githubusercontent.com:443",
+    "objects.githubusercontent.com:443"
   ]
 }
 

--- a/terraform/shared/modules/sandbox/https-proxy.tf
+++ b/terraform/shared/modules/sandbox/https-proxy.tf
@@ -13,9 +13,11 @@ module "https-proxy" {
     "${var.cf_org_name}-${var.cf_space.name}-egress-https-proxy.apps.internal",
     "idp.int.identitysandbox.gov:443",
     "secure.login.gov:443",
-    "objects.githubusercontent.com:443",
     "awscli.amazonaws.com:443",
-    "database.clamav.net:443"
+    "database.clamav.net:443",
+    "*.github.com:443",
+    "objects.githubusercontent.com:443",
+    "release-assets.githubusercontent.com:443"
   ]
 }
 


### PR DESCRIPTION
After noticing multiple failures on our cron jobs our proxy seems to be blocking a necessary endpoint/redirect for github content. Due to this, it was returning a 403 on the initial curl when attempting to get the necessary release binaries for the cron to run. Prior to this, `objects.githubusercontent.com:443` was enough to allow traffic to get said artifacts, and now, `release-assets.githubusercontent.com:443` seems to be a new redirect that it favors. Sporadically when running the job enough, it will go through, so presumably `objects.githubusercontent.com` has now become a secondary redirect.