### PR TITLE
Added terraform variable for metabase db plan

### DIFF
--- a/.github/workflows/terraform-plan-env.yml
+++ b/.github/workflows/terraform-plan-env.yml
@@ -55,7 +55,6 @@ jobs:
           backend_config: >
             access_key=${{ secrets.terraform_AWS_ACCESS_KEY_ID }},
             secret_key=${{ secrets.terraform_AWS_SECRET_ACCESS_KEY }}
-            endpoint=https://${{ secrets.terraform_ENDPOINT }},
             bucket=${{ secrets.terraform_BUCKET }},
             region=${{ secrets.terraform_REGION }},
             key=${{ env.KEY }},

--- a/terraform/production/production.tf
+++ b/terraform/production/production.tf
@@ -11,6 +11,7 @@ module "production" {
   clamav_instances       = 2
   clamav_fs_instances    = 1
   database_plan          = "xlarge-gp-psql-replica"
+  metabase_database_plan = "xlarge-gp-psql-redundant"
   snapshot_database_plan = "xlarge-gp-psql"
   postgrest_instances    = 2
   json_params = jsonencode(

--- a/terraform/shared/modules/env/metabase.tf
+++ b/terraform/shared/modules/env/metabase.tf
@@ -27,6 +27,6 @@ module "metabasedb" {
   cf_space_id   = var.cf_space.id
   name          = "metabase-db"
   tags          = ["rds"]
-  rds_plan_name = var.database_plan
+  rds_plan_name = var.metabase_database_plan
   json_params   = var.json_params
 }

--- a/terraform/shared/modules/env/variables.tf
+++ b/terraform/shared/modules/env/variables.tf
@@ -33,14 +33,21 @@ variable "cf_space" {
 
 variable "database_plan" {
   type        = string
-  description = "name of the cloud.gov RDS service plan name to create"
+  description = "name of the RDS service plan name to create"
   # See https://cloud.gov/docs/services/relational-database/#plans
   default = "medium-gp-psql-redundant"
 }
 
 variable "snapshot_database_plan" {
   type        = string
-  description = "name of the cloud.gov secondary RDS service plan name to create"
+  description = "name of the snapshot RDS service plan name to create"
+  # See https://cloud.gov/docs/services/relational-database/#plans
+  default = "medium-gp-psql-redundant"
+}
+
+variable "metabase_database_plan" {
+  type        = string
+  description = "name of the metabase RDS service plan name to create"
   # See https://cloud.gov/docs/services/relational-database/#plans
   default = "medium-gp-psql-redundant"
 }

--- a/terraform/staging/staging.tf
+++ b/terraform/staging/staging.tf
@@ -11,6 +11,7 @@ module "staging" {
 
   database_plan          = "medium-gp-psql"
   snapshot_database_plan = "medium-gp-psql"
+  metabase_database_plan = "medium-gp-psql"
   postgrest_instances    = 1
   postgrest_memory       = "512M"
   swagger_instances      = 1


### PR DESCRIPTION
<!-- These are comments and will not appear when the PR is created -->
<!-- For more tips on creating PRs, see https://github.com/GSA-TTS/FAC/blob/main/docs/pull-request-checklist.md -->

## Description of changes
<!-- Give a high level summary of the changes made -->
* Metabase was previously using the same db instance type as the FAC db. This PR adds a new variable allowing for different RDS instance types across the different services
