### PR TITLE
Prevent Unchanged Resubmissions

### DIFF
--- a/backend/audit/cross_validation/__init__.py
+++ b/backend/audit/cross_validation/__init__.py
@@ -91,6 +91,7 @@ from .tribal_data_sharing_consent import tribal_data_sharing_consent
 from .validate_general_information import validate_general_information
 from .check_auditee_auditor_ein_match import check_auditee_auditor_ein_match
 from .check_name_fields_not_unique import check_name_fields_not_unique
+from .check_resubmission_has_changes import check_resubmission_has_changes
 
 functions = [
     # "Errors", or validations that would prevent a submission upon failure.
@@ -122,4 +123,5 @@ functions = [
     # "Warnings", or validations that would just inform a user of a potential issue.
     check_auditee_auditor_ein_match,
     check_name_fields_not_unique,
+    check_resubmission_has_changes,
 ]

--- a/backend/audit/cross_validation/check_resubmission_has_changes.py
+++ b/backend/audit/cross_validation/check_resubmission_has_changes.py
@@ -1,34 +1,38 @@
+from .errors import err_identical_resubmissions
+
+
 def check_resubmission_has_changes(sac_dict, *_args, **_kwargs):
     """
     Errors if the SAC is a resubmission that has no changes compared to the
     previous version
     """
-    from audit.viewlib.compare_two_submissions import compare_with_prev
+    from audit.viewlib import compare_two_submissions
     from audit.models import SingleAuditChecklist
 
     sf_sac_meta = sac_dict.get("sf_sac_meta", {})
     resub_meta = sf_sac_meta.get("resubmission_meta") or {}
 
+    previous_report_id = resub_meta.get("previous_report_id")
     if not resub_meta.get("previous_report_id"):
         return []
 
     report_id = sf_sac_meta.get("report_id")
 
     try:
-        sac = SingleAuditChecklist.objects.get(report_id=report_id)
+        resub = SingleAuditChecklist.objects.get(report_id=report_id)
     except SingleAuditChecklist.DoesNotExist:
         return []
 
-    _, _, compared = compare_with_prev(sac)
+    _, _, compared = compare_two_submissions.compare_with_prev(resub)
     has_diff = False
 
     for val in compared.values():
         if val == "error" or val["status"] == "error":
-            return [{"error": compared.message}]
+            return [{"error": val["message"]}]
         if val["status"] != "same":
             has_diff = True
 
     if not has_diff:
-        return [{"error": f"This resubmission appears identical to the previous version ({report_id}). A resubmission that is identical to the original submission is not permitted."}]
+        return [{"error": err_identical_resubmissions(previous_report_id)}]
     else:
         return []

--- a/backend/audit/cross_validation/check_resubmission_has_changes.py
+++ b/backend/audit/cross_validation/check_resubmission_has_changes.py
@@ -1,0 +1,34 @@
+def check_resubmission_has_changes(sac_dict, *_args, **_kwargs):
+    """
+    Errors if the SAC is a resubmission that has no changes compared to the
+    previous version
+    """
+    from audit.viewlib.compare_two_submissions import compare_with_prev
+    from audit.models import SingleAuditChecklist
+
+    sf_sac_meta = sac_dict.get("sf_sac_meta", {})
+    resub_meta = sf_sac_meta.get("resubmission_meta") or {}
+
+    if not resub_meta.get("previous_report_id"):
+        return []
+
+    report_id = sf_sac_meta.get("report_id")
+
+    try:
+        sac = SingleAuditChecklist.objects.get(report_id=report_id)
+    except SingleAuditChecklist.DoesNotExist:
+        return []
+
+    _, _, compared = compare_with_prev(sac)
+    has_diff = False
+
+    for val in compared.values():
+        if val == "error" or val["status"] == "error":
+            return [{"error": compared.message}]
+        if val["status"] != "same":
+            has_diff = True
+
+    if not has_diff:
+        return [{"error": f"This resubmission appears identical to the previous version ({report_id}). A resubmission that is identical to the original submission is not permitted."}]
+    else:
+        return []

--- a/backend/audit/cross_validation/errors.py
+++ b/backend/audit/cross_validation/errors.py
@@ -179,3 +179,7 @@ def err_total_amount_expended(amount_expended):
         "for that year. "
         f"The amount expended is ${pretty_amount_expended}. "
     )
