### PR TITLE
Update OMB Control Number Expiration Date

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -560,7 +560,7 @@ STATIC_SITE_URL = "https://fac.gov/"
 
 # OMB-assigned values. Number doesn't change, date does.
 OMB_NUMBER = "3090-0330"
-OMB_EXP_DATE = "09/30/2026"
+OMB_EXP_DATE = "04/30/2029"
 
 # APP-level constants
 CENSUS_DATA_SOURCE = "CENSUS"


### PR DESCRIPTION
## Summary

Updates the PRA expiration date displayed by the FAC to reflect the latest approved OMB expiration date through 2029.

## Changes

- Updated PRA expiration date in `backend/config/settings.py`
- Kept the existing OMB control number unchanged

## Context

OMB approved an extension/revision of the FAC information collection through 2029. 

## Testing

- [ ] Confirm updated expiration date displays correctly on the site
- [ ] Confirm OMB control number remains unchanged
- [ ] Confirm PRA statement still renders correctly across affected pages