### PR TITLE
adding the aln workbook update template to ISSUE_TEMPLATE 

### DIFF
--- a/.github/ISSUE_TEMPLATE/aln-workbook-update-template.md
+++ b/.github/ISSUE_TEMPLATE/aln-workbook-update-template.md
@@ -1,0 +1,24 @@
+To ensure users have access to the most current ALNs and program names, the workbook source data and generated templates need to be refreshed.
+
+## Proposed Changes
+
+- Fetch the latest Active and Inactive Assistance Listings from the SAM.gov Assistance Listings API. (With all zeroes, including leading ones LOL)
+- Generate updated `active-alns.csv` and `inactive-alns.csv`.
+- Merge the source files to produce an updated `cfda-lookup.csv`.
+- Regenerate workbook templates and Cypress test workbooks using the updated ALN data.
+- Review the generated changes for expected additions, removals, and renamed programs.
+
+## Files Affected
+
+- `backend/schemas/source/data/aln_csvs_to_be_merged/active-alns.csv`
+- `backend/schemas/source/data/aln_csvs_to_be_merged/inactive-alns.csv`
+- `backend/schemas/source/data/cfda-lookup.csv`
+- Generated workbook templates in `backend/schemas/output/excel/`
+- Generated Cypress test workbooks in `backend/cypress/fixtures/test_workbooks/`
+
+## Acceptance Criteria
+
+- [ ] Latest Active and Inactive ALNs are retrieved from the SAM.gov Assistance Listings API.
+- [ ] `cfda-lookup.csv` is regenerated.
+- [ ] Workbook templates are regenerated using the updated lookup data.
+- [ ] Cypress test workbooks are regenerated.

--- a/terraform/meta/update-managed-files.py
+++ b/terraform/meta/update-managed-files.py
@@ -1,5 +1,6 @@
 import os
 
+
 def update_module_files(template_dir, dir, exclude_files, suffix="-managed"):
     root_path = os.path.dirname(os.path.abspath(__file__))
     for file in os.listdir(template_dir):
@@ -8,18 +9,19 @@ def update_module_files(template_dir, dir, exclude_files, suffix="-managed"):
 
         template_path = os.path.join(template_dir, file)
         if os.path.isfile(template_path):
-            with open(template_path, 'r') as loaded_file:
+            with open(template_path, "r") as loaded_file:
                 content = loaded_file.read()
 
             basename, ext = os.path.splitext(file)
             new_file = f"{basename}{suffix}.tf"
             output_path = os.path.join(f"{root_path}/../{dir}", new_file)
 
-            with open(output_path, 'w') as output_file:
+            with open(output_path, "w") as output_file:
                 output_file.write(content)
                 os.chmod(output_path, 0o644)
 
             print(f"Updated {dir}/{new_file}")
+
 
 environment_directory = ["preview", "dev", "staging", "production"]
 excluded_templates = ["main.tf-template", "init.sh-template"]


### PR DESCRIPTION
adding the aln workbook update template to ISSUE_TEMPLATE and black wanted to clean the terraform/meta/update-managed-files with ""

<!-- These are comments and will not appear when the PR is created -->
<!-- For more tips on creating PRs, see https://github.com/GSA-TTS/FAC/blob/main/docs/pull-request-checklist.md -->
## Related tickets
<!-- List all relevant tickets. If there are none, delete this section. -->
<!-- Tip: Use `Closes <ticket url>` to automatically close the ticket once merged -->
* https://github.com/GSA-TTS/FAC/issues/5761

## Description of changes
<!-- Give a high level summary of the changes made -->
* added a template for ISSUEs for the ALN workbook updates
* black wanted to change ' to " in terraform/meta/update-managed-files

## How to test
<!-- Provide clear instructions for testing your changes -->
* already tested in previous PR. This is just a change by black on update-managed-files
