### PR TITLE
Setting Django timezone to America/New_York

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -211,7 +211,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = "en-us"
 
-TIME_ZONE = 'America/New_York'
+TIME_ZONE = "America/New_York"
 
 USE_I18N = True
 

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -211,7 +211,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = "en-us"
 
-TIME_ZONE = "EST"
+TIME_ZONE = 'America/New_York'
 
 USE_I18N = True
 


### PR DESCRIPTION
<!-- These are comments and will not appear when the PR is created -->
<!-- For more tips on creating PRs, see https://github.com/GSA-TTS/FAC/blob/main/docs/pull-request-checklist.md -->
## Related tickets
<!-- List all relevant tickets. If there are none, delete this section. -->
<!-- Tip: Use `Closes <ticket url>` to automatically close the ticket once merged -->
* Closes https://github.com/GSA-TTS/FAC/issues/5487

## Description of changes
<!-- Give a high level summary of the changes made -->
* Setting Django timezone to America/New_York to fix off-by-one-hour issue

## How to test
<!-- Provide clear instructions for testing your changes -->
* Start a submission as normal
* Check a timestamp under a completed submission checklist entry. It should show the correct time and not an hour too early.
<img width="955" height="182" alt="image" src="https://github.com/user-attachments/assets/f5d2dd03-729f-4915-beb3-a3170a5f7629" />

