### PR TITLE
[DRAFT] Add a Healthcheck to the ClamAV Container

### DIFF
--- a/.github/workflows/testing-from-build.yml
+++ b/.github/workflows/testing-from-build.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Start services
         working-directory: ./backend
-        run: docker compose -f docker-compose.yml up
+        run: docker compose -f docker-compose.yml up -d
 
       - name: Run Django test suite
         working-directory: ./backend

--- a/.github/workflows/testing-from-build.yml
+++ b/.github/workflows/testing-from-build.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Start services
         working-directory: ./backend
-        run: docker compose -f docker-compose.yml up -d
+        run: docker compose -f docker-compose.yml up
 
       - name: Run Django test suite
         working-directory: ./backend

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -75,11 +75,11 @@ RUN wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.k
 
 RUN apt-get install -yqq groff && \
     apt-get install -yqq zip && \
-    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
     unzip awscliv2.zip && \
     ./aws/install
 
-RUN curl --fail -L "https://dl.min.io/client/mc/release/linux-amd64/mc" -o "/usr/local/bin/mc" && \
+RUN curl -fsSL "https://dl.min.io/client/mc/release/linux-amd64/mc" -o "/usr/local/bin/mc" && \
     chmod +x /usr/local/bin/mc
 
 # Copy from pip stage

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -79,7 +79,7 @@ RUN apt-get install -yqq groff && \
     unzip awscliv2.zip && \
     ./aws/install
 
-RUN curl "https://dl.min.io/client/mc/release/linux-amd64/mc" -o "/usr/local/bin/mc" && \
+RUN curl --fail -L "https://dl.min.io/client/mc/release/linux-amd64/mc" -o "/usr/local/bin/mc" && \
     chmod +x /usr/local/bin/mc
 
 # Copy from pip stage

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -91,8 +91,8 @@ services:
     ports:
       - ${CLAMAV_PORT:-9000}:${CLAMAV_PORT:-9000}
     healthcheck:
-      test: curl --fail -I http://localhost:9000/ || exit 1
-      interval: 10s
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:9000/"]
+      interval: 30s
       timeout: 5s
       retries: 10
 

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -46,7 +46,7 @@ services:
       db2:
         condition: service_healthy
       minio:
-        condition: service_started
+        condition: service_healthy
       clamav-rest:
         condition: service_healthy
     environment:

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       minio:
         condition: service_started
       clamav-rest:
-        condition: service_started
+        condition: service_healthy
     environment:
       DATABASE_URL: postgres://postgres@db/postgres
       POSTGREST_URL: http://api:3000
@@ -90,6 +90,11 @@ services:
       PORT: ${CLAMAV_PORT:-9000}
     ports:
       - ${CLAMAV_PORT:-9000}:${CLAMAV_PORT:-9000}
+    healthcheck:
+      test: curl --fail -I http://localhost:9000/ || exit 1
+      interval: 10s
+      timeout: 5s
+      retries: 10
 
   #---------------------------------------------
   # Minio (S3 clone)
@@ -98,6 +103,11 @@ services:
     container_name: "minio"
     image: minio/minio
     command: server /tmp/minio --console-address ":9002"
+    healthcheck:
+      test: curl --fail -I http://localhost:9002/minio/health/cluster || exit 1
+      interval: 10s
+      timeout: 5s
+      retries: 10
     ports:
       - "9001:9000"
       - "9002:9002"

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -91,7 +91,7 @@ services:
     ports:
       - ${CLAMAV_PORT:-9000}:${CLAMAV_PORT:-9000}
     healthcheck:
-      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:9000/"]
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:${CLAMAV_PORT:-9000}/"]
       interval: 30s
       timeout: 5s
       retries: 10


### PR DESCRIPTION
Tests were failing on file uploads. This could point to lots of different issues. There could have been updates to; Minio, our local dependencies or connection config, the ClamAV upstream, or container connections. We've only really poked with ClamAV in the days before the issues appeared.

Something may have changed in ClamAV that had it start up slower, or cause issues if our tests begin before it spins up.

<!-- These are comments and will not appear when the PR is created -->
<!-- For more tips on creating PRs, see https://github.com/GSA-TTS/FAC/blob/main/docs/pull-request-checklist.md -->
## Related tickets
<!-- List all relevant tickets. If there are none, delete this section. -->
<!-- Tip: Use `Closes <ticket url>` to automatically close the ticket once merged -->
* N/A

## Description of changes
<!-- Give a high level summary of the changes made -->
* Add a healthcheck to `clamav-rest`. Require a positive healthcheck before `web` comes up.
* Add a -L flag to the `mc` install in the Dockerfile. Missing `mc` may cause the upload configs to be broken.

## How to test
<!-- Provide clear instructions for testing your changes -->
* Spin things up locally, make sure it all runs right.
* Eyeball the CI/CD tests.

## Screenshots and recordings
<!-- Optional for UI work. If there are none, delete this section. -->
* N/A
