### PR TITLE
Fixing SAM metadata error handling

### DIFF
--- a/backend/report_submission/views/submission_views.py
+++ b/backend/report_submission/views/submission_views.py
@@ -83,7 +83,7 @@ class AuditeeInfoFormView(LoginRequiredMixin, View):
             if not info_check.get("info_check_passed"):
                 logger.error(f"Auditee metadata failed to validate for {auditee_uei}; returning to auditee info page")
                 logger.error(info_check["errors"])
-                
+
                 return redirect(reverse("report_submission:auditeeinfo"))
 
         return redirect(reverse("report_submission:eligibility"))

--- a/backend/report_submission/views/submission_views.py
+++ b/backend/report_submission/views/submission_views.py
@@ -76,12 +76,16 @@ class AuditeeInfoFormView(LoginRequiredMixin, View):
 
         info_check = api.views.auditee_info_check(request.user, formatted_post_with_sam)
         if not info_check.get("info_check_passed"):
-            logger.error(f"SAM auditee metadata failed to validate for {auditee_uei}; discarding")
+            logger.error(
+                f"SAM auditee metadata failed to validate for {auditee_uei}; discarding"
+            )
             logger.error(info_check["errors"])
 
             info_check = api.views.auditee_info_check(request.user, formatted_post)
             if not info_check.get("info_check_passed"):
-                logger.error(f"Auditee metadata failed to validate for {auditee_uei}; returning to auditee info page")
+                logger.error(
+                    f"Auditee metadata failed to validate for {auditee_uei}; returning to auditee info page"
+                )
                 logger.error(info_check["errors"])
 
                 return redirect(reverse("report_submission:auditeeinfo"))

--- a/backend/report_submission/views/submission_views.py
+++ b/backend/report_submission/views/submission_views.py
@@ -53,15 +53,11 @@ class AuditeeInfoFormView(LoginRequiredMixin, View):
         address = core_data.get("mailingAddress", {})
         entity_reg = sam_response.get("response", {}).get("entityRegistration", {})
         auditee_name = entity_reg.get("legalBusinessName", "")
+        auditee_uei = form.cleaned_data["auditee_uei"].upper()
 
         formatted_post = {
             "csrfmiddlewaretoken": request.POST.get("csrfmiddlewaretoken"),
-            "auditee_uei": form.cleaned_data["auditee_uei"].upper(),
-            "auditee_name": auditee_name,
-            "auditee_address_line_1": address.get("addressLine1", ""),
-            "auditee_city": address.get("city", ""),
-            "auditee_state": address.get("stateOrProvinceCode", ""),
-            "auditee_zip": address.get("zipCode", ""),
+            "auditee_uei": auditee_uei,
             "auditee_fiscal_period_start": form.cleaned_data[
                 "auditee_fiscal_period_start"
             ].strftime("%Y-%m-%d"),
@@ -69,10 +65,26 @@ class AuditeeInfoFormView(LoginRequiredMixin, View):
                 "auditee_fiscal_period_end"
             ].strftime("%Y-%m-%d"),
         }
+        formatted_post_with_sam = {
+            **formatted_post,
+            "auditee_name": auditee_name,
+            "auditee_address_line_1": address.get("addressLine1", ""),
+            "auditee_city": address.get("city", ""),
+            "auditee_state": address.get("stateOrProvinceCode", ""),
+            "auditee_zip": address.get("zipCode", ""),
+        }
 
-        info_check = api.views.auditee_info_check(request.user, formatted_post)
+        info_check = api.views.auditee_info_check(request.user, formatted_post_with_sam)
         if not info_check.get("info_check_passed"):
-            return redirect(reverse("report_submission:auditeeinfo"))
+            logger.error(f"SAM auditee metadata failed to validate for {auditee_uei}; discarding")
+            logger.error(info_check["errors"])
+
+            info_check = api.views.auditee_info_check(request.user, formatted_post)
+            if not info_check.get("info_check_passed"):
+                logger.error(f"Auditee metadata failed to validate for {auditee_uei}; returning to auditee info page")
+                logger.error(info_check["errors"])
+                
+                return redirect(reverse("report_submission:auditeeinfo"))
 
         return redirect(reverse("report_submission:eligibility"))
 


### PR DESCRIPTION
<!-- These are comments and will not appear when the PR is created -->
<!-- For more tips on creating PRs, see https://github.com/GSA-TTS/FAC/blob/main/docs/pull-request-checklist.md -->
## Related tickets
<!-- List all relevant tickets. If there are none, delete this section. -->
<!-- Tip: Use `Closes <ticket url>` to automatically close the ticket once merged -->
* Closes https://github.com/GSA-TTS/FAC/issues/5655

## Description of changes
<!-- Give a high level summary of the changes made -->
* Previously, if the auditee metadata from SAM fails to validate, the user would be infinitely redirected back to step 1. This change now discards the SAM metadata (name, address) to allow them to continue and logs.

## How to test
<!-- Provide clear instructions for testing your changes -->
* Using JAD9Y3J9TYZ8 for step 1 should log an error and allow you to continue
  * This one has such a long auditee name that it fails our validations
* Other UEIs (D7A4J33FUMJ1) should work as normal and still populate auditee name and address in Gen Info