+
+
+def err_identical_resubmissions(report_id):
+    return f"This resubmission appears identical to the previous version ({report_id}). A resubmission that is identical to the original submission is not permitted."

--- a/backend/audit/cross_validation/test_check_resubmission_has_changes.py
+++ b/backend/audit/cross_validation/test_check_resubmission_has_changes.py
@@ -1,0 +1,49 @@
+from django.test import TestCase
+from audit.models import SingleAuditChecklist
+from .check_resubmission_has_changes import (
+    check_resubmission_has_changes,
+)
+from .sac_validation_shape import sac_validation_shape
+from .errors import err_identical_resubmissions
+
+from model_bakery import baker
+from unittest.mock import patch
+
+
+class CheckResubmissionHasChangesTest(TestCase):
+    def _make_resub(self, version, previous_report_id) -> SingleAuditChecklist:
+        sac = baker.make(SingleAuditChecklist, report_id="resub")
+        sac.resubmission_meta = {
+            "version": version,
+            "previous_report_id": previous_report_id,
+        }
+        sac.save()
+
+        return sac
+
+    # Patching compare_single_audit_reports because it hits S3
+    @patch("audit.viewlib.compare_two_submissions.compare_single_audit_reports")
+    def test_has_no_changes(self, mock_sar_compare):
+        """When there are no changes, we should have an error"""
+        orig = baker.make(SingleAuditChecklist)
+        resub = self._make_resub(2, orig.report_id)
+        shaped_resub = sac_validation_shape(resub)
+        mock_sar_compare.return_value = {"status": "same"}
+
+        errors = check_resubmission_has_changes(shaped_resub)
+
+        self.assertEqual(
+            errors, [{"error": err_identical_resubmissions(orig.report_id)}]
+        )
+
+    @patch("audit.viewlib.compare_two_submissions.compare_single_audit_reports")
+    def test_has_changes(self, mock_sar_compare):
+        """When there are changes, we should not have an error"""
+        orig = baker.make(SingleAuditChecklist)
+        resub = self._make_resub(2, orig.report_id)
+        shaped_resub = sac_validation_shape(resub)
+        mock_sar_compare.return_value = {"status": "changed"}
+
+        errors = check_resubmission_has_changes(shaped_resub)
+
+        self.assertEqual(errors, [])

--- a/backend/audit/cross_validation/test_check_resubmission_has_changes.py
+++ b/backend/audit/cross_validation/test_check_resubmission_has_changes.py
@@ -1,10 +1,11 @@
 from django.test import TestCase
+
 from audit.models import SingleAuditChecklist
 from .check_resubmission_has_changes import (
     check_resubmission_has_changes,
 )
-from .sac_validation_shape import sac_validation_shape
 from .errors import err_identical_resubmissions
+from .sac_validation_shape import sac_validation_shape
 
 from model_bakery import baker
 from unittest.mock import patch
@@ -36,6 +37,7 @@ class CheckResubmissionHasChangesTest(TestCase):
             errors, [{"error": err_identical_resubmissions(orig.report_id)}]
         )
 
+    # Here we can also simulate compare_single_audit_reports detecting changes
     @patch("audit.viewlib.compare_two_submissions.compare_single_audit_reports")
     def test_has_changes(self, mock_sar_compare):
         """When there are changes, we should not have an error"""

--- a/backend/audit/templates/audit/comparison_sections_only.html
+++ b/backend/audit/templates/audit/comparison_sections_only.html
@@ -18,7 +18,7 @@
     <div class="grid-row width-full">
       <div class="tablet:grid-col">
         <h2>There are no changes between Single Audit Reports</h2>
-        <p>Note that identical resubmissions are not permitted, so pre-submission validation will fail in its current state.</p>
+        <p>Note: Identical resubmissions are not permitted. Pre-submission validation will fail for this submission in its current state.</p>
       </div>
     </div>
   {% endif %}

