### PR TITLE
Doing the right thing for search dates

### DIFF
--- a/backend/dissemination/searchlib/search_general.py
+++ b/backend/dissemination/searchlib/search_general.py
@@ -39,9 +39,17 @@ def search_general(base_model, params=None):
 
     ##############
     # Start/end dates
-    q_start_date = _get_start_date_match_query(params.get("start_date", None))
+    start = params.get("start_date", None)
+    end = params.get("end_date", None)
+
+    # Unflip the dates if they're backwards
+    if start and end and start > end:
+        start = params.get("end_date", None)
+        end = params.get("start_date", None)
+
+    q_start_date = _get_start_date_match_query(start)
     r_start_date = base_model.objects.filter(q_start_date)
-    q_end_date = _get_end_date_match_query(params.get("end_date", None))
+    q_end_date = _get_end_date_match_query(end)
     r_end_date = base_model.objects.filter(q_end_date)
 
     ##############

--- a/backend/dissemination/test_search.py
+++ b/backend/dissemination/test_search.py
@@ -288,8 +288,12 @@ class SearchGeneralTests(TestCase):
         self.assertEqual(len(results), 6)
 
         for r in results:
-            self.assertGreaterEqual(r.fac_accepted_date, search_start_date)
-            self.assertLessEqual(r.fac_accepted_date, search_end_date)
+            if backwards:
+                self.assertGreaterEqual(r.fac_accepted_date, search_end_date)
+                self.assertLessEqual(r.fac_accepted_date, search_start_date)
+            else:
+                self.assertGreaterEqual(r.fac_accepted_date, search_start_date)
+                self.assertLessEqual(r.fac_accepted_date, search_end_date)
 
     def test_date_range(self):
         self._test_date_range_helper(backwards=False)

--- a/backend/dissemination/test_search.py
+++ b/backend/dissemination/test_search.py
@@ -254,11 +254,10 @@ class SearchGeneralTests(TestCase):
         assert_all_results_public(self, results)
         self.assertEqual(len(results), 2)
 
-    def test_date_range(self):
+    def _test_date_range_helper(self, backwards):
         """
         Given a start and end date, search_general should return only records inside the date range
         """
-
         # seed the database with one record for each day of June
         seed_start_date = datetime.date(2023, 6, 1)
         seed_end_date = datetime.date(2023, 6, 30)
@@ -269,8 +268,12 @@ class SearchGeneralTests(TestCase):
             d += datetime.timedelta(days=1)
 
         # search for records between June 10 and June 15
-        search_start_date = datetime.date(2023, 6, 10)
-        search_end_date = datetime.date(2023, 6, 15)
+        if backwards:
+            search_start_date = datetime.date(2023, 6, 15)
+            search_end_date = datetime.date(2023, 6, 10)
+        else:
+            search_start_date = datetime.date(2023, 6, 10)
+            search_end_date = datetime.date(2023, 6, 15)
 
         results = search_general(
             General,
@@ -282,12 +285,17 @@ class SearchGeneralTests(TestCase):
 
         assert_all_results_public(self, results)
 
-        # we should get 6 results, one for each day between June 10-15
         self.assertEqual(len(results), 6)
 
         for r in results:
             self.assertGreaterEqual(r.fac_accepted_date, search_start_date)
             self.assertLessEqual(r.fac_accepted_date, search_end_date)
+
+    def test_date_range(self):
+        self._test_date_range_helper(backwards=False)
+
+    def test_date_range_backwards(self):
+        self._test_date_range_helper(backwards=True)
 
     def test_audit_year(self):
         """


### PR DESCRIPTION
<!-- These are comments and will not appear when the PR is created -->
<!-- For more tips on creating PRs, see https://github.com/GSA-TTS/FAC/blob/main/docs/pull-request-checklist.md -->
## Related tickets
<!-- List all relevant tickets. If there are none, delete this section. -->
<!-- Tip: Use `Closes <ticket url>` to automatically close the ticket once merged -->
* Closes https://github.com/GSA-TTS/FAC/issues/5188

## Description of changes
<!-- Give a high level summary of the changes made -->
* Search used to yield no results when the user specified a start date that came after the end date. This change now swaps the two values when that happens to make the search work as normal.

## How to test
<!-- Provide clear instructions for testing your changes -->
* http://localhost:8000/dissemination/search/
* Find some submissions by whatever means you want. Using their acceptance date, perform another search using the date range input but make the dates backwards. As in, if your submission was accepted 01/**05**/2020, then make the start date 01/**07**/2020 and the end date 01/**03**/2020, or similar.
* The submissions should show up as normal
* Works for advanced search, too, since it hits the same code
