### PR TITLE
Searching on General when possible for faster searches

### DIFF
--- a/backend/dissemination/search.py
+++ b/backend/dissemination/search.py
@@ -54,6 +54,38 @@ def is_beta_search(params_dict):
     return params_dict.get("beta_search_flag", False)
 
 
+GENERAL_PARAMS = [
+    'audit_years',
+    'uei_or_ein',
+    'entity_name',
+    'start_date',
+    'end_date',
+    'auditee_state',
+    'fy_end_month',
+    'report_id',
+    'page',
+    'order_by',
+    'order_direction',
+    'advanced_search_flag',
+    'beta_search_flag',
+    'LIMIT',
+]
+
+
+def only_searching_on_general(params_dict):
+    """
+    Returns True if the given params only contain fields that can be search on
+    the General model.
+    """
+    for param, value in params_dict.items():
+        if param == 'cog_or_oversight' and value == 'either':
+            continue
+        elif value and param not in GENERAL_PARAMS:
+            return False
+
+    return True
+
+
 def search(request, params):
     """
     Given any (or no) search fields, build and execute a query on the General table and return the results.
@@ -71,8 +103,12 @@ def search(request, params):
 
     if is_advanced_search(params):
         if is_beta_search(params):
-            logger.info("search Searching `Unified`")
-            results = search_general(Unified, params)
+            if only_searching_on_general(params):
+                logger.info("search Searching `General`")
+                results = search_general(General, params)
+            else:
+                logger.info("search Searching `Unified`")
+                results = search_general(Unified, params)
         else:
             logger.info("search Searching `DisseminationCombined`")
             results = search_general(DisseminationCombined, params)

--- a/backend/dissemination/search.py
+++ b/backend/dissemination/search.py
@@ -55,20 +55,20 @@ def is_beta_search(params_dict):
 
 
 GENERAL_PARAMS = [
-    'audit_years',
-    'uei_or_ein',
-    'entity_name',
-    'start_date',
-    'end_date',
-    'auditee_state',
-    'fy_end_month',
-    'report_id',
-    'page',
-    'order_by',
-    'order_direction',
-    'advanced_search_flag',
-    'beta_search_flag',
-    'LIMIT',
+    "audit_years",
+    "uei_or_ein",
+    "entity_name",
+    "start_date",
+    "end_date",
+    "auditee_state",
+    "fy_end_month",
+    "report_id",
+    "page",
+    "order_by",
+    "order_direction",
+    "advanced_search_flag",
+    "beta_search_flag",
+    "LIMIT",
 ]
 
 
@@ -78,7 +78,7 @@ def only_searching_on_general(params_dict):
     on the General model.
     """
     for param, value in params_dict.items():
-        if param == 'cog_or_oversight' and value == 'either':
+        if param == "cog_or_oversight" and value == "either":
             continue
         elif value and param not in GENERAL_PARAMS:
             return False

