### PR TITLE
API v1.3.0: Unified view

### DIFF
--- a/backend/dissemination/api/api_v1_3_0/base.sql
+++ b/backend/dissemination/api/api_v1_3_0/base.sql
@@ -1,0 +1,29 @@
+DO
+$do$
+BEGIN
+   IF EXISTS (
+      SELECT FROM pg_catalog.pg_roles
+      WHERE  rolname = 'authenticator') THEN
+      RAISE NOTICE 'Role "authenticator" already exists. Skipping.';
+   ELSE
+      CREATE ROLE authenticator LOGIN NOINHERIT NOCREATEDB NOCREATEROLE NOSUPERUSER;
+   END IF;
+END
+$do$;
+
+DO
+$do$
+BEGIN
+   IF EXISTS (
+      SELECT FROM pg_catalog.pg_roles
+      WHERE  rolname = 'api_fac_gov') THEN
+      RAISE NOTICE 'Role "api_fac_gov" already exists. Skipping.';
+   ELSE
+      CREATE ROLE api_fac_gov NOLOGIN;
+   END IF;
+END
+$do$;
+
+GRANT api_fac_gov TO authenticator;
+
+NOTIFY pgrst, 'reload schema';

--- a/backend/dissemination/api/api_v1_3_0/create_functions.sql
+++ b/backend/dissemination/api/api_v1_3_0/create_functions.sql
@@ -1,0 +1,129 @@
+-- WARNING
+-- Under PostgreSQL 12, the functions below work.
+-- Under PostgreSQL 14, these will break.
+--
+-- Note the differences:
+--
+-- raise info 'Works under PostgreSQL 12';
+-- raise info 'request.header.x-magic %', (SELECT current_setting('request.header.x-magic', true));
+-- raise info 'request.jwt.claim.expires %', (SELECT current_setting('request.jwt.claim.expires', true));
+-- raise info 'Works under PostgreSQL 14';
+-- raise info 'request.headers::json->>x-magic %', (SELECT current_setting('request.headers', true)::json->>'x-magic');
+-- raise info 'request.jwt.claims::json->expires %', (SELECT current_setting('request.jwt.claims', true)::json->>'expires');
+--
+-- To quote the work of Dav Pilkey, "remember this now."
+
+
+CREATE OR REPLACE FUNCTION api_v1_3_0_functions.get_header(item text) RETURNS text
+    AS $get_header$
+    declare res text;
+   	begin
+    	SELECT (current_setting('request.headers', true)::json)->>item into res;
+    	return res;
+   end;
+$get_header$ LANGUAGE plpgsql;
+
+create or replace function api_v1_3_0_functions.get_api_key_uuid() returns TEXT
+as $gaku$
+declare uuid text;
+begin
+	select api_v1_3_0_functions.get_header('x-api-user-id') into uuid;
+	return uuid;
+end;
+$gaku$ LANGUAGE plpgsql;
+
+create or replace function api_v1_3_0_functions.has_tribal_data_access()
+returns boolean
+as $has_tribal_data_access$
+DECLARE
+    uuid_header UUID;
+    key_exists boolean;
+BEGIN
+
+    SELECT api_v1_3_0_functions.get_api_key_uuid() INTO uuid_header;
+    SELECT
+        CASE WHEN EXISTS (
+            SELECT key_id
+            FROM public.dissemination_TribalApiAccessKeyIds taaki
+            WHERE taaki.key_id = uuid_header::TEXT)
+            THEN 1::BOOLEAN
+            ELSE 0::BOOLEAN
+            END
+        INTO key_exists;
+    RAISE INFO 'api_v1_3_0 has_tribal % %', uuid_header, key_exists;
+    RETURN key_exists;
+END;
+$has_tribal_data_access$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION api_v1_3_0_functions.is_public_audit_or_authorized_user(is_public BOOLEAN)
+RETURNS BOOLEAN AS $$
+BEGIN
+    RETURN (
+        is_public = true
+        OR
+        (is_public = false AND api_v1_3_0_functions.has_tribal_data_access())
+    );
+END;
+$$ LANGUAGE plpgsql STABLE;
+
+CREATE OR REPLACE FUNCTION api_v1_3_0_functions.is_most_recent_audit_or_authorized_user(resubmission_status TEXT)
+RETURNS BOOLEAN AS $$
+BEGIN
+    RETURN (
+        resubmission_status is NULL
+        OR
+        resubmission_status = 'most_recent'
+        OR
+        api_v1_3_0_functions.has_tribal_data_access()
+    );
+END;
+$$ LANGUAGE plpgsql STABLE;
+
+CREATE OR REPLACE FUNCTION api_v1_3_0.request_file_access(
+    report_id TEXT
+) RETURNS JSON LANGUAGE plpgsql AS
+$$
+DECLARE
+    v_uuid_header TEXT;
+    v_access_uuid VARCHAR(200);
+    v_key_exists BOOLEAN;
+    v_key_added_date DATE;
+BEGIN
+
+    SELECT api_v1_3_0_functions.get_api_key_uuid() INTO v_uuid_header;
+
+    -- Check if the provided API key exists in public.dissemination_TribalApiAccessKeyIds
+    SELECT
+        EXISTS(
+            SELECT 1
+            FROM public.dissemination_TribalApiAccessKeyIds
+            WHERE key_id = v_uuid_header
+        ) INTO v_key_exists;
+
+
+    -- Get the added date of the key from public.dissemination_TribalApiAccessKeyIds
+    SELECT date_added
+    INTO v_key_added_date
+    FROM public.dissemination_TribalApiAccessKeyIds
+    WHERE key_id = v_uuid_header;
+
+
+    -- Check if the key is less than 6 months old
+    IF v_uuid_header IS NOT NULL AND v_key_exists AND v_key_added_date >= CURRENT_DATE - INTERVAL '6 months' THEN
+        -- Generate UUID (using PostgreSQL's gen_random_uuid function)
+        SELECT gen_random_uuid() INTO v_access_uuid;
+
+        -- Inserting data into the one_time_access table
+        INSERT INTO public.dissemination_onetimeaccess (uuid, api_key_id, timestamp, report_id)
+        VALUES (v_access_uuid::UUID, v_uuid_header, CURRENT_TIMESTAMP, report_id);
+
+        -- Return the UUID to the user
+        RETURN json_build_object('access_uuid', v_access_uuid);
+    ELSE
+        -- Return an error for unauthorized access
+        RETURN json_build_object('error', 'Unauthorized access or key older than 6 months')::JSON;
+    END IF;
+END;
+$$;
+
+NOTIFY pgrst, 'reload schema';

--- a/backend/dissemination/api/api_v1_3_0/create_schema.sql
+++ b/backend/dissemination/api/api_v1_3_0/create_schema.sql
@@ -1,0 +1,48 @@
+begin;
+
+do
+$$
+begin
+    DROP SCHEMA IF EXISTS api_v1_3_0 CASCADE;
+    DROP SCHEMA IF EXISTS api_v1_3_0_functions CASCADE;
+
+    if not exists (select schema_name from information_schema.schemata where schema_name = 'api_v1_3_0') then
+        create schema api_v1_3_0;
+        create schema api_v1_3_0_functions;
+
+        grant usage on schema api_v1_3_0_functions to api_fac_gov;
+
+        -- Grant access to tables and views
+        alter default privileges
+            in schema api_v1_3_0
+            grant select
+        -- this includes views
+        on tables
+        to api_fac_gov;
+
+        -- Grant access to sequences, if we have them
+        grant usage on schema api_v1_3_0 to api_fac_gov;
+        grant select, usage on all sequences in schema api_v1_3_0 to api_fac_gov;
+        alter default privileges
+            in schema api_v1_3_0
+            grant select, usage
+        on sequences
+        to api_fac_gov;
+    end if;
+end
+$$
+;
+
+-- https://postgrest.org/en/stable/references/api/openapi.html
+-- This is the title (version number) and description (text).
+COMMENT ON SCHEMA api_v1_3_0 IS
+$$v1.1.0
+
+A RESTful API that serves data from the SF-SAC.$$;
+
+
+commit;
+
+notify pgrst,
+       'reload schema';
+

--- a/backend/dissemination/api/api_v1_3_0/create_schema.sql
+++ b/backend/dissemination/api/api_v1_3_0/create_schema.sql
@@ -36,7 +36,7 @@ $$
 -- https://postgrest.org/en/stable/references/api/openapi.html
 -- This is the title (version number) and description (text).
 COMMENT ON SCHEMA api_v1_3_0 IS
-$$v1.1.0
+$$v1.3.0
 
 A RESTful API that serves data from the SF-SAC.$$;
 

--- a/backend/dissemination/api/api_v1_3_0/create_views.sql
+++ b/backend/dissemination/api/api_v1_3_0/create_views.sql
@@ -391,8 +391,115 @@ create view api_v1_3_0.resubmission as
     order by resub.id
 ;
 
+---------------------------------------
+-- unified
+---------------------------------------
+create view api_v1_3_0.unified as
+    select
+        unified.report_id,
+        unified.award_reference,
+        unified.reference_number,
+        unified.aln,
+        unified.agencies_with_prior_findings,
+        unified.audit_period_covered,
+        unified.audit_type,
+        unified.audit_year,
+        unified.auditee_address_line_1,
+        unified.auditee_certified_date,
+        unified.auditee_certify_name,
+        unified.auditee_certify_title,
+        unified.auditee_city,
+        unified.auditee_contact_name,
+        unified.auditee_contact_title,
+        unified.auditee_ein,
+        unified.auditee_email,
+        unified.auditee_name,
+        unified.auditee_phone,
+        unified.auditee_state,
+        unified.auditee_uei,
+        unified.auditee_zip,
+        unified.auditor_address_line_1,
+        unified.auditor_certified_date,
+        unified.auditor_certify_name,
+        unified.auditor_certify_title,
+        unified.auditor_city,
+        unified.auditor_contact_name,
+        unified.auditor_contact_title,
+        unified.auditor_country,
+        unified.auditor_ein,
+        unified.auditor_email,
+        unified.auditor_firm_name,
+        unified.auditor_foreign_address,
+        unified.auditor_phone,
+        unified.auditor_state,
+        unified.auditor_zip,
+        unified.resubmission_version,
+        unified.resubmission_status,
+        unified.cognizant_agency,
+        unified.data_source,
+        unified.date_created,
+        unified.dollar_threshold,
+        unified.entity_type,
+        unified.fac_accepted_date,
+        unified.fy_end_date,
+        unified.fy_start_date,
+        unified.gaap_results,
+        unified.is_additional_ueis,
+        unified.is_aicpa_audit_guide_included,
+        unified.is_going_concern_included,
+        unified.is_internal_control_deficiency_disclosed,
+        unified.is_internal_control_material_weakness_disclosed,
+        unified.is_low_risk_auditee,
+        unified.is_material_noncompliance_disclosed,
+        unified.is_public,
+        unified.is_sp_framework_required,
+        unified.number_months,
+        unified.oversight_agency,
+        unified.ready_for_certification_date,
+        unified.sp_framework_basis,
+        unified.sp_framework_opinions,
+        unified.submitted_date,
+        unified.total_amount_expended,
+        unified.type_audit_code,
+        unified.additional_award_identification,
+        unified.amount_expended,
+        unified.cluster_name,
+        unified.cluster_total,
+        unified.federal_agency_prefix,
+        unified.federal_award_extension,
+        unified.federal_program_name,
+        unified.federal_program_total,
+        unified.findings_count,
+        unified.is_direct,
+        unified.is_loan,
+        unified.is_major,
+        unified.is_passthrough_award,
+        unified.loan_balance,
+        unified.audit_report_type,
+        unified.other_cluster_name,
+        unified.passthrough_amount,
+        unified.state_cluster_name,
+        unified.is_material_weakness,
+        unified.is_modified_opinion,
+        unified.is_other_findings,
+        unified.is_other_matters,
+        unified.is_questioned_costs,
+        unified.is_repeat_finding,
+        unified.is_significant_deficiency,
+        unified.prior_finding_ref_numbers,
+        unified.type_requirement,
+        unified.passthrough_name,
+        unified.passthrough_id
+    from
+        dissemination_unified unified
+    where
+        api_v1_3_0_functions.is_public_audit_or_authorized_user(unified.is_public)
+        and
+        api_v1_3_0_functions.is_most_recent_audit_or_authorized_user(unified.resubmission_status)
+    order by unified.id
+;
+
 commit;
 
 notify pgrst,
        'reload schema';
-

--- a/backend/dissemination/api/api_v1_3_0/create_views.sql
+++ b/backend/dissemination/api/api_v1_3_0/create_views.sql
@@ -1,0 +1,398 @@
+begin;
+
+---------------------------------------
+-- findings_text
+---------------------------------------
+create view api_v1_3_0.findings_text as
+    select
+        gen.report_id,
+        gen.auditee_uei,
+        gen.audit_year,
+        gen.fac_accepted_date,
+        ft.finding_ref_number,
+        ft.contains_chart_or_table,
+        ft.finding_text
+    from
+        dissemination_findingtext ft,
+        dissemination_general gen
+    where
+        ft.report_id = gen.report_id
+        and
+        api_v1_3_0_functions.is_public_audit_or_authorized_user(gen.is_public)
+        and
+        api_v1_3_0_functions.is_most_recent_audit_or_authorized_user(gen.resubmission_status)
+    order by ft.id
+;
+
+---------------------------------------
+-- additional_ueis
+---------------------------------------
+create view api_v1_3_0.additional_ueis as
+    select
+        gen.report_id,
+        gen.auditee_uei,
+        gen.audit_year,
+        gen.fac_accepted_date,
+        ---
+        uei.additional_uei
+    from
+        dissemination_general gen,
+        dissemination_additionaluei uei
+    where
+        gen.report_id = uei.report_id
+        and
+        api_v1_3_0_functions.is_most_recent_audit_or_authorized_user(gen.resubmission_status)
+    order by uei.id
+;
+
+---------------------------------------
+-- findings
+---------------------------------------
+create view api_v1_3_0.findings as
+    select
+        gen.report_id,
+        gen.auditee_uei,
+        gen.audit_year,
+        gen.fac_accepted_date,
+        finding.award_reference,
+        finding.reference_number,
+        finding.is_material_weakness,
+        finding.is_modified_opinion,
+        finding.is_other_findings,
+        finding.is_other_matters,
+        finding.prior_finding_ref_numbers,
+        finding.is_questioned_costs,
+        finding.is_repeat_finding,
+        finding.is_significant_deficiency,
+        finding.type_requirement
+    from
+        dissemination_finding finding,
+        dissemination_general gen
+    where
+        finding.report_id = gen.report_id
+        and
+        api_v1_3_0_functions.is_most_recent_audit_or_authorized_user(gen.resubmission_status)
+    order by finding.id
+;
+
+---------------------------------------
+-- federal_awards
+---------------------------------------
+create view api_v1_3_0.federal_awards as
+    select
+        award.report_id,
+        gen.auditee_uei,
+        gen.audit_year,
+        gen.fac_accepted_date,
+        ---
+        award.award_reference,
+        award.federal_agency_prefix,
+        award.federal_award_extension,
+        award.additional_award_identification,
+        award.federal_program_name,
+        award.amount_expended,
+        award.cluster_name,
+        award.other_cluster_name,
+        award.state_cluster_name,
+        award.cluster_total,
+        award.federal_program_total,
+        award.is_major,
+        award.is_loan,
+        award.loan_balance,
+        award.is_direct,
+        award.audit_report_type,
+        award.findings_count,
+        award.is_passthrough_award,
+        award.passthrough_amount
+    from
+        dissemination_federalaward award,
+        dissemination_general gen
+    where
+        award.report_id = gen.report_id
+        and
+        api_v1_3_0_functions.is_most_recent_audit_or_authorized_user(gen.resubmission_status)
+    order by award.id
+;
+
+
+---------------------------------------
+-- corrective_action_plans
+---------------------------------------
+create view api_v1_3_0.corrective_action_plans as
+    select
+        gen.report_id,
+        gen.auditee_uei,
+        gen.audit_year,
+        gen.fac_accepted_date,
+        ---
+        ct.finding_ref_number,
+        ct.contains_chart_or_table,
+        ct.planned_action
+    from
+        dissemination_CAPText ct,
+        dissemination_General gen
+    where
+        ct.report_id = gen.report_id
+        and
+        api_v1_3_0_functions.is_public_audit_or_authorized_user(gen.is_public)
+        and
+        api_v1_3_0_functions.is_most_recent_audit_or_authorized_user(gen.resubmission_status)
+    order by ct.id
+;
+
+---------------------------------------
+-- notes_to_sefa
+---------------------------------------
+create view api_v1_3_0.notes_to_sefa as
+    select
+        gen.report_id,
+        gen.auditee_uei,
+        gen.audit_year,
+        gen.fac_accepted_date,
+        ---
+        note.note_title as title,
+        note.accounting_policies,
+        note.is_minimis_rate_used,
+        note.rate_explained,
+        note.content,
+        note.contains_chart_or_table
+    from
+        dissemination_general gen,
+        dissemination_note note
+    where
+        note.report_id = gen.report_id
+        and
+        api_v1_3_0_functions.is_public_audit_or_authorized_user(gen.is_public)
+        and
+        api_v1_3_0_functions.is_most_recent_audit_or_authorized_user(gen.resubmission_status)
+    order by note.id
+;
+
+---------------------------------------
+-- passthrough
+---------------------------------------
+create view api_v1_3_0.passthrough as
+    select
+        gen.report_id,
+        gen.auditee_uei,
+        gen.audit_year,
+        gen.fac_accepted_date,
+        ---
+        pass.award_reference,
+        pass.passthrough_id,
+        pass.passthrough_name
+    from
+        dissemination_general as gen,
+        dissemination_passthrough as pass
+    where
+        gen.report_id = pass.report_id
+        and
+        api_v1_3_0_functions.is_most_recent_audit_or_authorized_user(gen.resubmission_status)
+    order by pass.id
+;
+
+
+---------------------------------------
+-- general
+---------------------------------------
+create view api_v1_3_0.general as
+    select
+        -- every table starts with report_id, UEI, and year
+        gen.report_id,
+        gen.auditee_uei,
+        gen.audit_year,
+        --- auditee
+        gen.auditee_certify_name,
+        gen.auditee_certify_title,
+        gen.auditee_contact_name,
+        gen.auditee_email,
+        gen.auditee_name,
+        gen.auditee_phone,
+        gen.auditee_contact_title,
+        gen.auditee_address_line_1,
+        gen.auditee_city,
+        gen.auditee_state,
+        gen.auditee_ein,
+        gen.auditee_zip,
+        -- auditor
+        gen.auditor_certify_name,
+        gen.auditor_certify_title,
+        gen.auditor_phone,
+        gen.auditor_state,
+        gen.auditor_city,
+        gen.auditor_contact_title,
+        gen.auditor_address_line_1,
+        gen.auditor_zip,
+        gen.auditor_country,
+        gen.auditor_contact_name,
+        gen.auditor_email,
+        gen.auditor_firm_name,
+        gen.auditor_foreign_address,
+        gen.auditor_ein,
+        -- agency
+        coalesce(gen.cognizant_agency,'') as cognizant_agency,
+        coalesce(gen.oversight_agency,'') as oversight_agency,
+        -- dates
+        gen.date_created,
+        gen.ready_for_certification_date,
+        gen.auditor_certified_date,
+        gen.auditee_certified_date,
+        gen.submitted_date,
+        gen.fac_accepted_date,
+        gen.fy_end_date,
+        gen.fy_start_date,
+        --- audit info and metadata
+        gen.audit_type,
+        gen.gaap_results,
+        gen.sp_framework_basis,
+        gen.is_sp_framework_required,
+        gen.sp_framework_opinions,
+        gen.is_going_concern_included,
+        gen.is_internal_control_deficiency_disclosed,
+        gen.is_internal_control_material_weakness_disclosed,
+        gen.is_material_noncompliance_disclosed,
+        gen.dollar_threshold,
+        gen.is_low_risk_auditee,
+        gen.agencies_with_prior_findings,
+        gen.entity_type,
+        gen.number_months,
+        gen.audit_period_covered,
+        gen.total_amount_expended,
+        gen.type_audit_code,
+        gen.is_public,
+        gen.data_source,
+        gen.is_aicpa_audit_guide_included,
+        gen.is_additional_ueis,
+        gen.resubmission_version,
+        gen.resubmission_status,
+        CASE EXISTS(SELECT ein.report_id FROM dissemination_additionalein ein WHERE ein.report_id = gen.report_id)
+            WHEN FALSE THEN 'No'
+            ELSE 'Yes'
+        END AS is_multiple_eins,
+        CASE EXISTS(SELECT aud.report_id FROM dissemination_secondaryauditor aud WHERE aud.report_id = gen.report_id)
+            WHEN FALSE THEN 'No'
+            ELSE 'Yes'
+        END AS is_secondary_auditors
+    from
+        dissemination_general gen
+    where
+        api_v1_3_0_functions.is_most_recent_audit_or_authorized_user(gen.resubmission_status)
+    order by gen.id
+;
+
+---------------------------------------
+-- secondary_auditors
+---------------------------------------
+create view api_v1_3_0.secondary_auditors as
+    select
+        gen.report_id,
+        gen.auditee_uei,
+        gen.audit_year,
+        gen.fac_accepted_date,
+        ---
+        sa.auditor_ein,
+        sa.auditor_name,
+        sa.contact_name,
+        sa.contact_title,
+        sa.contact_email,
+        sa.contact_phone,
+        sa.address_street,
+        sa.address_city,
+        sa.address_state,
+        sa.address_zipcode
+    from
+        dissemination_General gen,
+        dissemination_SecondaryAuditor sa
+    where
+        sa.report_id = gen.report_id
+        and
+        api_v1_3_0_functions.is_most_recent_audit_or_authorized_user(gen.resubmission_status)
+    order by sa.id
+;
+
+---------------------------------------
+-- additional_eins
+---------------------------------------
+create view api_v1_3_0.additional_eins as
+    select
+        gen.report_id,
+        gen.auditee_uei,
+        gen.audit_year,
+        gen.fac_accepted_date,
+        ---
+        ein.additional_ein
+    from
+        dissemination_general gen,
+        dissemination_additionalein ein
+    where
+        gen.report_id = ein.report_id
+        and
+        api_v1_3_0_functions.is_most_recent_audit_or_authorized_user(gen.resubmission_status)
+    order by ein.id
+;
+
+---------------------------------------
+-- resubmission
+---------------------------------------
+create view api_v1_3_0.resubmission as
+    with recursive chain as (
+        -- Base case: start from each resubmission row
+        select
+            resub.report_id,
+            resub.previous_report_id,
+            resub.report_id as origin_report_id
+        from
+            dissemination_resubmission resub
+
+        union all
+
+        -- Recursive step: follow previous_report_id links
+        select
+            c.report_id,
+            prev.previous_report_id,
+            prev.report_id as origin_report_id
+        from
+            chain c
+            join dissemination_resubmission prev
+                on c.previous_report_id = prev.report_id
+        where
+            c.previous_report_id is not null
+    ),
+    -- Select only the final row in each chain (the original submission)
+    original as (
+        select
+            chain.report_id,
+            orig_gen.fac_accepted_date as original_submission_date
+        from
+            chain
+            join dissemination_general orig_gen
+                on chain.origin_report_id = orig_gen.report_id
+        where
+            chain.previous_report_id is null
+    )
+    select
+        gen.report_id,
+        gen.auditee_uei,
+        gen.audit_year,
+        gen.fac_accepted_date,
+        ---
+        resub.version,
+        resub.status,
+        resub.previous_report_id,
+        resub.next_report_id,
+        original.original_submission_date
+    from
+        dissemination_general gen,
+        dissemination_resubmission resub
+        left join original
+            on resub.report_id = original.report_id
+    where
+        gen.report_id = resub.report_id
+    order by resub.id
+;
+
+commit;
+
+notify pgrst,
+       'reload schema';
+

--- a/backend/dissemination/api/api_v1_3_0/drop_schema.sql
+++ b/backend/dissemination/api/api_v1_3_0/drop_schema.sql
@@ -1,0 +1,11 @@
+
+begin;
+
+DROP SCHEMA IF EXISTS api_v1_3_0 CASCADE;
+-- DROP ROLE IF EXISTS authenticator;
+-- DROP ROLE IF EXISTS api_fac_gov;
+
+commit;
+
+notify pgrst,
+       'reload schema';

--- a/backend/dissemination/api/api_v1_3_0/drop_views.sql
+++ b/backend/dissemination/api/api_v1_3_0/drop_views.sql
@@ -1,0 +1,17 @@
+begin;
+    drop table if exists api_v1_3_0.metadata;
+    drop view if exists api_v1_3_0.general;
+    drop view if exists api_v1_3_0.auditor;
+    drop view if exists api_v1_3_0.federal_awards;
+    drop view if exists api_v1_3_0.findings;
+    drop view if exists api_v1_3_0.findings_text;
+    drop view if exists api_v1_3_0.corrective_action_plans;
+    drop view if exists api_v1_3_0.additional_ueis;
+    drop view if exists api_v1_3_0.notes_to_sefa;
+    drop view if exists api_v1_3_0.passthrough;
+    drop view if exists api_v1_3_0.secondary_auditors;
+    drop view if exists api_v1_3_0.additional_eins;
+commit;
+
+notify pgrst,
+       'reload schema';

--- a/backend/dissemination/api/api_v1_3_0/drop_views.sql
+++ b/backend/dissemination/api/api_v1_3_0/drop_views.sql
@@ -11,6 +11,7 @@ begin;
     drop view if exists api_v1_3_0.passthrough;
     drop view if exists api_v1_3_0.secondary_auditors;
     drop view if exists api_v1_3_0.additional_eins;
+    drop view if exists api_v1_3_0.unified;
 commit;
 
 notify pgrst,

--- a/backend/dissemination/api_versions.py
+++ b/backend/dissemination/api_versions.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 # These are API versions we want live.
 live = {
-    "dissemination": ["api_v1_1_0", "api_v1_2_0"],
+    "dissemination": ["api_v1_1_0", "api_v1_2_0", "api_v1_3_0"],
     "support": ["admin_api_v1_1_0"],
 }
 

--- a/backend/docker-compose-web.yml
+++ b/backend/docker-compose-web.yml
@@ -97,7 +97,7 @@ services:
       PGRST_OPENAPI_SERVER_PROXY_URI: http://127.0.0.1:3000
       PGRST_DB_ANON_ROLE: anon
       # See https://postgrest.org/en/stable/references/api/schemas.html#multiple-schemas for multiple schemas
-      PGRST_DB_SCHEMAS: "api_v1_1_0, api_v1_2_0, admin_api_v1_1_0"
+      PGRST_DB_SCHEMAS: "api_v1_1_0, api_v1_2_0, api_v1_3_0, admin_api_v1_1_0"
       PGRST_JWT_SECRET: ${PGRST_JWT_SECRET:-32_chars_fallback_secret_testing} # Fallback value for testing environments
     depends_on:
       db:

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -135,7 +135,7 @@ services:
       PGRST_OPENAPI_SERVER_PROXY_URI: http://127.0.0.1:3000
       PGRST_DB_ANON_ROLE: anon
       # See https://postgrest.org/en/stable/references/api/schemas.html#multiple-schemas for multiple schemas
-      PGRST_DB_SCHEMAS: "api_v1_1_0, api_v1_2_0, admin_api_v1_1_0"
+      PGRST_DB_SCHEMAS: "api_v1_1_0, api_v1_2_0, api_v1_3_0, admin_api_v1_1_0"
       PGRST_JWT_SECRET: ${PGRST_JWT_SECRET:-32_chars_fallback_secret_testing} # Fallback value for testing environments
       # Enable this to inspect the DB plans for queries via EXPLAIN
       PGRST_DB_PLAN_ENABLED: ${PGRST_DB_PLAN_ENABLED:-false}

--- a/terraform/shared/modules/env/postgrest.tf
+++ b/terraform/shared/modules/env/postgrest.tf
@@ -25,7 +25,7 @@ resource "cloudfoundry_app" "postgrest" {
   strategy     = "rolling"
   environment = {
     PGRST_DB_URI : cloudfoundry_service_key.postgrest.credentials.uri
-    PGRST_DB_SCHEMAS : "api_v1_1_0,api_v1_2_0,admin_api_v1_1_0"
+    PGRST_DB_SCHEMAS : "api_v1_1_0,api_v1_2_0,api_v1_3_0,admin_api_v1_1_0"
     PGRST_DB_ANON_ROLE : "anon"
     PGRST_JWT_SECRET : var.pgrst_jwt_secret
     PGRST_DB_MAX_ROWS : 20000


### PR DESCRIPTION
<!-- These are comments and will not appear when the PR is created -->
<!-- For more tips on creating PRs, see https://github.com/GSA-TTS/FAC/blob/main/docs/pull-request-checklist.md -->
## Related tickets
<!-- List all relevant tickets. If there are none, delete this section. -->
<!-- Tip: Use `Closes <ticket url>` to automatically close the ticket once merged -->
* Closes https://github.com/GSA-TTS/FAC/issues/5681

## Description of changes
<!-- Give a high level summary of the changes made -->
* Creating API v1.3.0, which makes the `dissemination_unified` data available via `/unified` endpoint

## How to test
<!-- Provide clear instructions for testing your changes -->
* Make some requests in Postman using the `Accept-Profile: api_v1_3_0` header. I used the 20k dump.
  * http://localhost:3000/unified?audit_year=eq.2023
  * http://localhost:3000/unified?report_id=eq.2023-03-GSAFAC-0000000812
  * http://localhost:3000/unified?aln=eq.14.872
* Ensure v1.3.0 isn't being used as the default by removing the `Accept-Profile` header. You should get the error `relation "api_v1_1_0.unified" does not exist`