--- a/backend/audit/templates/audit/comparison_sections_only.html
+++ b/backend/audit/templates/audit/comparison_sections_only.html
@@ -18,7 +18,7 @@
     <div class="grid-row width-full">
       <div class="tablet:grid-col">
         <h2>There are no changes between Single Audit Reports</h2>
-        <p>Note: Identical resubmissions are not permitted. Pre-submission validation will fail for this submission in its current state.</p>
+        <p>Note: Identical resubmissions are not permitted. Pre-submission validation will fail for this submission unless changes are made.</p>
       </div>
     </div>
   {% endif %}

--- a/backend/audit/templates/audit/comparison_sections_only.html
+++ b/backend/audit/templates/audit/comparison_sections_only.html
@@ -1,7 +1,7 @@
 {% comment %}
   each key is a section, mapped to what changed
   each section contains a tag "status" (same, changed) and "in_r1", "in_r2" as lists
-  this is broken out so that it can be embedded in a Federal view without the trappings, 
+  this is broken out so that it can be embedded in a Federal view without the trappings,
     if we decide that is desirable/necessary.
 {% endcomment %}
 
@@ -18,6 +18,7 @@
     <div class="grid-row width-full">
       <div class="tablet:grid-col">
         <h2>There are no changes between Single Audit Reports</h2>
+        <p>Note that identical resubmissions are not permitted, so pre-submission validation will fail in its current state.</p>
       </div>
     </div>
   {% endif %}
@@ -153,6 +154,6 @@
     {% endif %}
   {% else %}
     <!-- same or identical -->
-    <!-- <div class="grid-row"><div class="tablet:grid-col"><p>No differences detected.</p></div></div> -->    
+    <!-- <div class="grid-row"><div class="tablet:grid-col"><p>No differences detected.</p></div></div> -->
   {% endif %} <!-- for the big is changed/same -->
 {% endfor %} <!-- end section loop -->

--- a/backend/audit/viewlib/compare_two_submissions.py
+++ b/backend/audit/viewlib/compare_two_submissions.py
@@ -631,10 +631,14 @@ def compare_with_prev(rid):
         sac = rid
     else:
         logger.error(f"{rid} is not a report ID or SAC object")
-        return {
-            "status": "error",
-            "message": f"It seems {rid} is not a report; if you think this is an error, please contact the FAC helpdesk.",
-        }
+        return (
+            None,
+            None,
+            {
+                "status": "error",
+                "message": f"It seems {rid} is not a report; if you think this is an error, please contact the FAC helpdesk.",
+            },
+        )
 
     if sac.resubmission_meta:
         if "previous_report_id" in sac.resubmission_meta:
@@ -644,10 +648,14 @@ def compare_with_prev(rid):
             rid = sac.resubmission_meta["next_report_id"]
         else:
             logger.error(f"No previous report ID for {rid}")
-            return {
-                "status": "error",
-                "message": f"No previous report for {rid}. If this seems to be an error, contact the FAC helpdesk.",
-            }
+            return (
+                None,
+                None,
+                {
+                    "status": "error",
+                    "message": f"No previous report for {rid}. If this seems to be an error, contact the FAC helpdesk.",
+                },
+            )
         logger.info(f"[DIFF] {prev} <-> {rid}")
         return (
             report_id_as_string(prev),
@@ -655,7 +663,11 @@ def compare_with_prev(rid):
             compare_report_ids(prev, rid),
         )
     else:
-        return {
-            "status": "error",
-            "message": "There's no resubmission info for {rid}. If this seems to be an error, contact the FAC helpdesk.",
-        }
+        return (
+            None,
+            None,
+            {
+                "status": "error",
+                "message": "There's no resubmission info for {rid}. If this seems to be an error, contact the FAC helpdesk.",
+            },
+        )

