### PR TITLE
Added condition to check for service-account for local development

### DIFF
--- a/backend/tools/setup_local_env.sh
+++ b/backend/tools/setup_local_env.sh
@@ -10,7 +10,13 @@ function setup_local_env {
         rc alias set local "${AWS_S3_PRIVATE_ENDPOINT}" rustfsadmin rustfsadmin
         # Do nothing if the bucket already exists.
         rc mb --ignore-existing local/gsa-fac-private-s3
-        rc admin service-account create local $AWS_PRIVATE_ACCESS_KEY_ID $AWS_PRIVATE_SECRET_ACCESS_KEY
+        
+        if rc admin service-account list local | grep -q "$AWS_PRIVATE_ACCESS_KEY_ID"; then 
+            echo "Service account ${AWS_PRIVATE_ACCESS_KEY_ID} already exists."
+        else
+            echo "Service account ${AWS_PRIVATE_ACCESS_KEY_ID} not found. Creating..."
+            rc admin service-account create local $AWS_PRIVATE_ACCESS_KEY_ID $AWS_PRIVATE_SECRET_ACCESS_KEY
+        fi
         return 0
     fi;
 }


### PR DESCRIPTION
<!-- These are comments and will not appear when the PR is created -->
<!-- For more tips on creating PRs, see https://github.com/GSA-TTS/FAC/blob/main/docs/pull-request-checklist.md --> 

## Description of changes
<!-- Give a high level summary of the changes made -->
* There is a 500 error when running `rc admin service-account create` when the service account already exists. This PR adds a check to determine if that command should be run.