### PR TITLE
Add Tooltip to UEI/EIN search

### DIFF
--- a/backend/cypress/e2e/accessibility.cy.js
+++ b/backend/cypress/e2e/accessibility.cy.js
@@ -172,30 +172,30 @@ describe('A11y Testing on search pages', () => {
   it('Removes dashes from EIN input', () => {
     cy.visit('/dissemination/search/');
 
-    cy.get('#input_uei-or-ein')
-      .clear()
-      .type('12-3456789')
-      .should('have.value', '123456789');
+    cy.get('#input_uei-or-ein').clear();
+    cy.get('#input_uei-or-ein').type('12-3456789');
+    cy.get('#input_uei-or-ein').should('have.value', '123456789');
   });
 
   it('Removes special characters from UEI/EIN input', () => {
     cy.visit('/dissemination/search/');
 
-    cy.get('#input_uei-or-ein')
-      .clear()
-      .type('ABC-123 XYZ!')
-      .should('have.value', 'ABC123XYZ');
+    cy.get('#input_uei-or-ein').clear();
+    cy.get('#input_uei-or-ein').type('ABC-123 XYZ!');
+    cy.get('#input_uei-or-ein').should('have.value', 'ABC123XYZ');
   });
 
   it('Preserves multiple UEI/EIN entries on separate lines', () => {
     cy.visit('/dissemination/search/');
 
-    cy.get('#input_uei-or-ein')
-      .clear()
-      .type('12-3456789{enter}ABC-123-XYZ')
-      .should('have.value', '123456789\nABC123XYZ');
+    cy.get('#input_uei-or-ein').clear();
+    cy.get('#input_uei-or-ein').type('12-3456789{enter}ABC-123-XYZ');
+    cy.get('#input_uei-or-ein').should(
+      'have.value',
+      '123456789\nABC123XYZ'
+    );
   });
-
+  
   it('Associates EIN guidance with the UEI/EIN input', () => {
     cy.visit('/dissemination/search/');
 

--- a/backend/cypress/e2e/accessibility.cy.js
+++ b/backend/cypress/e2e/accessibility.cy.js
@@ -161,6 +161,52 @@ describe('A11y Testing on search pages', () => {
     });
   });
 
+  it('Displays EIN guidance', () => {
+    cy.visit('/dissemination/search/');
+
+    cy.get('#uei-ein-help')
+      .should('be.visible')
+      .and('contain.text', 'Enter EIN with no dashes.');
+  });
+
+  it('Removes dashes from EIN input', () => {
+    cy.visit('/dissemination/search/');
+
+    cy.get('#input_uei-or-ein')
+      .clear()
+      .type('12-3456789')
+      .should('have.value', '123456789');
+  });
+
+  it('Removes special characters from UEI/EIN input', () => {
+    cy.visit('/dissemination/search/');
+
+    cy.get('#input_uei-or-ein')
+      .clear()
+      .type('ABC-123 XYZ!')
+      .should('have.value', 'ABC123XYZ');
+  });
+
+  it('Preserves multiple UEI/EIN entries on separate lines', () => {
+    cy.visit('/dissemination/search/');
+
+    cy.get('#input_uei-or-ein')
+      .clear()
+      .type('12-3456789{enter}ABC-123-XYZ')
+      .should('have.value', '123456789\nABC123XYZ');
+  });
+
+  it('Associates EIN guidance with the UEI/EIN input', () => {
+    cy.visit('/dissemination/search/');
+
+    cy.get('#input_uei-or-ein')
+      .should('have.attr', 'aria-describedby', 'uei-ein-help');
+
+    cy.get('label[for="input_uei-or-ein"]')
+      .should('exist')
+      .and('contain.text', 'UEI or EIN');
+  });
+
   test_check_a11y('/dissemination/search/', 'basic search');
   test_check_a11y('/dissemination/search/advanced/', 'advanced search');
 });