--- a/backend/cypress/support/general-info.js
+++ b/backend/cypress/support/general-info.js
@@ -5,15 +5,18 @@ export function testValidGeneralInfo(isResubmission=false) {
 	//cy.get('#auditee_fiscal_period_start').type('05/08/2023');
 	//cy.get('#auditee_fiscal_period_end').type('05/08/2024');
 
-	if (!isResubmission) {
+	if (isResubmission) {
+		// This allows us to pass the check_resubmission_has_changes
+		const randomPhone = String(Math.floor(1000000000 + Math.random() * 9000000000));
+		cy.get('#auditee_phone').clear();
+		cy.get('#auditee_phone').type(randomPhone);
+	}	else {
 		// Audit Type
 		cy.get('label[for=single-audit]').click();
 		cy.get('label[for=audit-period-annual]').click();
 
 		// Auditee information
 		cy.get('#auditee_name').type('Audit McAuditee')
-		// clear()s are needed for resubmission tests, which pre-fills some fields.
-		cy.get('#ein').clear();
 		cy.get('#ein').type('546000173');
 		cy.get('label[for=ein_not_an_ssn_attestation]').click();
 		cy.get('label[for=multiple-eins-yes]').click();
@@ -30,13 +33,10 @@ export function testValidGeneralInfo(isResubmission=false) {
 		// Auditee contact information
 		cy.get('#auditee_contact_name').type('John Doe');
 		cy.get('#auditee_contact_title').type('Keymaster');
-		cy.get('#auditee_phone').clear();
 		cy.get('#auditee_phone').type('5558675309');
-		cy.get('#auditee_email').clear();
 		cy.get('#auditee_email').type('va@test.com');
 
 		// Auditor information
-		cy.get('#auditor_ein').clear();
 		cy.get('#auditor_ein').type('987654321');
 		cy.get('label[for=auditor_ein_not_an_ssn_attestation]').click();
 		cy.get('#auditor_firm_name').type('House of Auditor');
@@ -45,15 +45,12 @@ export function testValidGeneralInfo(isResubmission=false) {
 		cy.get('#auditor_address_line_1').type('123 Around the corner');
 		cy.get('#auditor_city').type('Centreville');
 		cy.get('#auditor_state').type('VA{enter}');
-		cy.get('#auditor_zip').clear();
 		cy.get('#auditor_zip').type('20121');
 
 		// Auditor contact information
 		cy.get('#auditor_contact_name').type('Jane Doe');
 		cy.get('#auditor_contact_title').type('Auditor');
-		cy.get('#auditor_phone').clear();
 		cy.get('#auditor_phone').type('5555555555');
-		cy.get('#auditor_email').clear();
 		cy.get('#auditor_email').type('qualified.human.accountant@auditor.com');
 
 		cy.get('label[for=secondary_auditors-yes]').click();


### PR DESCRIPTION
<!-- These are comments and will not appear when the PR is created -->
<!-- For more tips on creating PRs, see https://github.com/GSA-TTS/FAC/blob/main/docs/pull-request-checklist.md -->
## Related tickets
<!-- List all relevant tickets. If there are none, delete this section. -->
<!-- Tip: Use `Closes <ticket url>` to automatically close the ticket once merged -->
* Closes https://github.com/GSA-TTS/FAC/issues/5217

## Description of changes
<!-- Give a high level summary of the changes made -->
* Adding cross-val `check_resubmission_has_changes()` that errors if `compare_with_prev()` detects no changes between a resubmission and the original
* `compare_with_prev()` now always returns a tuple by using `None` for report_ids when appropriate
* Updating resubmission-full since they used be identical. Now the resubs have a randomized phone number.
* Added a blurb to the comparison page when no changes are found so that they're aware it isn't going to pass validation

## How to test
<!-- Provide clear instructions for testing your changes -->
* Have a submission disseminated and begin the normal resub process without making any changes
* The comparison page should show no changes
* Presubmission validation should fail
* Now, go back and change a field somewhere
* The comparison page should show changes
* Presubmission validation should pass
* full-resubmission passes

## Screenshots and recordings
<!-- Optional for UI work. If there are none, delete this section. -->
<img width="996" height="506" alt="image" src="https://github.com/user-attachments/assets/33e27963-d107-466e-8151-972a32af2d9a" />
<img width="755" height="484" alt="image" src="https://github.com/user-attachments/assets/7566ae67-64f9-4f22-9c3a-2e0ac8024aa4" />
