### PR TITLE
Forcing setuptools v83

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1574,10 +1574,11 @@ zope-interface==7.1.0 \
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==75.2.0 \
-    --hash=sha256:753bb6ebf1f465a1912e19ed1d41f403a79173a9acf66a42e7e6aec45c3c16ec \
-    --hash=sha256:a7fcb66f68b4d9e8e66b42f9876150a3371558f98fa32222ffaa5bced76406f8
+setuptools==83.0.0 \
+    --hash=sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef \
+    --hash=sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3
     # via
+    #   -r ./requirements/requirements.in
     #   fs
     #   zope-event
     #   zope-interface

--- a/backend/requirements/requirements.in
+++ b/backend/requirements/requirements.in
@@ -39,6 +39,7 @@ python-json-logger==2.0.7
 python-slugify==8.0.4
 pyyaml==6.0.2
 requests==2.32.4
+setuptools==83.0.0
 sqlalchemy==2.0.36
 sqlparse==0.5.5
 types-python-dateutil==2.9.0.20240821


### PR DESCRIPTION
<!-- These are comments and will not appear when the PR is created -->
<!-- For more tips on creating PRs, see https://github.com/GSA-TTS/FAC/blob/main/docs/pull-request-checklist.md -->
## Related tickets
<!-- List all relevant tickets. If there are none, delete this section. -->
<!-- Tip: Use `Closes <ticket url>` to automatically close the ticket once merged -->
* Closes https://github.com/GSA-TTS/FAC/issues/5743

## Description of changes
<!-- Give a high level summary of the changes made -->
* The version of setuptools used by the app is pretty old. Normally it shouldn't be in a `requirements` file at all, but we're [forced to use an old version of Gunicorn](https://github.com/GSA-TTS/FAC/issues/5521) and it's old `zope-*` dependencies require it.
* The [Dependabot PR](https://github.com/GSA-TTS/FAC/pull/5558) also updates `sqlparse`, but we [already did that](https://github.com/GSA-TTS/FAC/blob/main/backend/requirements/requirements.in#L43)

## How to test
<!-- Provide clear instructions for testing your changes -->
* App runs as normal