--- a/backend/cypress/e2e/accessibility.cy.js
+++ b/backend/cypress/e2e/accessibility.cy.js
@@ -161,42 +161,40 @@ describe('A11y Testing on search pages', () => {
     });
   });
 
-  it('Displays EIN guidance', () => {
+  it('Displays UEI/EIN guidance', () => {
     cy.visit('/dissemination/search/');
 
     cy.get('#uei-ein-help')
       .should('be.visible')
-      .and('contain.text', 'Enter EIN with no dashes.');
+      .and(
+        'contain.text',
+        'Separate multiple UEIs or EINs by commas or newlines.'
+      );
   });
 
-  it('Removes dashes from EIN input', () => {
+  it('Allows dashes to remain in the UEI/EIN input before submission', () => {
     cy.visit('/dissemination/search/');
 
     cy.get('#input_uei-or-ein').clear();
     cy.get('#input_uei-or-ein').type('12-3456789');
-    cy.get('#input_uei-or-ein').should('have.value', '123456789');
+    cy.get('#input_uei-or-ein').should('have.value', '12-3456789');
   });
 
-  it('Removes special characters from UEI/EIN input', () => {
+  it('Allows multiple UEIs or EINs separated by commas or newlines', () => {
     cy.visit('/dissemination/search/');
 
     cy.get('#input_uei-or-ein').clear();
-    cy.get('#input_uei-or-ein').type('ABC-123 XYZ!');
-    cy.get('#input_uei-or-ein').should('have.value', 'ABC123XYZ');
-  });
+    cy.get('#input_uei-or-ein').type(
+      '12-3456789,987654321{enter}ABCDEFG12345'
+    );
 
-  it('Preserves multiple UEI/EIN entries on separate lines', () => {
-    cy.visit('/dissemination/search/');
-
-    cy.get('#input_uei-or-ein').clear();
-    cy.get('#input_uei-or-ein').type('12-3456789{enter}ABC-123-XYZ');
     cy.get('#input_uei-or-ein').should(
       'have.value',
-      '123456789\nABC123XYZ'
+      '12-3456789,987654321\nABCDEFG12345'
     );
   });
-  
-  it('Associates EIN guidance with the UEI/EIN input', () => {
+
+  it('Associates UEI/EIN guidance with the input', () => {
     cy.visit('/dissemination/search/');
 
     cy.get('#input_uei-or-ein')

--- a/backend/dissemination/forms/search_forms.py
+++ b/backend/dissemination/forms/search_forms.py
@@ -142,6 +142,7 @@ class AdvancedSearchForm(forms.Form):
         Split on the newlines. Strip all the resulting elements.
         """
         text_input = self.cleaned_data["uei_or_ein"]
+        text_input = text_input.replace("-", "")
         return clean_text_field(text_input)
 
     def clean_audit_year(self):
@@ -304,6 +305,7 @@ class SearchForm(forms.Form):
         Split on the newlines. Strip all the resulting elements.
         """
         text_input = self.cleaned_data["uei_or_ein"]
+        text_input = text_input.replace("-", "")
         return clean_text_field(text_input)
 
     def clean_audit_year(self):

--- a/backend/dissemination/templates/search_filters/uei-ein.html
+++ b/backend/dissemination/templates/search_filters/uei-ein.html
@@ -4,10 +4,24 @@
         <button type="button"
                 class="usa-accordion__button"
                 aria-expanded="true"
-                {% comment %} aria-expanded={% if form_user_input.uei_or_ein %}"true"{% else %}"false"{% endif %} {% endcomment %}
-                aria-controls="uei-or-ein">UEI or EIN</button>
+                aria-controls="uei-or-ein">
+            UEI or EIN
+        </button>
     </label>
+
     <div id="uei-or-ein">
-        <textarea class="usa-textarea" id="input_uei-or-ein" name="uei_or_ein">{{form_user_input.uei_or_ein}}</textarea>
+        <textarea
+            class="usa-textarea"
+            id="input_uei-or-ein"
+            name="uei_or_ein"
+            aria-describedby="uei-ein-help"
+            oninput="this.value = this.value.split('\n').map(function(line) {
+                return line.replace(/[^a-zA-Z0-9]/g, '');
+            }).join('\n');"
+        >{{form_user_input.uei_or_ein}}</textarea>
+
+        <div id="uei-ein-help" class="usa-hint">
+            Enter EIN with no dashes.
+        </div>
     </div>
 </div>

--- a/backend/dissemination/templates/search_filters/uei-ein.html
+++ b/backend/dissemination/templates/search_filters/uei-ein.html
@@ -19,7 +19,7 @@
                   return line.replace(/[^a-zA-Z0-9]/g, '');
               }).join('\n');">{{ form_user_input.uei_or_ein }}</textarea>
 
-    <div id="uei-ein-help" class="usa-hint">
+    <div id="uei-ein-help" class="margin-top-1">
         Enter EIN with no dashes.
     </div>
 </div>

--- a/backend/dissemination/templates/search_filters/uei-ein.html
+++ b/backend/dissemination/templates/search_filters/uei-ein.html
@@ -14,12 +14,9 @@
     <textarea class="usa-textarea"
               id="input_uei-or-ein"
               name="uei_or_ein"
-              aria-describedby="uei-ein-help"
-              oninput="this.value = this.value.split('\n').map(function(line) {
-                  return line.replace(/[^a-zA-Z0-9]/g, '');
-              }).join('\n');">{{ form_user_input.uei_or_ein }}</textarea>
+              aria-describedby="uei-ein-help">{{ form_user_input.uei_or_ein }}</textarea>
 
-    <div id="uei-ein-help" class="margin-top-1">
-        Enter EIN with no dashes.
+    <div id="uei-ein-help" class="margin-top-1 text-ink">
+        Separate multiple UEIs or EINs by commas or newlines.
     </div>
 </div>

--- a/backend/dissemination/templates/search_filters/uei-ein.html
+++ b/backend/dissemination/templates/search_filters/uei-ein.html
@@ -1,27 +1,25 @@
 {% comment %} UEI/EIN {% endcomment %}
-<div class="usa-accordion">
-    <label class="usa-accordion__heading" for="input_uei-or-ein">
-        <button type="button"
-                class="usa-accordion__button"
-                aria-expanded="true"
-                aria-controls="uei-or-ein">
-            UEI or EIN
-        </button>
+<button type="button"
+        class="usa-accordion__button"
+        aria-expanded="true"
+        aria-controls="uei-or-ein">
+    UEI or EIN
+</button>
+
+<div id="uei-or-ein">
+    <label class="usa-sr-only" for="input_uei-or-ein">
+        UEI or EIN
     </label>
 
-    <div id="uei-or-ein">
-        <textarea
-            class="usa-textarea"
-            id="input_uei-or-ein"
-            name="uei_or_ein"
-            aria-describedby="uei-ein-help"
-            oninput="this.value = this.value.split('\n').map(function(line) {
-                return line.replace(/[^a-zA-Z0-9]/g, '');
-            }).join('\n');"
-        >{{form_user_input.uei_or_ein}}</textarea>
+    <textarea class="usa-textarea"
+              id="input_uei-or-ein"
+              name="uei_or_ein"
+              aria-describedby="uei-ein-help"
+              oninput="this.value = this.value.split('\n').map(function(line) {
+                  return line.replace(/[^a-zA-Z0-9]/g, '');
+              }).join('\n');">{{ form_user_input.uei_or_ein }}</textarea>
 
