### PR TITLE
Make Final Submission Step Consistent with Submission Checklist Pattern (TAKE TWO)

### DIFF
--- a/backend/audit/templates/audit/submission_checklist/submission-checklist.html
+++ b/backend/audit/templates/audit/submission_checklist/submission-checklist.html
@@ -110,41 +110,41 @@
                     </li>
 
                     {% comment %} Submit to the FAC for processing {% endcomment %}
-                    {% if submission.enabled %}
-                    <li class="padding-bottom-3" id="submit-audit">
-                        <div class="usa-summary-box font-sans-md bg-success-lighter"
-                             role="region"
-                             aria-label="summary-box-submission">
-                            <div class="usa-summary-box__body">
-                                <div class="usa-summary-box__text">
-                                    <p class="text-bold margin-0">
-                                        <a class="usa-link" href="{% url 'audit:Submission' report_id %}">Submit to the FAC for processing</a>
-                                    </p>
-                                    <p class="margin-0">
-                                        This is the last step and must be completed by the <span class="text-underline">certifying auditee</span>. <strong>Once the audit has been submitted, it cannot be undone.</strong>
-                                    </p>
-                                </div>
+                    <li class="usa-icon-list__item padding-bottom-3"
+                        id="submit-audit">
+                        {% if submission.accepted %}
+                            {% include "./icon-list-icon.html" with completed=submission.accepted %}
+                            <div class="text-success-darker">
+                                <p class="text-bold text-underline margin-0">
+                                    Submit to the FAC for processing (Complete)
+                                </p>
+                                <p class="margin-0">
+                                    This is the last step and must be completed by the <span class="text-underline">certifying auditee</span>. <strong>Once the audit has been submitted, it cannot be undone.</strong>
+                                </p>
                             </div>
-                        </div>
-                    </li>
-                    {% else %}
-                    <li class="padding-bottom-3" id="submit-audit">
-                        <div class="usa-summary-box font-sans-md bg-success-lighter"
-                             role="region"
-                             aria-label="summary-box-submission">
-                            <div class="usa-summary-box__body">
-                                <div class="usa-summary-box__text">
-                                    <p class="text-bold margin-0">
-                                        Submit to the FAC for processing
-                                    </p>
-                                    <p class="margin-0">
-                                        This is the last step and must be completed by the <span class="text-underline">certifying auditee</span>. <strong>Once the audit has been submitted, it cannot be undone.</strong>
-                                    </p>
-                                </div>
+                        {% elif submission.enabled %}
+                            {% include "./icon-list-icon.html" with completed=submission.accepted %}
+                            <div>
+                                <p class="text-bold margin-0">
+                                    <a class="usa-link"
+                                       href="{% url 'audit:Submission' report_id %}">Submit to the FAC for processing</a>
+                                </p>
+                                <p class="margin-0">
+                                    This is the last step and must be completed by the <span class="text-underline">certifying auditee</span>. <strong>Once the audit has been submitted, it cannot be undone.</strong>
+                                </p>
                             </div>
-                        </div>
+                        {% else %}
+                            {% include "./icon-list-icon.html" with completed=submission.accepted %}
+                            <div>
+                                <p class="text-bold margin-0">
+                                    Submit to the FAC for processing
+                                </p>
+                                <p class="margin-0">
+                                    This is the last step and must be completed by the <span class="text-underline">certifying auditee</span>. <strong>Once the audit has been submitted, it cannot be undone.</strong>
+                                </p>
+                            </div>
+                        {% endif %}
                     </li>
-                    {% endif %}
                 </ul>
             </div>
         </div>

--- a/backend/audit/templates/audit/submission_checklist/submission-checklist.html
+++ b/backend/audit/templates/audit/submission_checklist/submission-checklist.html
@@ -112,8 +112,8 @@
                     {% comment %} Submit to the FAC for processing {% endcomment %}
                     <li class="usa-icon-list__item padding-bottom-3"
                         id="submit-audit">
-                        {% if submission.accepted %}
-                            {% include "./icon-list-icon.html" with completed=submission.accepted %}
+                        {% if submission.completed %}
+                            {% include "./icon-list-icon.html" with completed=submission.completed %}
                             <div class="text-success-darker">
                                 <p class="text-bold text-underline margin-0">
                                     Submit to the FAC for processing (Complete)
@@ -123,7 +123,7 @@
                                 </p>
                             </div>
                         {% elif submission.enabled %}
-                            {% include "./icon-list-icon.html" with completed=submission.accepted %}
+                            {% include "./icon-list-icon.html" with completed=submission.completed %}
                             <div>
                                 <p class="text-bold margin-0">
                                     <a class="usa-link"
@@ -134,7 +134,7 @@
                                 </p>
                             </div>
                         {% else %}
-                            {% include "./icon-list-icon.html" with completed=submission.accepted %}
+                            {% include "./icon-list-icon.html" with completed=submission.completed %}
                             <div>
                                 <p class="text-bold margin-0">
                                     Submit to the FAC for processing


### PR DESCRIPTION
## Summary

Updates the final "Submit to the FAC for processing" step on the submission checklist so it follows the same visual pattern as the Auditor Certification and Auditee Certification steps.

Previously, the final submission action was rendered inside a shaded box, which made it appear informational rather than part of the required workflow. Users could overlook the final submission action after completing both certification steps.

This change renders the final submission step as a standard checklist item using the existing icon-list pattern.

## Changes

- Replaced the `usa-summary-box` presentation for the final submission step.
- Rendered the final submission step as a `usa-icon-list__item`.
- Added standard checklist icon treatment using `icon-list-icon.html`.
- Preserved clickable behavior when submission is enabled.
- Preserved non-clickable behavior when submission is not enabled.
- Added a completed state that displays:
  - `Submit to the FAC for processing (Complete)`
- Kept existing explanatory and warning text.

## Before

The final submission action appeared in a shaded box and did not visually match the preceding checklist items.

## After

The final submission action appears as a checklist item:

- Completed submissions display a green checkmark and "(Complete)" status.
- Ready-to-submit audits display the final submission action as the next available checklist item.
- Users can more easily identify that submission is part of the checklist workflow.

## Screenshots

### Before
<img width="1284" height="676" alt="image" src="https://github.com/user-attachments/assets/2d2e595e-1000-40eb-b1f9-b35426d86648" />


### After - Ready for Submission
<img width="1365" height="696" alt="image" src="https://github.com/user-attachments/assets/b373a18d-262f-4cc4-8860-38acef3d1ba1" />

### After - Completed Submission
<img width="1328" height="696" alt="image" src="https://github.com/user-attachments/assets/531e41ee-3043-4dcb-b9b1-a013f92ed91c" />

## Testing

- [x] Verified checklist layout renders correctly.
- [x] Verified enabled state renders as a clickable link.
- [x] Verified completed state renders with completion styling.
- [x] Verified warning text remains visible.
- [x] Confirmed visual consistency with Auditor Certification and Auditee Certification checklist items.

## Files Changed

- `backend/audit/templates/audit/submission_progress/submission-checklist.html`

## Notes

The implementation currently uses `submission.accepted` to determine completion status. Future discussion may be warranted regarding whether disseminated reports should also display the final submission step as complete.
