### PR TITLE
Unified dissemination fix for findingless submissions

### DIFF
--- a/backend/audit/intake_to_dissemination.py
+++ b/backend/audit/intake_to_dissemination.py
@@ -582,21 +582,28 @@ class IntakeToDissemination(object):
     def load_unified(self):
         gen = self.loaded_objects["Generals"][0]
         unifieds = []
+        logger.warning("######## load_unified ######")
 
         for fed in self.loaded_objects["FederalAwards"]:
-            for fin in self.loaded_objects["Findings"]:
-                if fed.award_reference != fin.award_reference:
-                    continue
+            fins = [fin for fin in self.loaded_objects["Findings"] if fin.award_reference == fed.award_reference]
+            passes = [pas for pas in self.loaded_objects["Passthroughs"] if pas.award_reference == fed.award_reference]
 
-                passes = self.loaded_objects["Passthroughs"]
-                if passes:
-                    for pas in passes:
-                        if fed.award_reference == pas.award_reference:
-                            unifieds.append(
-                                self._load_unified_helper(gen, fed, fin, pas)
-                            )
-                else:
+            if not fins and not passes:
+                logger.warning("1")
+                unifieds.append(self._load_unified_helper(gen, fed, None, None))
+            elif fins and not passes:
+                for fin in fins:
+                    logger.warning("2")
                     unifieds.append(self._load_unified_helper(gen, fed, fin, None))
+            elif passes and not fins:
+                for pas in passes:
+                    logger.warning("3")
+                    unifieds.append(self._load_unified_helper(gen, fed, None, pas))
+            else:
+                for fin in fins:
+                    for pas in passes:
+                        logger.warning("4")
+                        unifieds.append(self._load_unified_helper(gen, fed, fin, pas))
 
         self.loaded_objects["Unifieds"] = unifieds
 
@@ -608,7 +615,7 @@ class IntakeToDissemination(object):
             "aln": aln,
             **model_to_dict(gen),
             **model_to_dict(fed),
-            **model_to_dict(fin),
+            **(model_to_dict(fin) if fin else {}),
             **(model_to_dict(pas) if pas else {}),
         }
 

--- a/backend/audit/intake_to_dissemination.py
+++ b/backend/audit/intake_to_dissemination.py
@@ -585,38 +585,42 @@ class IntakeToDissemination(object):
         logger.warning("######## load_unified ######")
 
         for fed in self.loaded_objects["FederalAwards"]:
-            fins = [fin for fin in self.loaded_objects["Findings"] if fin.award_reference == fed.award_reference]
-            passes = [pas for pas in self.loaded_objects["Passthroughs"] if pas.award_reference == fed.award_reference]
+            fins = [
+                fin
+                for fin in self.loaded_objects["Findings"]
+                if fin.award_reference == fed.award_reference
+            ]
+            pts = [
+                pt
+                for pt in self.loaded_objects["Passthroughs"]
+                if pt.award_reference == fed.award_reference
+            ]
 
-            if not fins and not passes:
-                logger.warning("1")
+            if not fins and not pts:
                 unifieds.append(self._load_unified_helper(gen, fed, None, None))
-            elif fins and not passes:
+            elif fins and not pts:
                 for fin in fins:
-                    logger.warning("2")
                     unifieds.append(self._load_unified_helper(gen, fed, fin, None))
-            elif passes and not fins:
-                for pas in passes:
-                    logger.warning("3")
-                    unifieds.append(self._load_unified_helper(gen, fed, None, pas))
+            elif pts and not fins:
+                for pt in pts:
+                    unifieds.append(self._load_unified_helper(gen, fed, None, pt))
             else:
                 for fin in fins:
-                    for pas in passes:
-                        logger.warning("4")
-                        unifieds.append(self._load_unified_helper(gen, fed, fin, pas))
+                    for pt in pts:
+                        unifieds.append(self._load_unified_helper(gen, fed, fin, pt))
 
         self.loaded_objects["Unifieds"] = unifieds
 
         return unifieds
 
-    def _load_unified_helper(self, gen, fed, fin, pas):
+    def _load_unified_helper(self, gen, fed, fin, pt):
         aln = f"{fed.federal_agency_prefix}.{fed.federal_award_extension}"
         params = {
             "aln": aln,
             **model_to_dict(gen),
             **model_to_dict(fed),
             **(model_to_dict(fin) if fin else {}),
-            **(model_to_dict(pas) if pas else {}),
+            **(model_to_dict(pt) if pt else {}),
         }
 
         # Since report_id is a FK, the model needs an instance of General, not a string

