### PR TITLE
Allowing null resub status for API

### DIFF
--- a/backend/dissemination/api/api_v1_1_0/create_functions.sql
+++ b/backend/dissemination/api/api_v1_1_0/create_functions.sql
@@ -70,6 +70,8 @@ CREATE OR REPLACE FUNCTION api_v1_1_0_functions.is_most_recent_audit_or_authoriz
 RETURNS BOOLEAN AS $$
 BEGIN
     RETURN (
+        resubmission_status is NULL
+        OR
         resubmission_status = 'most_recent'
         OR
         api_v1_1_0_functions.has_tribal_data_access()

--- a/backend/dissemination/api/api_v1_1_1/create_functions.sql
+++ b/backend/dissemination/api/api_v1_1_1/create_functions.sql
@@ -59,6 +59,8 @@ CREATE OR REPLACE FUNCTION api_v1_1_1_functions.is_most_recent_audit_or_authoriz
 RETURNS BOOLEAN AS $$
 BEGIN
     RETURN (
+        resubmission_status is NULL
+        OR
         resubmission_status = 'most_recent'
         OR
         api_v1_1_1_functions.has_tribal_data_access()


### PR DESCRIPTION
<!-- These are comments and will not appear when the PR is created -->
<!-- For more tips on creating PRs, see https://github.com/GSA-TTS/FAC/blob/main/docs/pull-request-checklist.md -->
## Related tickets
<!-- List all relevant tickets. If there are none, delete this section. -->
<!-- Tip: Use `Closes <ticket url>` to automatically close the ticket once merged -->
* Unblocks https://github.com/GSA-TTS/FAC/issues/5460

## Description of changes
<!-- Give a high level summary of the changes made -->
* The API views were only allowing audits through that have a `resubmission_status` of "most_recent". This only applies to new submissions, though, as older/existing ones have a `NULL` status, so most were getting filtered unnecessarily. This change now permits submissions of both "most_recent" and `NULL` statuses.

## How to test
<!-- Provide clear instructions for testing your changes -->
* Do a full docker up/down to load the new views
* In Postman, hit something like http://localhost:3000/general?limit=5
* Grab a `report_id` and find it in DBeaver
* http://localhost:3000/general?report_id=eq.your-report-id should work when the submission has a `resubmission_status` of either "most_recent" or `NULL`
* Confirm things work in preview
