### PR TITLE
fix(ui): Eliminate ORIGINAL status from resubmission chains #5205

### DIFF
--- a/backend/audit/check_resubmission_allowed.py
+++ b/backend/audit/check_resubmission_allowed.py
@@ -69,9 +69,9 @@ def check_resubmission_allowed(
             "Audit record is incomplete and cannot be evaluated for resubmission.",
         )
 
-    # ORIGINAL_SUBMISSION + version 1 can be resubmitted or MOST_RECENT + version > 1 can be resubmitted
-    if resub_status in [RESUBMISSION_STATUS.ORIGINAL, RESUBMISSION_STATUS.MOST_RECENT]:
-        if (resub_status == RESUBMISSION_STATUS.ORIGINAL and version == 1) or (
+    # MOST_RECENT + version > 1 can be resubmitted
+    if resub_status in [RESUBMISSION_STATUS.MOST_RECENT]:
+        if (
             resub_status == RESUBMISSION_STATUS.MOST_RECENT and version > 1
         ):
             return True, "Audit is eligible for resubmission."

--- a/backend/audit/intake_to_dissemination.py
+++ b/backend/audit/intake_to_dissemination.py
@@ -305,8 +305,6 @@ class IntakeToDissemination(object):
             return RESUBMISSION_STATUS.DEPRECATED
         elif resubmission_version > 1:
             return RESUBMISSION_STATUS.MOST_RECENT
-        elif resubmission_version == 1:
-            return RESUBMISSION_STATUS.ORIGINAL
         elif resubmission_version == 0:
             return RESUBMISSION_STATUS.UNKNOWN
         else:
@@ -538,7 +536,6 @@ class IntakeToDissemination(object):
         if not resubmission_meta:
             resubmission_meta = {
                 "version": 1,
-                "resubmission_status": RESUBMISSION_STATUS.ORIGINAL,
             }
 
         resubmission_version = resubmission_meta.get("version", 1)

--- a/backend/audit/models/constants.py
+++ b/backend/audit/models/constants.py
@@ -46,14 +46,12 @@ STATUS_CHOICES = (
 
 
 class RESUBMISSION_STATUS:
-    ORIGINAL = "original_submission"
     MOST_RECENT = "most_recent"
     DEPRECATED = "deprecated_via_resubmission"
     UNKNOWN = "unknown_resubmission_status"
 
 
 RESUBMISSION_STATUS_CHOICES = (
-    (RESUBMISSION_STATUS.ORIGINAL, "Original Submission"),
     (RESUBMISSION_STATUS.MOST_RECENT, "Most Recent"),
     (RESUBMISSION_STATUS.DEPRECATED, "Deprecated via Resubmission"),
 )

--- a/backend/audit/test_check_resubmission.py
+++ b/backend/audit/test_check_resubmission.py
@@ -83,16 +83,6 @@ class TestCheckResubmissionAllowed(TestCase):
         self.assertFalse(allowed)
         self.assertIn("deprecated", message.lower())
 
-    def test_original_submission_v1_allowed(self):
-        sac = create_sac(
-            version=1,
-            meta={"resubmission_status": RESUBMISSION_STATUS.ORIGINAL},
-            status=STATUS.DISSEMINATED,
-        )
-        allowed, message = check_resubmission_allowed(sac)
-        self.assertTrue(allowed)
-        self.assertIn("eligible", message.lower())
-
     def test_most_recent_v2_allowed(self):
         sac = create_sac(
             version=2,

--- a/backend/dissemination/models/combined.py
+++ b/backend/dissemination/models/combined.py
@@ -113,7 +113,7 @@ class DisseminationCombined(models.Model):
         null=True,
     )
     resubmission_status = models.TextField(
-        "Resubmission Status (Original, Deprecated, Resubmission)",
+        "Resubmission Status (Deprecated, Resubmission)",
         # help_text=docs.resubmission_status,  # "The resubmission status of this record. Displays whether it is a singular original, a resubmission, or a previous version."
         null=True,
     )

--- a/backend/dissemination/test_search_resub_tags.py
+++ b/backend/dissemination/test_search_resub_tags.py
@@ -27,13 +27,6 @@ class ResubmissionTagTests(TestCase):
         tag_map = build_resub_tag_map([row])
         self.assertEqual(tag_map["1002"], "Resubmitted")
 
-    def test_original_should_not_tag(self):
-        row = baker.make(
-            General, report_id="1003", resubmission_status=RESUBMISSION_STATUS.ORIGINAL
-        )
-        tag_map = build_resub_tag_map([row])
-        self.assertNotIn("1003", tag_map)
-
     def test_missing_status_should_not_tag(self):
         row = baker.make(General, report_id="1004", resubmission_status=None)
         tag_map = build_resub_tag_map([row])
@@ -51,7 +44,7 @@ class ResubmissionTagTests(TestCase):
             resubmission_status=RESUBMISSION_STATUS.MOST_RECENT,
         )
         row2 = baker.make(
-            General, report_id="1007", resubmission_status=RESUBMISSION_STATUS.ORIGINAL
+            General, report_id="1007", resubmission_status=RESUBMISSION_STATUS.DEPRECATED
         )
         rows = [row1, row2]
 


### PR DESCRIPTION
http://github.com/GSA-TTS/FAC/issues/5205

### Summary:
- Remove the constant. Find everything that breaks. Make sure we don't use the ORIGINAL status, and instead flag new submissions going forward as MOST_RECENT. This should remove one status, but not generally break our design.

These are the three statuses we will continue to have:

MOST_RECENT
DEPRECATED_VIA_RESUBMISSION
UNKNOWN
and UNKNOWN will come to be if we run a whole-DB curation action (e.g. building linkages and then tagging the unknowns that remain)

Logic: 
- 

### Changes:
-

### Unit Testing: 
-
  
### Local Testing: 
- 

## PR Checklist: Submitter

- [ ]   Link to an issue if possible. If there’s no issue, describe what your branch does. Even if there is an issue, a brief description in the PR is still useful.
- [ ]   List any special steps reviewers have to follow to test the PR. For example, adding a local environment variable, creating a local test file, etc.
- [ ]   For extra credit, submit a screen recording like [this one](https://github.com/GSA-TTS/FAC/pull/1821).
- [ ]   Make sure you’ve merged `main` into your branch shortly before creating the PR. (You should also be merging `main` into your branch regularly during development.)
- [ ]   Make sure you’ve accounted for any migrations. When you’re about to create the PR, bring up the application locally and then run `git status | grep migrations`. If there are any results, you probably need to add them to the branch for the PR. Your PR should have only **one** new migration file for each of the component apps, except in rare circumstances; you may need to delete some and re-run `python manage.py makemigrations` to reduce the number to one. (Also, unless in exceptional circumstances, your PR should not delete any migration files.)
- [ ]   Make sure that whatever feature you’re adding has tests that cover the feature. This includes test coverage to make sure that the previous workflow still works, if applicable.
- [ ]   Make sure the full-submission.cy.js [Cypress test](https://github.com/GSA-TTS/FAC/blob/main/docs/testing.md#end-to-end-testing) passes, if applicable.
- [ ]   Do manual testing locally. Our tests are not good enough yet to allow us to skip this step. If that’s not applicable for some reason, check this box.
- [ ]   Verify that no Git surgery was necessary, or, if it was necessary at any point, repeat the testing after it’s finished.
- [ ]   Once a PR is merged, keep an eye on it until it’s deployed to dev, and do enough testing on dev to verify that it deployed successfully, the feature works as expected, and the happy path for the broad feature area (such as submission) still works.
- [ ]   Ensure that prior to merging, the working branch is up to date with main and the terraform plan is what you expect.

## PR Checklist: Reviewer

- [ ]   Pull the branch to your local environment and run `make docker-clean; make docker-first-run && docker compose up`; then run `docker compose exec web /bin/bash -c "python manage.py test"`
- [ ]   Manually test out the changes locally, or check this box to verify that it wasn’t applicable in this case.
- [ ]   Check that the PR has appropriate tests. Look out for changes in HTML/JS/JSON Schema logic that may need to be captured in Python tests even though the logic isn’t in Python.
- [ ]   Verify that no Git surgery is necessary at any point (such as during a merge party), or, if it was, repeat the testing after it’s finished.

The larger the PR, the stricter we should be about these points.

## Pre Merge Checklist: Merger

- [ ]   Ensure that prior to approving, the terraform plan is what we expect it to be. `-/+ resource "null_resource" "cors_header" ` should be destroying and recreating its self and ` ~ resource "cloudfoundry_app" "clamav_api" ` might be updating its `sha256` for the `fac-file-scanner` and `fac-av-${ENV}` by default.
- [ ]   Ensure that the branch is up to date with `main`.
- [ ]   Ensure that a terraform plan has been recently generated for the pull request.
