### PR TITLE
Fix edit field record validation for entity type options

### DIFF
--- a/backend/curation/management/commands/update_after_submission.py
+++ b/backend/curation/management/commands/update_after_submission.py
@@ -189,7 +189,11 @@ def validate_entity_type_options(options):
 def have_pair_of(flag, options):
     old_flag = f"old_{flag}"
     new_flag = f"new_{flag}"
-    return not nonelike(options[old_flag]) and not nonelike(options[new_flag])
+
+    return (
+        not nonelike(options.get(old_flag))
+        and not nonelike(options.get(new_flag))
+    )
 
 
 def just_one_pair(flags, options):

--- a/backend/curation/management/commands/update_after_submission.py
+++ b/backend/curation/management/commands/update_after_submission.py
@@ -190,10 +190,7 @@ def have_pair_of(flag, options):
     old_flag = f"old_{flag}"
     new_flag = f"new_{flag}"
 
-    return (
-        not nonelike(options.get(old_flag))
-        and not nonelike(options.get(new_flag))
-    )
+    return not nonelike(options.get(old_flag)) and not nonelike(options.get(new_flag))
 
 
 def just_one_pair(flags, options):

--- a/backend/curation/models.py
+++ b/backend/curation/models.py
@@ -56,6 +56,8 @@ class EditRecord(models.Model):
             "new_auditee_name": None,
             "old_authorization": None,
             "new_authorization": None,
+            "old_entity_type": None,
+            "new_entity_type": None,
         }
         if self.field_to_edit == "uei":
             options.update({"old_uei": self.old_value, "new_uei": self.new_value})

--- a/backend/curation/test_edit_record_admin.py
+++ b/backend/curation/test_edit_record_admin.py
@@ -142,6 +142,8 @@ class TestEditRecordAdmin(TestCase):
                 "new_auditee_name": None,
                 "old_authorization": None,
                 "new_authorization": None,
+                "old_entity_type": None,
+                "new_entity_type": None,
             }
         )
 
@@ -178,6 +180,8 @@ class TestEditRecordAdmin(TestCase):
                 "new_auditee_name": None,
                 "old_authorization": None,
                 "new_authorization": None,
+                "old_entity_type": None,
+                "new_entity_type": None,
             },
             "ein",
         )
@@ -215,6 +219,8 @@ class TestEditRecordAdmin(TestCase):
                 "new_auditee_name": NEW_AUDITEE_NAME,
                 "old_authorization": None,
                 "new_authorization": None,
+                "old_entity_type": None,
+                "new_entity_type": None,
             },
             "auditee_name",
         )


### PR DESCRIPTION
## Description of changes
<!-- Give a high level summary of the changes made -->
* Fixes the Edit Field Record validation failure caused by missing `old_entity_type` and `new_entity_type` options.
* Adds default `old_entity_type` and `new_entity_type` values to the Edit Field Record options payload.
* Updates shared validation logic to use `options.get()` when checking old/new field pairs, preventing `KeyError` when optional fields are not provided.

## How to test
<!-- Provide clear instructions for testing your changes -->
1. Start the application and navigate to the Django admin.
2. Create an Edit Field Record for a disseminated report.
3. Test updating each supported field (`UEI`, `EIN`, and `Auditee Name`).
4. Verify the update completes successfully and the record status is set to `success`.
5. Verify the logs no longer contain `Validation failed: 'old_entity_type'`.
6. Verify invalid inputs are still rejected and the record status is set to `failed`.

## Screenshots and recordings
<!-- Optional for UI work. If there are none, delete this section. -->
* N/A – backend validation fix.