--- a/backend/audit/intake_to_dissemination.py
+++ b/backend/audit/intake_to_dissemination.py
@@ -582,7 +582,6 @@ class IntakeToDissemination(object):
     def load_unified(self):
         gen = self.loaded_objects["Generals"][0]
         unifieds = []
-        logger.warning("######## load_unified ######")
 
         for fed in self.loaded_objects["FederalAwards"]:
             fins = [

--- a/backend/dissemination/management/commands/delete_and_regenerate_dissemination_from_intake.py
+++ b/backend/dissemination/management/commands/delete_and_regenerate_dissemination_from_intake.py
@@ -24,8 +24,8 @@ class Command(BaseCommand):
     Regenerates all dissemination_ records from SingleAuditChecklist.
     Does this one record at a time; can be run while the system is operating.
 
-    Optionally, use `--report_id` to attempt to force the redissemination of a particular record.
-    Useful for debugging.
+    --report_id (optional): Redisseminate a single report_id
+    --year (optional): Redisseminate a single audit year
     """
 
     dissemination_models = [
@@ -48,29 +48,50 @@ class Command(BaseCommand):
             help="The ID of the SAC.",
             default=None,
         )
+        parser.add_argument(
+            "--year",
+            type=str,
+            help="The year to process.",
+            default=None,
+        )
 
     def handle(self, *args, **_kwargs):
         report_id = _kwargs.get("report_id")
+        year = _kwargs.get("year")
+
+        if report_id and year:
+            logger.error("Only one of --report_id or --year can be provided. Exiting.")
+            exit(-1)
 
         if report_id:
+            logger.info(f"Redisseminating {report_id}.")
+
             try:
                 sac = SingleAuditChecklist.objects.get(report_id=report_id)
                 sac.redisseminate()
-                logger.info(f"Redisseminated: {report_id}")
+                logger.info(f"Redisseminated: {report_id}.")
                 exit(0)
             except SingleAuditChecklist.DoesNotExist:
-                logger.info(f"No report with report_id found: {report_id}")
+                logger.error(f"No report with report_id found: {report_id}. Exiting.")
                 exit(-1)
+        else:
+            if year:
+                years = [year]
+            else:
+                logger.info("Redisseminating all records.")
+                years = range(2015, date.today().year + 1)
 
-        logger.info("Re-running dissemination for all records.")
+            redisseminated = {}
 
-        redisseminated = {}
-        for year in range(2015, date.today().year + 1):
-            logger.info(f"Working year {year}")
-            for sac in SingleAuditChecklist.objects.filter(
-                submission_status__in=[STATUS.DISSEMINATED, STATUS.RESUBMITTED],
-                general_information__auditee_fiscal_period_end__startswith=f"{year}",
-            ):
-                logger.info(f"Redisseminating {sac.report_id}")
-                sac.redisseminate()
-                redisseminated[sac.report_id] = True
+            for year in years:
+                logger.info(f"Working year {year}")
+
+                for sac in SingleAuditChecklist.objects.filter(
+                    submission_status__in=[STATUS.DISSEMINATED, STATUS.RESUBMITTED],
+                    general_information__auditee_fiscal_period_end__startswith=f"{year}",
+                ):
+                    logger.info(f"Redisseminating {sac.report_id}.")
+                    sac.redisseminate()
+                    redisseminated[sac.report_id] = True
+
+        logger.info("Redisseminating complete.")


### PR DESCRIPTION
## Description of changes
<!-- Give a high level summary of the changes made -->
* During our last attempt at redisseminating in prod to populate the Unified table, we discovered that submissions without findings are skipped. This will fix that.
* Adding `--year` support to redissemination command

## How to test
<!-- Provide clear instructions for testing your changes -->
* Have an audit that has no findings. This means `audit_singleauditchecklist.findings_uniform_guidance` is empty.
  * Redisseminate using your report_id: `docker compose run --rm web python manage.py delete_and_regenerate_dissemination_from_intake --report_id <your report id>`
  * Entries/an entry should show up in `dissemination_unified` for your report_id
* Redisseminating by year should also work: `docker compose run --rm web python manage.py delete_and_regenerate_dissemination_from_intake --year 2016`
  * Confirm again stuff shows up in `dissemination_unified`