-        <div id="uei-ein-help" class="usa-hint">
-            Enter EIN with no dashes.
-        </div>
+    <div id="uei-ein-help" class="usa-hint">
+        Enter EIN with no dashes.
     </div>
 </div>

--- a/backend/dissemination/test_search_forms.py
+++ b/backend/dissemination/test_search_forms.py
@@ -1,0 +1,55 @@
+from django.test import TestCase
+
+from dissemination.forms.search_forms import AdvancedSearchForm, SearchForm
+
+
+class SearchFormTests(TestCase):
+    def test_uei_or_ein_removes_dashes(self):
+        form = SearchForm(data={"uei_or_ein": "12-3456789"})
+
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data["uei_or_ein"], ["123456789"])
+
+    def test_uei_or_ein_separates_commas(self):
+        form = SearchForm(data={"uei_or_ein": "123456789,987654321"})
+
+        self.assertTrue(form.is_valid())
+        self.assertEqual(
+            form.cleaned_data["uei_or_ein"],
+            ["123456789", "987654321"],
+        )
+
+    def test_uei_or_ein_separates_newlines(self):
+        form = SearchForm(data={"uei_or_ein": "123456789\n987654321"})
+
+        self.assertTrue(form.is_valid())
+        self.assertEqual(
+            form.cleaned_data["uei_or_ein"],
+            ["123456789", "987654321"],
+        )
+
+
+class AdvancedSearchFormTests(TestCase):
+    def test_uei_or_ein_removes_dashes(self):
+        form = AdvancedSearchForm(data={"uei_or_ein": "12-3456789"})
+
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data["uei_or_ein"], ["123456789"])
+
+    def test_uei_or_ein_separates_commas(self):
+        form = AdvancedSearchForm(data={"uei_or_ein": "123456789,987654321"})
+
+        self.assertTrue(form.is_valid())
+        self.assertEqual(
+            form.cleaned_data["uei_or_ein"],
+            ["123456789", "987654321"],
+        )
+
+    def test_uei_or_ein_separates_newlines(self):
+        form = AdvancedSearchForm(data={"uei_or_ein": "123456789\n987654321"})
+
+        self.assertTrue(form.is_valid())
+        self.assertEqual(
+            form.cleaned_data["uei_or_ein"],
+            ["123456789", "987654321"],
+        )


