### PR TITLE
Updating dumper docs

### DIFF
--- a/backend/util/load_public_dissem_data/README-prepare_prod_data_for_local.md
+++ b/backend/util/load_public_dissem_data/README-prepare_prod_data_for_local.md
@@ -1,6 +1,6 @@
 # prepare_prod_data_for_local.bash
 
-The `prepare_prod_data_for_local` bash script is a menu-driven tool for repeatbly downloading data dumps from `production` and sanitizing them for local use.
+The `prepare_prod_data_for_local` bash script is a menu-driven tool for repeatably downloading data dumps from `production` and sanitizing them for local use. We generally keep them stored on [the GDrive](https://drive.google.com/drive/folders/1WymwJtdQ287SdgrOx__aEraoVTx7ig9D).
 
 ## goal
 
@@ -54,7 +54,7 @@ Once logged in, you will be prompted with a selection menu. To create the dump, 
 
 If you are feeling bold, select the option for running everything straight through. This runs steps 2-7.
 
-Upload the resulting file (e.g. `sanitized-20250731.dump`) to GDrive for sharing with the team. It is now ready for load via `manage_local_data.bash`.
+Upload the resulting file (e.g. `sanitized-20250731.dump`) to [the GDrive](https://drive.google.com/drive/folders/1WymwJtdQ287SdgrOx__aEraoVTx7ig9D) for sharing with the team. It is now ready for load via `manage_local_data.bash`.
 
 This file will contain 100% public data (disseminated and in-progress). To make sure no in-progress audits are Tribal submissions for which an attestation has not yet been made, we delete all `tribal` audits that do not yet have an attestation. This should guarantee that 100% of all in-progress is *also* public data.
 
@@ -66,12 +66,12 @@ The menu is roughly in order of use.
 
 This is an optional step.
 
-When we download a backup from `production`, we need to choose which dump we want to work with. These are named `MM-DD-HH` in the scheduled folder.
+When we download a backup from `production`, we need to choose which dump we want to work with. These are named `YYYY-MM-DDTHH:MM:SS-0400` in the scheduled folder. To find the backups that are available, follow the steps [here](https://github.com/GSA-TTS/fac-team/blob/main/infra/s3-connection.md) using the service-name `backups`. Your `ls` command to view the backups should look something like `aws s3 ls s3://cg-040c4133-1efe-4281-a485-005960b58405/backups/scheduled/`.
 
 The script sets a dump path:
 
 ```
-DESIRED_BACKUP="07-27-12"
+DESIRED_BACKUP="2026-08-27T19:10:01-0400"
 ```
 
 Generally, this should be updated and committed if a new dump is going to be worked with. However, for temporary/local testing, it is possible to specify the path. Be careful: no checking is performed when this value is entered. Better to verify the path exists and set it in the script.

--- a/backend/util/load_public_dissem_data/prepare_prod_data_for_local.bash
+++ b/backend/util/load_public_dissem_data/prepare_prod_data_for_local.bash
@@ -71,7 +71,7 @@ echo -e "\n"
 # This can be changed via the menu.
 # Better, when a new backup is targeted, to
 # make the change and commit back to the repo.
-DESIRED_BACKUP="04-04-20"
+DESIRED_BACKUP="2026-08-27T19:10:01-0400"
 
 ############################################################
 # environment variables
@@ -91,7 +91,7 @@ source "tables.source"
 select_target_backup_for_download () {
   echo "select_target_backup_for_download"
   # https://stackoverflow.com/a/18546416
-  read -p "Target backup (MM-DD-HH): " TARGET
+  read -p "Target backup (YYYY-MM-DDTHH:MM:SS-0400): " TARGET
   DESIRED_BACKUP=$TARGET
   echo "Targeting ${TARGET}"
 }


### PR DESCRIPTION
## Description of changes
<!-- Give a high level summary of the changes made -->
* Our backups names changed from MM-DD-HH to YYYY-MM-DDTHH:MM:SS-0400, so this updates the docs for creating sanitized dumps. I also included how to see the dumps available via aws cli.

## How to test
<!-- Provide clear instructions for testing your changes -->
* You could create a dump yourself but it takes forever so I don't expect anyone to. It worked for me!