### PR TITLE
Bug - Resubmission Creation Ignores Org Type

### DIFF
--- a/backend/audit/models/models.py
+++ b/backend/audit/models/models.py
@@ -340,14 +340,17 @@ class SingleAuditChecklist(models.Model, GeneralInformationMixin):  # type: igno
             ]
             data = model_to_dict(self, fields=include_list)
 
-            # Update individual fields
-            data["general_information"]["auditee_uei"] = self.auditee_uei
-            data["general_information"][
-                "auditee_fiscal_period_start"
-            ] = self.auditee_fiscal_period_start
-            data["general_information"][
-                "auditee_fiscal_period_end"
-            ] = self.auditee_fiscal_period_end
+            # These are the fields that are pulled fresh from the pre-submission eligibility steps.
+            # UEI and fiscal period are also from pre-submission eligibility, but we can rely on them being copied from the previous record - they were validated then.
+            # "met_spending_threshold" and "is_usa_based" are always true. We store them as an user attestation, so we'll continue to do that and use the new values.
+            user_form_data = user.profile.entry_form_data
+            data["general_information"]["user_provided_organization_type"] = (
+                user_form_data["user_provided_organization_type"]
+            )
+            data["general_information"]["met_spending_threshold"] = user_form_data[
+                "met_spending_threshold"
+            ]
+            data["general_information"]["is_usa_based"] = user_form_data["is_usa_based"]
 
             # Manually add back foreign key as instance
             data["submitted_by"] = self.submitted_by

--- a/backend/audit/test_initiate_resubmission_create.py
+++ b/backend/audit/test_initiate_resubmission_create.py
@@ -12,6 +12,11 @@ User = get_user_model()
 class ResubmissionTest(TestCase):
     def setUp(self):
         self.user = User.objects.create_user(username="resubuser")
+        self.user.profile.entry_form_data = {
+            "is_usa_based": True,
+            "met_spending_threshold": True,
+            "user_provided_organization_type": "non-profit"
+        }
         general_information = {
             "auditee_fiscal_period_start": "2024-01-01",
             "auditee_fiscal_period_end": "2024-12-31",

--- a/backend/audit/test_initiate_resubmission_create.py
+++ b/backend/audit/test_initiate_resubmission_create.py
@@ -15,7 +15,7 @@ class ResubmissionTest(TestCase):
         self.user.profile.entry_form_data = {
             "is_usa_based": True,
             "met_spending_threshold": True,
-            "user_provided_organization_type": "non-profit"
+            "user_provided_organization_type": "non-profit",
         }
         general_information = {
             "auditee_fiscal_period_start": "2024-01-01",

--- a/backend/curation/curationlib/export_resubmission_chains.py
+++ b/backend/curation/curationlib/export_resubmission_chains.py
@@ -106,7 +106,8 @@ def export_chains_as_markdown(chains, AY=None, report_ids=None):
     """
     filename = _data_path(f"{AY or report_ids[0]}-resubmission-chains-{len(chains)}.md")
     title = (
-        f"### Resubmissions for {f"audit year {AY}" if AY else report_ids[0]}"
+        "### Resubmissions for "
+        + {f"audit year {AY}" if AY else report_ids[0]}
         + NEWLINE
         + NEWLINE
     )


### PR DESCRIPTION
# Bug - Resubmission Creation Ignores Org Type

Don't _explicitly_ copy UEI/FY info from previous. _Do_ copy the org type and user attestations.

<!-- These are comments and will not appear when the PR is created -->
<!-- For more tips on creating PRs, see https://github.com/GSA-TTS/FAC/blob/main/docs/pull-request-checklist.md -->
## Related tickets
<!-- List all relevant tickets. If there are none, delete this section. -->
<!-- Tip: Use `Closes <ticket url>` to automatically close the ticket once merged -->
* Closes https://github.com/GSA-TTS/FAC/issues/5660

## Description of changes
<!-- Give a high level summary of the changes made -->
We copy the general information from the previous submission into the new one. When creating a new resubmission, the pre-eligibility fields then get overwritten. The UEI and FY being overwritten is fine and preferred. The user provided org type is not. So, let's copy that from the user profile.

Also, reformats a line because my local linters really didn't like the nested f-strings.

## How to test
<!-- Provide clear instructions for testing your changes -->
* Start a resub, verify the error. You're looking for the `user_provided_organization_type` in the `general_information` JSON to be the same, even after selecting a different type in the form.
* Switch to this branch, run normally.
* Start a resub, verify the fix. Make sure the FY dates are still copied into the general information, even after I removed the explicit copy.

## Screenshots and recordings
<!-- Optional for UI work. If there are none, delete this section. -->
* N/A