--- a/backend/dissemination/search.py
+++ b/backend/dissemination/search.py
@@ -74,8 +74,8 @@ GENERAL_PARAMS = [
 
 def only_searching_on_general(params_dict):
     """
-    Returns True if the given params only contain fields that can be search on
-    the General model.
+    Returns True if the given params only contain fields that can be searched
+    on the General model.
     """
     for param, value in params_dict.items():
         if param == 'cog_or_oversight' and value == 'either':
@@ -101,14 +101,14 @@ def search(request, params):
     ##############
     # GENERAL
 
-    if is_advanced_search(params):
+    if not is_advanced_search(params) or only_searching_on_general(params):
+        # Don't bother querying the huge tables if General can be used instead
+        logger.info("search Searching `General`")
+        results = search_general(General, params)
+    else:
         if is_beta_search(params):
-            if only_searching_on_general(params):
-                logger.info("search Searching `General`")
-                results = search_general(General, params)
-            else:
-                logger.info("search Searching `Unified`")
-                results = search_general(Unified, params)
+            logger.info("search Searching `Unified`")
+            results = search_general(Unified, params)
         else:
             logger.info("search Searching `DisseminationCombined`")
             results = search_general(DisseminationCombined, params)
@@ -121,10 +121,6 @@ def search(request, params):
         results = search_major_program(results, params)
         results = search_passthrough_name(results, params)
         results = search_type_requirement(results, params)
-    else:
-        logger.info("search Searching `General`")
-        results = search_general(General, params)
-
     results = search_resubmissions(request, results, params)
     results = _sort_results(results, params)
     results = _make_distinct(results, params)

--- a/backend/dissemination/test_search.py
+++ b/backend/dissemination/test_search.py
@@ -12,6 +12,7 @@ from dissemination.models import (
     AdditionalEin,
 )
 from dissemination.search import (
+    only_searching_on_general,
     search_general,
     search_alns,
     search,
@@ -52,7 +53,7 @@ def assert_results_contain_private_and_public(cls, results):
 
 
 class SearchGeneralTests(TestCase):
-    def is_advanced_search(self):
+    def test_is_advanced_search(self):
         basic_params = {
             "names": "not_important",
             "uei_or_eins": "not_important",
@@ -69,6 +70,34 @@ class SearchGeneralTests(TestCase):
 
         self.assertTrue(is_advanced_search(advanced_params))
         self.assertFalse(is_advanced_search(basic_params))
+
+    def test_only_searching_on_general(self):
+        # Searching on General fields and not specifying cog/over searches on General
+        params = {
+            "audit_years": "2020",
+            "cog_or_oversight": "either",
+        }
+        self.assertTrue(only_searching_on_general(params))
+
+        # Having an advanced field can still search General if the value is empty
+        params = {
+            "audit_years": "2020",
+            "federal_program_name": "",
+        }
+        self.assertTrue(only_searching_on_general(params))
+
+        # Specifying cog/over can't search General
+        params = {
+            "audit_years": "2020",
+            "cog_or_oversight": "cog",
+        }
+        self.assertFalse(only_searching_on_general(params))
+
+        # A non-General field can't search General
+        params = {
+            "federal_program_name": "foo name",
+        }
+        self.assertFalse(only_searching_on_general(params))
 
     def test_empty_query(self):
         """


### PR DESCRIPTION
<!-- These are comments and will not appear when the PR is created -->
<!-- For more tips on creating PRs, see https://github.com/GSA-TTS/FAC/blob/main/docs/pull-request-checklist.md -->
## Related tickets
<!-- List all relevant tickets. If there are none, delete this section. -->
<!-- Tip: Use `Closes <ticket url>` to automatically close the ticket once merged -->
* Related to https://github.com/GSA-TTS/FAC/issues/5683
* Related to https://github.com/GSA-TTS/FAC/issues/5685

## Description of changes
<!-- Give a high level summary of the changes made -->
* When testing Unified search performance, it dawned on us that if you use advanced search to do not-actually-advanced searches, then it will be way slower than doing a basic search. This is because basic search hits the much smaller General table. This isn't terrible for the current app, but because we're removing basic search, this will soon be not great.
* This change checks to see if any advanced/non-basic/non-General fields are actually being searched on before querying DisseminationCombined or Unified. If the params are all basic, then it'll just stick to using the speedy General table.
* Specifying cog_or_oversight will only trigger an Advanced search if "either" is NOT used
* This effects both Advanced Search and Beta Search

## How to test
<!-- Provide clear instructions for testing your changes -->
* I deployed the branch to preview, this way we can compare [prod beta search](https://app.fac.gov/dissemination/search/beta/) with [preview beta search](https://fac-preview.app.cloud.gov/dissemination/search/beta/)
* Searching by basic params in beta should now be as fast as using basic search
  * "Basic param" here means any fields that can be found on the basic search page, like audit years, states, etc.
* Advanced search should be faster for basic fields, too
* Searches generally working as normal
* Specifying cog_or_oversight will only trigger an Advanced search if "either" is NOT used
* If testing locally, you can tell what table/model is being used via the log line `INFO search Searching <model name>`