### PR TITLE
Rm/ein cross validation

### DIFF
--- a/backend/audit/cross_validation/__init__.py
+++ b/backend/audit/cross_validation/__init__.py
@@ -93,6 +93,7 @@ from .check_auditee_auditor_ein_match import check_auditee_auditor_ein_match
 from .check_name_fields_not_unique import check_name_fields_not_unique
 from .check_resubmission_has_changes import check_resubmission_has_changes
 from .check_resubmission_metadata import check_resubmission_metadata
+from .check_previous_ein import check_previous_ein
 
 functions = [
     # "Errors", or validations that would prevent a submission upon failure.
@@ -126,4 +127,5 @@ functions = [
     check_auditee_auditor_ein_match,
     check_name_fields_not_unique,
     check_resubmission_has_changes,
+    check_previous_ein,
 ]

--- a/backend/audit/cross_validation/check_previous_ein.py
+++ b/backend/audit/cross_validation/check_previous_ein.py
@@ -4,7 +4,7 @@ from audit.utils import Util
 def check_previous_ein(sac, sar=None):
     """
     Warn when the EIN for a new submission does not match the EIN
-    from a previous fully accepted dissemination record with the same UEI.
+    from the previous fully accepted dissemination record with the same UEI.
     """
     general_information = sac["sf_sac_sections"].get(
         "general_information",

--- a/backend/audit/cross_validation/check_previous_ein.py
+++ b/backend/audit/cross_validation/check_previous_ein.py
@@ -1,0 +1,25 @@
+from audit.utils import Util
+
+
+def check_previous_ein(sac, sar=None):
+    """
+    Warn when the EIN for a new submission does not match the EIN
+    from a previous fully accepted dissemination record with the same UEI.
+    """
+    general_information = sac["sf_sac_sections"].get(
+        "general_information",
+        {},
+    )
+
+    current_uei = general_information.get("auditee_uei")
+    current_ein = general_information.get("ein")
+
+    warning = Util.get_previous_ein_warning(
+        current_uei,
+        current_ein,
+    )
+
+    if not warning:
+        return []
+
+    return [{"warning": warning}]

--- a/backend/audit/cross_validation/test_check_previous_ein.py
+++ b/backend/audit/cross_validation/test_check_previous_ein.py
@@ -1,0 +1,92 @@
+from datetime import date
+
+from django.test import TestCase
+from model_bakery import baker
+
+from dissemination.models import General
+from audit.cross_validation.check_previous_ein import check_previous_ein
+
+
+class TestCheckPreviousEin(TestCase):
+    def build_sac(self, uei="TEST_UEI", ein="12-3456789"):
+        return {
+            "sf_sac_sections": {
+                "general_information": {
+                    "auditee_uei": uei,
+                    "ein": ein,
+                }
+            }
+        }
+
+    def test_no_warning_when_no_previous_submission(self):
+        self.assertEqual(check_previous_ein(self.build_sac()), [])
+
+    def test_no_warning_when_ein_matches_previous_submission(self):
+        baker.make(
+            General,
+            auditee_uei="TEST_UEI",
+            auditee_ein="12-3456789",
+            fac_accepted_date=date(2025, 1, 1),
+            fy_end_date=date(2025, 9, 30),
+            audit_year="2025",
+        )
+
+        result = check_previous_ein(self.build_sac())
+
+        self.assertEqual(result, [])
+
+    def test_warning_when_ein_does_not_match_previous_submission(self):
+        baker.make(
+            General,
+            auditee_uei="TEST_UEI",
+            auditee_ein="12-3456789",
+            fac_accepted_date=date(2025, 1, 1),
+            fy_end_date=date(2025, 9, 30),
+            audit_year="2025",
+        )
+
+        result = check_previous_ein(self.build_sac(ein="98-7654321"))
+
+        self.assertEqual(len(result), 1)
+        self.assertIn("warning", result[0])
+        self.assertIn("12-3456789", result[0]["warning"])
+        self.assertIn("98-7654321", result[0]["warning"])
+
+    def test_uses_most_recent_accepted_submission(self):
+        baker.make(
+            General,
+            auditee_uei="TEST_UEI",
+            auditee_ein="11-1111111",
+            fac_accepted_date=date(2024, 1, 1),
+            fy_end_date=date(2024, 9, 30),
+            audit_year="2024",
+        )
+
+        baker.make(
+            General,
+            auditee_uei="TEST_UEI",
+            auditee_ein="22-2222222",
+            fac_accepted_date=date(2025, 1, 1),
+            fy_end_date=date(2025, 9, 30),
+            audit_year="2025",
+        )
+
+        result = check_previous_ein(self.build_sac(ein="98-7654321"))
+
+        self.assertEqual(len(result), 1)
+        self.assertIn("22-2222222", result[0]["warning"])
+        self.assertNotIn("11-1111111", result[0]["warning"])
+
+    def test_does_not_warn_for_different_uei(self):
+        baker.make(
+            General,
+            auditee_uei="OTHER_UEI",
+            auditee_ein="12-3456789",
+            fac_accepted_date=date(2025, 1, 1),
+            fy_end_date=date(2025, 9, 30),
+            audit_year="2025",
+        )
+
+        result = check_previous_ein(self.build_sac(uei="TEST_UEI", ein="98-7654321"))
+
+        self.assertEqual(result, [])

--- a/backend/audit/cross_validation/test_check_previous_ein.py
+++ b/backend/audit/cross_validation/test_check_previous_ein.py
@@ -3,8 +3,8 @@ from datetime import date
 from django.test import TestCase
 from model_bakery import baker
 
-from dissemination.models import General
 from audit.cross_validation.check_previous_ein import check_previous_ein
+from dissemination.models import General
 
 
 class TestCheckPreviousEin(TestCase):
@@ -24,6 +24,7 @@ class TestCheckPreviousEin(TestCase):
     def test_no_warning_when_ein_matches_previous_submission(self):
         baker.make(
             General,
+            report_id="2025-09-GSAFAC-0000000001",
             auditee_uei="TEST_UEI",
             auditee_ein="12-3456789",
             fac_accepted_date=date(2025, 1, 1),
@@ -36,8 +37,11 @@ class TestCheckPreviousEin(TestCase):
         self.assertEqual(result, [])
 
     def test_warning_when_ein_does_not_match_previous_submission(self):
+        previous_report_id = "2025-09-GSAFAC-0000000001"
+
         baker.make(
             General,
+            report_id=previous_report_id,
             auditee_uei="TEST_UEI",
             auditee_ein="12-3456789",
             fac_accepted_date=date(2025, 1, 1),
@@ -49,12 +53,17 @@ class TestCheckPreviousEin(TestCase):
 
         self.assertEqual(len(result), 1)
         self.assertIn("warning", result[0])
+        self.assertIn(previous_report_id, result[0]["warning"])
         self.assertIn("12-3456789", result[0]["warning"])
         self.assertIn("98-7654321", result[0]["warning"])
 
     def test_uses_most_recent_accepted_submission(self):
+        older_report_id = "2024-09-GSAFAC-0000000001"
+        newest_report_id = "2025-09-GSAFAC-0000000002"
+
         baker.make(
             General,
+            report_id=older_report_id,
             auditee_uei="TEST_UEI",
             auditee_ein="11-1111111",
             fac_accepted_date=date(2024, 1, 1),
@@ -64,6 +73,7 @@ class TestCheckPreviousEin(TestCase):
 
         baker.make(
             General,
+            report_id=newest_report_id,
             auditee_uei="TEST_UEI",
             auditee_ein="22-2222222",
             fac_accepted_date=date(2025, 1, 1),
@@ -74,12 +84,15 @@ class TestCheckPreviousEin(TestCase):
         result = check_previous_ein(self.build_sac(ein="98-7654321"))
 
         self.assertEqual(len(result), 1)
+        self.assertIn(newest_report_id, result[0]["warning"])
         self.assertIn("22-2222222", result[0]["warning"])
+        self.assertNotIn(older_report_id, result[0]["warning"])
         self.assertNotIn("11-1111111", result[0]["warning"])
 
     def test_does_not_warn_for_different_uei(self):
         baker.make(
             General,
+            report_id="2025-09-GSAFAC-0000000001",
             auditee_uei="OTHER_UEI",
             auditee_ein="12-3456789",
             fac_accepted_date=date(2025, 1, 1),
@@ -87,6 +100,11 @@ class TestCheckPreviousEin(TestCase):
             audit_year="2025",
         )
 
-        result = check_previous_ein(self.build_sac(uei="TEST_UEI", ein="98-7654321"))
+        result = check_previous_ein(
+            self.build_sac(
+                uei="TEST_UEI",
+                ein="98-7654321",
+            )
+        )
 
         self.assertEqual(result, [])

--- a/backend/audit/utils.py
+++ b/backend/audit/utils.py
@@ -93,8 +93,54 @@ class Util:
             return redirect("/")
 
     @staticmethod
+    def get_previous_ein_mismatch(auditee_uei, current_ein):
+        """
+        Return the most recent accepted EIN for the UEI when it differs
+        from the current EIN. Otherwise, return None.
+        """
+        from dissemination.models import General
+
+        if not auditee_uei or not current_ein:
+            return None
+
+        previous_submission = (
+            General.objects.filter(
+                auditee_uei=auditee_uei,
+            )
+            .order_by("-fy_end_date")
+            .first()
+        )
+
+        if not previous_submission:
+            return None
+
+        previous_ein = previous_submission.auditee_ein
+
+        if not previous_ein or previous_ein == current_ein:
+            return None
+
+        return previous_ein
+
+    @staticmethod
     def format_date(date):
         return date.strftime("%Y-%m-%d")
+
+    @staticmethod
+    def get_previous_ein_warning(auditee_uei, current_ein):
+        previous_ein = Util.get_previous_ein_mismatch(
+            auditee_uei,
+            current_ein,
+        )
+
+        if not previous_ein:
+            return None
+
+        return (
+            f"The EIN entered for this submission ({current_ein}) "
+            f"does not match the EIN used in a previously accepted "
+            f"submission ({previous_ein}) for this UEI. "
+            "If this change is intentional, you may continue submitting."
+        )
 
 
 class ExcelExtractionError(Exception):

--- a/backend/audit/utils.py
+++ b/backend/audit/utils.py
@@ -33,6 +33,7 @@ from audit.validators import (
     validate_notes_to_sefa_json,
     validate_secondary_auditors_json,
 )
+from dissemination.models import General
 
 
 class Util:
@@ -95,11 +96,9 @@ class Util:
     @staticmethod
     def get_previous_ein_mismatch(auditee_uei, current_ein):
         """
-        Return the most recent accepted EIN for the UEI when it differs
-        from the current EIN. Otherwise, return None.
+        Return the most recent accepted submission for the UEI when its EIN
+        differs from the current EIN. Otherwise, return None.
         """
-        from dissemination.models import General
-
         if not auditee_uei or not current_ein:
             return None
 
@@ -119,27 +118,25 @@ class Util:
         if not previous_ein or previous_ein == current_ein:
             return None
 
-        return previous_ein
-
-    @staticmethod
-    def format_date(date):
-        return date.strftime("%Y-%m-%d")
+        return previous_submission
 
     @staticmethod
     def get_previous_ein_warning(auditee_uei, current_ein):
-        previous_ein = Util.get_previous_ein_mismatch(
+        previous_submission = Util.get_previous_ein_mismatch(
             auditee_uei,
             current_ein,
         )
 
-        if not previous_ein:
+        if not previous_submission:
             return None
 
         return (
             f"The EIN entered for this submission ({current_ein}) "
-            f"does not match the EIN used in a previously accepted "
-            f"submission ({previous_ein}) for this UEI. "
-            "If this change is intentional, you may continue submitting."
+            f"does not match the EIN used in the previously accepted "
+            f"submission ({previous_submission.report_id}), "
+            f"which used EIN ({previous_submission.auditee_ein}) "
+            "for this UEI. If this change is intentional, "
+            "you may continue submitting."
         )
 
 

--- a/backend/report_submission/templates/report_submission/gen-form.html
+++ b/backend/report_submission/templates/report_submission/gen-form.html
@@ -161,12 +161,30 @@
                             <legend class="usa-legend">Auditee Employer Identification Number (EIN)</legend>
                             <div class="usa-form-group">
                                 <label class="usa-label" for="ein">What is your Auditee EIN?</label>
+
                                 <input class="usa-input"
-                                       id="ein"
-                                       name="ein"
-                                       aria-required="false"
-                                       value="{{ ein | default_if_none:'' }}" />
-                                <span class="usa-error-message" id="ein-error-message" role="alert">{{ errors.ein|space_before_striptags }}</span>
+                                    id="ein"
+                                    name="ein"
+                                    aria-required="false"
+                                    data-warning-url="{% url 'report_submission:auditee_ein_warning' report_id %}"
+                                    value="{{ ein | default_if_none:'' }}" />
+
+                                <span class="usa-error-message"
+                                    id="ein-error-message"
+                                    role="alert">
+                                    {{ errors.ein|space_before_striptags }}
+                                </span>
+
+                                <div id="auditee-ein-warning"
+                                    class="usa-alert usa-alert--warning margin-top-2"
+                                    role="alert"
+                                    {% if not auditee_ein_warning %}hidden{% endif %}>
+                                    <div class="usa-alert__body">
+                                        <p class="usa-alert__text" id="auditee-ein-warning-text">
+                                            {{ auditee_ein_warning }}
+                                        </p>
+                                    </div>
+                                </div>
                             </div>
                             <div class="usa-checkbox">
                                 <input class="usa-checkbox__input"

--- a/backend/report_submission/urls.py
+++ b/backend/report_submission/urls.py
@@ -1,5 +1,8 @@
 from django.urls import path
 from . import views
+from report_submission.views.general_information_form_view import (
+    AuditeeEinWarningView,
+)
 
 app_name = "report_submission"
 
@@ -54,6 +57,11 @@ urlpatterns = [
         "general-information/<str:report_id>",
         views.GeneralInformationFormView.as_view(),
         name="general_information",
+    ),
+    path(
+        "general-information/<str:report_id>/auditee-ein-warning",
+        AuditeeEinWarningView.as_view(),
+        name="auditee_ein_warning",
     ),
 ]
 

--- a/backend/report_submission/views/general_information_form_view.py
+++ b/backend/report_submission/views/general_information_form_view.py
@@ -16,6 +16,7 @@ from audit.validators import validate_general_information_json
 
 from audit.utils import Util
 from config.settings import STATE_ABBREVS
+from django.http import JsonResponse
 
 from report_submission.forms import GeneralInformationForm
 from report_submission.views.utils import parse_hyphened_date, parse_slashed_date
@@ -45,6 +46,11 @@ class GeneralInformationFormView(LoginRequiredMixin, View):
             audit_context = self._dates_to_slashes(audit_context)
 
             self._compare_contexts(sac_context, audit_context)
+
+            sac_context["auditee_ein_warning"] = self._get_auditee_ein_warning(
+                sac_context.get("auditee_uei"),
+                sac_context.get("ein"),
+            )
 
             # SOT TODO What happens here when SOT is the only thing?
             # Does this become audit_context?
@@ -126,6 +132,13 @@ class GeneralInformationFormView(LoginRequiredMixin, View):
             message = f"Unexpected error in GeneralInformationFormView post. Report ID {report_id}"
             logger.error(message)
             raise err
+
+    @staticmethod
+    def _get_auditee_ein_warning(auditee_uei, current_ein):
+        return Util.get_previous_ein_warning(
+            auditee_uei,
+            current_ein,
+        )
 
     @staticmethod
     def _dates_to_slashes(data):
@@ -354,3 +367,27 @@ def _update_audit(report_id, general_information, request):
             event_user=request.user,
             event_type=SubmissionEvent.EventType.GENERAL_INFORMATION_UPDATED,
         )
+
+
+class AuditeeEinWarningView(LoginRequiredMixin, View):
+    def get(self, request, *args, **kwargs):
+        report_id = kwargs["report_id"]
+        current_ein = request.GET.get("ein", "").strip()
+
+        try:
+            sac = SingleAuditChecklist.objects.get(report_id=report_id)
+        except SingleAuditChecklist.DoesNotExist as err:
+            raise PermissionDenied("You do not have access to this audit.") from err
+
+        if not Access.objects.filter(
+            sac=sac,
+            user=request.user,
+        ).exists():
+            raise PermissionDenied("You do not have access to this audit.")
+
+        warning = GeneralInformationFormView._get_auditee_ein_warning(
+            sac.auditee_uei,
+            current_ein,
+        )
+
+        return JsonResponse({"warning": warning})

--- a/backend/static/js/sf-sac.js
+++ b/backend/static/js/sf-sac.js
@@ -5,6 +5,11 @@ const countrySelect = document.querySelector('#auditor_country');
 
 function setFormDisabled(shouldDisable) {
   const continueBtn = document.getElementById('continue');
+
+  if (!continueBtn) {
+    return;
+  }
+
   continueBtn.disabled = shouldDisable;
 }
 
@@ -72,16 +77,20 @@ function attachEventHandlers() {
   const monthsInput = document.querySelector('#audit_period_other_months');
   rbInputs.forEach((input) => {
     input.addEventListener('change', () => {
-      if (input.id == 'audit-period-other') {
+      if (!monthsInput) {
+        return;
+      }
+
+      if (input.id === 'audit-period-other') {
         monthsInput.removeAttribute('disabled');
       } else {
         monthsInput.setAttribute('disabled', true);
       }
     });
   });
-  countrySelect.addEventListener('change', () => {
-    setupAddress();
-  });
+  if (countrySelect) {
+    countrySelect.addEventListener('change', setupAddress);
+  }
 
   window.addEventListener('scroll', highlightActiveNavSection);
 }
@@ -89,10 +98,15 @@ function attachEventHandlers() {
 const foreignFields = document.querySelectorAll('[name="foreign_address"]');
 const domesticFields = document.querySelectorAll('[name="domestic_address"]');
 function setupAddress() {
-  if (countrySelect.value == 'USA') {
+  if (!countrySelect) {
+    return;
+  }
+
+  if (countrySelect.value === 'USA') {
     foreignFields.forEach((input) => {
       input.setAttribute('hidden', true);
     });
+
     domesticFields.forEach((input) => {
       input.removeAttribute('hidden');
     });
@@ -100,15 +114,106 @@ function setupAddress() {
     foreignFields.forEach((input) => {
       input.removeAttribute('hidden');
     });
+
     domesticFields.forEach((input) => {
       input.setAttribute('hidden', true);
     });
   }
 }
 
+function setupAuditeeEinWarning() {
+  const auditeeEinInput = document.getElementById('ein');
+  const auditeeEinWarning = document.getElementById(
+    'auditee-ein-warning'
+  );
+  const auditeeEinWarningText = document.getElementById(
+    'auditee-ein-warning-text'
+  );
+
+  if (
+    !auditeeEinInput ||
+    !auditeeEinWarning ||
+    !auditeeEinWarningText
+  ) {
+    return;
+  }
+
+  let timer;
+  let abortController;
+
+  const hideWarning = () => {
+    auditeeEinWarning.hidden = true;
+    auditeeEinWarningText.textContent = '';
+  };
+
+  const checkEin = async () => {
+    const currentEin = auditeeEinInput.value.trim();
+    const warningUrl = auditeeEinInput.dataset.warningUrl;
+
+    // Remove any dashes or other non-numeric characters
+    const normalizedEin = currentEin.replace(/\D/g, '');
+
+    // Only check once a full 9-digit EIN has been entered
+    if (normalizedEin.length !== 9 || !warningUrl) {
+      hideWarning();
+      return;
+    }
+
+    if (abortController) {
+      abortController.abort();
+    }
+
+    abortController = new AbortController();
+
+    const url = new URL(warningUrl, window.location.origin);
+    url.searchParams.set('ein', normalizedEin);
+
+    try {
+      const response = await fetch(url, {
+        headers: {
+          'X-Requested-With': 'XMLHttpRequest',
+        },
+        signal: abortController.signal,
+      });
+
+      if (!response.ok) {
+        throw new Error(
+          `EIN warning request failed: ${response.status}`
+        );
+      }
+
+      const data = await response.json();
+
+      if (data.warning) {
+        auditeeEinWarningText.textContent = data.warning;
+        auditeeEinWarning.hidden = false;
+      } else {
+        hideWarning();
+      }
+    } catch (error) {
+      if (error.name !== 'AbortError') {
+        console.error(error);
+        hideWarning();
+      }
+    }
+  };
+
+  auditeeEinInput.addEventListener('input', () => {
+    window.clearTimeout(timer);
+    timer = window.setTimeout(checkEin, 400);
+  });
+}
+
 function init() {
-  attachEventHandlers();
-  setupAddress();
+  setupAuditeeEinWarning();
+
+  if (FORM) {
+    attachEventHandlers();
+  }
+
+  if (countrySelect) {
+    setupAddress();
+  }
 }
 
 init();


### PR DESCRIPTION
<!-- These are comments and will not appear when the PR is created -->
<!-- For more tips on creating PRs, see https://github.com/GSA-TTS/FAC/blob/main/docs/pull-request-checklist.md -->
## Related tickets
<!-- List all relevant tickets. If there are none, delete this section. -->
<!-- Tip: Use `Closes <ticket url>` to automatically close the ticket once merged -->
https://github.com/GSA-TTS/FAC/issues/5800

## Description of changes

* Added a cross-validation warning when an Auditee EIN does not match the EIN from the most recent submission for the same UEI.
* Added an inline warning on the General Information page so users receive immediate feedback while entering an EIN, without needing to continue to the next page.
* Shared the EIN lookup and warning message logic through `Util.get_previous_ein_warning()` to eliminate duplicated logic between the UI warning endpoint and cross-validation.
* Added automated tests covering matching, mismatched, missing, and multiple previous submissions.
* Updated the frontend to only validate once a complete 9-digit EIN has been entered.

## How to test

* Start the application and navigate to the General Information page of a report submission.
* Enter an EIN that matches the most recent submission for the same UEI and verify no warning is displayed.
* Enter a different valid 9-digit EIN for a UEI with a previous submission and verify the warning appears below the EIN field.
* Verify no requests are sent while typing partial EIN values (fewer than 9 digits).
* Continue to the next page and verify the same warning is returned by cross-validation.
* Run the automated tests:
  ```bash
  python manage.py test audit.cross_validation.test_check_previous_ein
  
 ## Screenshots and recordings <!-- Optional for UI work. If there are none, delete this section. --> 
<img width="1499" height="827" alt="Screenshot 2026-08-04 at 12 39 26 PM" src="https://github.com/user-attachments/assets/a4ef3fe5-a9ec-4f3a-95fc-ad85a68cf788" />