### PR DESCRIPTION
<!-- These are comments and will not appear when the PR is created -->
<!-- For more tips on creating PRs, see https://github.com/GSA-TTS/FAC/blob/main/docs/pull-request-checklist.md -->
## Related tickets
<!-- List all relevant tickets. If there are none, delete this section. -->
<!-- Tip: Use `Closes <ticket url>` to automatically close the ticket once merged -->
https://github.com/GSA-TTS/FAC/issues/5822

## Description of changes
* Added helper text to the UEI/EIN search field instructing users to separate multiple UEIs or EINs by commas or newlines.
* Added `aria-describedby` to associate the helper text with the UEI/EIN field for accessibility.
* Updated UEI/EIN search handling to ignore dashes during form validation instead of modifying the user's input in the browser.
* Added unit tests to verify:
  * Dashes are removed from EIN values.
  * Multiple UEI/EIN values can be separated by commas.
  * Multiple UEI/EIN values can be separated by newlines.
  * Sanitization works for both basic and advanced search forms.
* Updated Cypress accessibility coverage for the UEI/EIN helper text and field association.

## How to test
1. Navigate to the FAC search page.
2. Expand the **UEI or EIN** search field.
3. Verify the helper text **"Separate multiple UEIs or EINs by commas or newlines."** appears below the field.
4. Enter an EIN containing dashes, such as `12-3456789`.
5. Perform the search and verify the EIN is processed as `123456789`.
6. Enter multiple UEIs or EINs separated by commas and verify the search processes them as separate values.
7. Enter multiple UEIs or EINs on separate lines and verify the search processes them as separate values.
8. Verify the same behavior on the advanced search page.
9. Run the UEI/EIN form unit tests and verify they pass.

## Screenshots and recordings
<img width="1916" height="848" alt="Screenshot 2026-08-26 at 12 45 58 PM" src="https://github.com/user-attachments/assets/8af984ea-6078-4e30-b721-19696adb0f59" />


