### PR TITLE
added prefix to proxy variable for clamav instances

### DIFF
--- a/terraform/shared/modules/env/clamav.tf
+++ b/terraform/shared/modules/env/clamav.tf
@@ -20,7 +20,7 @@ module "clamav" {
   instances     = var.clamav_instances
   clamav_memory = var.clamav_memory
 
-  proxy_server   = module.https-proxy.domain
+  proxy_server   = "https://${module.https-proxy.domain}" # freshclam needs the https:// prefix to identify the proxy type
   proxy_port     = module.https-proxy.https_port
   proxy_username = module.https-proxy.username
   proxy_password = module.https-proxy.password
@@ -39,7 +39,7 @@ module "file_scanner_clamav" {
   instances     = var.clamav_fs_instances
   clamav_memory = var.clamav_memory
 
-  proxy_server   = module.https-proxy.domain
+  proxy_server   = "https://${module.https-proxy.domain}" # freshclam needs the https:// prefix to identify the proxy type
   proxy_port     = module.https-proxy.https_port
   proxy_username = module.https-proxy.username
   proxy_password = module.https-proxy.password


### PR DESCRIPTION
<!-- These are comments and will not appear when the PR is created -->
<!-- For more tips on creating PRs, see https://github.com/GSA-TTS/FAC/blob/main/docs/pull-request-checklist.md -->

## Description of changes
<!-- Give a high level summary of the changes made -->
The clamav service is failing to pull updates from database.clamav.net via the https proxy. Freshclam uses the proxy server prefix to determine the type of proxy being used. This PR sets the prefix to https to override the default (http).

