### PR TITLE
Adding pagination to redissemination cmd

### DIFF
--- a/backend/dissemination/management/commands/delete_and_regenerate_dissemination_from_intake.py
+++ b/backend/dissemination/management/commands/delete_and_regenerate_dissemination_from_intake.py
@@ -18,6 +18,8 @@ from datetime import date
 
 logger = logging.getLogger(__name__)
 
+CHUNK_SIZE = 500
+
 
 class Command(BaseCommand):
     """
@@ -70,10 +72,8 @@ class Command(BaseCommand):
                 sac = SingleAuditChecklist.objects.get(report_id=report_id)
                 sac.redisseminate()
                 logger.info(f"Redisseminated: {report_id}.")
-                exit(0)
             except SingleAuditChecklist.DoesNotExist:
                 logger.error(f"No report with report_id found: {report_id}. Exiting.")
-                exit(-1)
         else:
             if year:
                 years = [year]
@@ -86,10 +86,12 @@ class Command(BaseCommand):
             for year in years:
                 logger.info(f"Working year {year}")
 
-                for sac in SingleAuditChecklist.objects.filter(
+                queryset = SingleAuditChecklist.objects.filter(
                     submission_status__in=[STATUS.DISSEMINATED, STATUS.RESUBMITTED],
                     general_information__auditee_fiscal_period_end__startswith=f"{year}",
-                ):
+                )
+
+                for sac in queryset.iterator(chunk_size=CHUNK_SIZE):
                     logger.info(f"Redisseminating {sac.report_id}.")
                     sac.redisseminate()
                     redisseminated[sac.report_id] = True


### PR DESCRIPTION
<!-- These are comments and will not appear when the PR is created -->
<!-- For more tips on creating PRs, see https://github.com/GSA-TTS/FAC/blob/main/docs/pull-request-checklist.md -->
## Related tickets
<!-- List all relevant tickets. If there are none, delete this section. -->
<!-- Tip: Use `Closes <ticket url>` to automatically close the ticket once merged -->
* Related to https://github.com/GSA-TTS/FAC/issues/5682

## Description of changes
<!-- Give a high level summary of the changes made -->
* Adding pagination to `delete_and_regenerate_dissemination_from_intake.py` command to prevent ram spikes
* Removing early exits because they're confusing

## How to test
<!-- Provide clear instructions for testing your changes -->
* `docker compose run --rm web python manage.py delete_and_regenerate_dissemination_from_intake --year 2016`
  * Use whatever year you want and results should show up in `dissemination_unified`
