### PR TITLE
Offboarding Checklist - Repository List

### DIFF
--- a/.github/ISSUE_TEMPLATE/offboarding.md
+++ b/.github/ISSUE_TEMPLATE/offboarding.md
@@ -28,5 +28,11 @@ assignees: ''
 ## For admins
 - [ ] If the departing team member is a Google Group manager, designate a new manager for any groups they manage.
 - [ ] Make someone else the Maintainer and remove the departing team member from [the FAC-admins team in GitHub](https://github.com/orgs/GSA-TTS/teams/fac-admins/members) and [the FAC-team team in GitHub](https://github.com/orgs/GSA-TTS/teams/fac-team/members).
-- [ ] Remove any deployment tokens associated with the PL/PO from the repository.
+- [ ] Remove any deployment tokens or keys associated with the PL/PO from the repository.
+  - [ ] The [FAC app](https://github.com/GSA-TTS/FAC) repository
+  - [ ] The [static site](https://github.com/GSA-TTS/FAC-transition-site) repository
+  - [ ] The [FAC team](https://github.com/GSA-TTS/fac-team) repository
+  - [ ] The [FAC ops](https://github.com/GSA-TTS/fac-ops) repository
+  - [ ] The [ClamAV REST](https://github.com/GSA-TTS/clamav-rest) fork repository
+  - [ ] The [backup utility](https://github.com/GSA-TTS/fac-backup-utility) repository
 - [ ] Ensure there's someone with "manage sharing" permission on the Google Calendar (fac-team-two)


### PR DESCRIPTION
Update the offboarding checklist with a repository list for secrets/tokens that may need to be cycled.

We have deployment tokens and secrets in lots of places. The vast majority are here, in the app repo. But we should be checking everything when offboarding an admin.