### PR TITLE
Fixes for resub meta population

### DIFF
--- a/backend/audit/models/models.py
+++ b/backend/audit/models/models.py
@@ -336,6 +336,7 @@ class SingleAuditChecklist(models.Model, GeneralInformationMixin):  # type: igno
                 "additional_eins",
                 "secondary_auditors",
                 "notes_to_sefa",
+                "resubmission_meta",
             ]
             data = model_to_dict(self, fields=include_list)
 

--- a/backend/audit/views/submissions.py
+++ b/backend/audit/views/submissions.py
@@ -196,7 +196,6 @@ class SubmissionView(CertifyingAuditeeRequiredMixin, generic.View):
                         "next_report_id": sac.report_id,
                         "next_row_id": sac.id,
                     }
-
                     old_sac.redisseminate()
 
                 if audit:

--- a/backend/audit/views/submissions.py
+++ b/backend/audit/views/submissions.py
@@ -188,10 +188,15 @@ class SubmissionView(CertifyingAuditeeRequiredMixin, generic.View):
                     old_sac = SingleAuditChecklist.objects.get(
                         report_id=previous_report_id
                     )
-                    old_sac.resubmission_meta = old_sac.resubmission_meta or {
+                    old_resubmission_meta = getattr(old_sac, 'resubmission_meta', {}) or {}
+                    old_sac.resubmission_meta = {
+                        "previous_report_id": old_resubmission_meta.get("previous_report_id", None),
+                        "previous_row_id": old_resubmission_meta.get("previous_row_id", None),
+                        "version": old_resubmission_meta.get("version", 1),
                         "next_report_id": sac.report_id,
                         "next_row_id": sac.id,
                     }
+
                     old_sac.redisseminate()
 
                 if audit:

--- a/backend/audit/views/submissions.py
+++ b/backend/audit/views/submissions.py
@@ -188,10 +188,16 @@ class SubmissionView(CertifyingAuditeeRequiredMixin, generic.View):
                     old_sac = SingleAuditChecklist.objects.get(
                         report_id=previous_report_id
                     )
-                    old_resubmission_meta = getattr(old_sac, 'resubmission_meta', {}) or {}
+                    old_resubmission_meta = (
+                        getattr(old_sac, "resubmission_meta", {}) or {}
+                    )
                     old_sac.resubmission_meta = {
-                        "previous_report_id": old_resubmission_meta.get("previous_report_id", None),
-                        "previous_row_id": old_resubmission_meta.get("previous_row_id", None),
+                        "previous_report_id": old_resubmission_meta.get(
+                            "previous_report_id", None
+                        ),
+                        "previous_row_id": old_resubmission_meta.get(
+                            "previous_row_id", None
+                        ),
                         "version": old_resubmission_meta.get("version", 1),
                         "next_report_id": sac.report_id,
                         "next_row_id": sac.id,

--- a/backend/cypress/e2e/resubmission-full.cy.js
+++ b/backend/cypress/e2e/resubmission-full.cy.js
@@ -3,16 +3,26 @@ import { testLoginGovLogin } from '../support/login-gov.js';
 
 describe('Full audit resubmission', () => {
   it('Non-tribal, public', () => {
-    testFullSubmission(false, true).then((previous_report_id) => {
+    testFullSubmission(false, true).then((previous_report_id_1) => {
       testLoginGovLogin();
 
       cy.visit('/audit/resubmission-start');
       cy.get('#id_material_change_reasons_0').check({ force: true });
-      cy.get('#report_id').type(previous_report_id);
+      cy.get('#report_id').type(previous_report_id_1);
       cy.get('#continue').click();
       cy.url().should('include', '/report_submission/eligibility/');
 
-      testFullSubmission(false, true, true);
+      testFullSubmission(false, true, true).then((previous_report_id_2) => {
+        testLoginGovLogin();
+
+        cy.visit('/audit/resubmission-start');
+        cy.get('#id_material_change_reasons_0').check({ force: true });
+        cy.get('#report_id').type(previous_report_id_2);
+        cy.get('#continue').click();
+        cy.url().should('include', '/report_submission/eligibility/');
+
+        testFullSubmission(false, true, true)
+      });
     });
   });
 });


### PR DESCRIPTION
<!-- These are comments and will not appear when the PR is created -->
<!-- For more tips on creating PRs, see https://github.com/GSA-TTS/FAC/blob/main/docs/pull-request-checklist.md -->
## Related tickets
<!-- List all relevant tickets. If there are none, delete this section. -->
<!-- Tip: Use `Closes <ticket url>` to automatically close the ticket once merged -->
* Nope

## Description of changes
<!-- Give a high level summary of the changes made -->
* Fixes for resub meta population
* `resubmission-full` now does two resubs instead of one, which replicated the bug

## How to test
<!-- Provide clear instructions for testing your changes -->
* Run `resubmission-full`
* `resubmission_meta` looks correct for the 3 new submissions in `audit_singleauditchecklist`, and `disseminated_resubmission` looks good for them too
